### PR TITLE
feat: add LLM judge support for eval scoring

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -197,7 +197,7 @@ async function runOne(
     | ToolScorer;
   let last: ScoreResult = {
     passed: false,
-    checks: [{ type: "deterministic", name: "ran at least one attempt", passed: false }],
+    checks: [{ name: "ran at least one attempt", passed: false }],
   };
   let lastToolCalls: unknown[] = [];
   let lastTranscript: TranscriptPart[] = [];

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -195,7 +195,10 @@ async function runOne(
   const scorer = (await import(pathToFileURL(ev.evalPath).href)).default as
     | ProjectScorer
     | ToolScorer;
-  let last: ScoreResult = { passed: false, score: 0, notes: "no attempts" };
+  let last: ScoreResult = {
+    passed: false,
+    assertions: [{ type: "deterministic", name: "ran at least one attempt", passed: false }],
+  };
   let lastToolCalls: unknown[] = [];
   let lastTranscript: TranscriptPart[] = [];
   let lastAgentReport = "";
@@ -244,7 +247,7 @@ async function runOne(
       continue;
     }
 
-    // Tool mode: boot runtime, expose MCP tools, run agent, score result.
+    // Tool mode: boot runtime, expose MCP tools, run agent, evaluate result.
     const projectSeedSql = join(ev.seedDir, "project.sql");
     const logsSeedJsonl = join(ev.seedDir, "logs.jsonl");
 
@@ -386,7 +389,7 @@ async function main() {
           ),
         );
         console.log(
-          `  -> ${res.passed ? "PASS" : "FAIL"} (score ${res.score.toFixed(2)}, attempts ${res.attempts})`,
+          `  -> ${res.passed ? "PASS" : "FAIL"} (attempts ${res.attempts})`,
         );
       } catch (e) {
         console.error(

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -197,7 +197,7 @@ async function runOne(
     | ToolScorer;
   let last: ScoreResult = {
     passed: false,
-    assertions: [{ type: "deterministic", name: "ran at least one attempt", passed: false }],
+    checks: [{ type: "deterministic", name: "ran at least one attempt", passed: false }],
   };
   let lastToolCalls: unknown[] = [];
   let lastTranscript: TranscriptPart[] = [];

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -247,7 +247,7 @@ async function runOne(
       continue;
     }
 
-    // Tool mode: boot runtime, expose MCP tools, run agent, evaluate result.
+    // Tool mode: boot runtime, expose MCP tools, run agent, score result.
     const projectSeedSql = join(ev.seedDir, "project.sql");
     const logsSeedJsonl = join(ev.seedDir, "logs.jsonl");
 

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -309,6 +309,17 @@ function normalizeExperimentName(s: string): string {
   return s.replace(/^experiments\//, "").replace(/\.ts$/, "");
 }
 
+function formatRunSummary(res: ScoreResult & { attempts: number }): string {
+  const parts: string[] = [];
+  if (res.checks?.length) {
+    const passed = res.checks.filter((check) => check.passed).length;
+    parts.push(`checks ${passed}/${res.checks.length}`);
+  }
+  parts.push(`attempts ${res.attempts}`);
+
+  return parts.join(", ");
+}
+
 async function main() {
   const experiments = (await loadExperiments()).filter(({ name, config }) => {
     if (
@@ -389,7 +400,7 @@ async function main() {
           ),
         );
         console.log(
-          `  -> ${res.passed ? "PASS" : "FAIL"} (attempts ${res.attempts})`,
+          `  -> ${res.passed ? "PASS" : "FAIL"} (${formatRunSummary(res)})`,
         );
       } catch (e) {
         console.error(

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -20,6 +20,7 @@ import type {
   ToolScorer,
   ProjectScorer,
   ScoreResult,
+  TranscriptPart,
 } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -181,6 +182,7 @@ async function runOne(
   ScoreResult & {
     attempts: number;
     toolCalls: unknown[];
+    transcript: TranscriptPart[];
     agentReport: string;
     stoppedReason: string;
   }
@@ -195,6 +197,7 @@ async function runOne(
     | ToolScorer;
   let last: ScoreResult = { passed: false, score: 0, notes: "no attempts" };
   let lastToolCalls: unknown[] = [];
+  let lastTranscript: TranscriptPart[] = [];
   let lastAgentReport = "";
   let lastStoppedReason = "not_started";
 
@@ -217,12 +220,14 @@ async function runOne(
       const vitest = build.ok ? await vitestRun(workspace) : undefined;
 
       lastToolCalls = run.toolCalls;
+      lastTranscript = run.transcript;
       lastAgentReport = run.agentReport;
       lastStoppedReason = run.stoppedReason;
       last = await (scorer as ProjectScorer)({
         workspace,
         projectResult: { build, vitest },
         toolCalls: run.toolCalls,
+        transcript: run.transcript,
         agentReport: run.agentReport,
       });
 
@@ -231,6 +236,7 @@ async function runOne(
           ...last,
           attempts: attempt,
           toolCalls: run.toolCalls,
+          transcript: run.transcript,
           agentReport: run.agentReport,
           stoppedReason: run.stoppedReason,
         };
@@ -261,11 +267,13 @@ async function runOne(
       });
 
       lastToolCalls = run.toolCalls;
+      lastTranscript = run.transcript;
       lastAgentReport = run.agentReport;
       lastStoppedReason = run.stoppedReason;
       last = await (scorer as ToolScorer)({
         ...session.scoringContext,
         toolCalls: run.toolCalls,
+        transcript: run.transcript,
         agentReport: run.agentReport,
       });
 
@@ -274,6 +282,7 @@ async function runOne(
           ...last,
           attempts: attempt,
           toolCalls: run.toolCalls,
+          transcript: run.transcript,
           agentReport: run.agentReport,
           stoppedReason: run.stoppedReason,
         };
@@ -287,6 +296,7 @@ async function runOne(
     ...last,
     attempts: RUNS,
     toolCalls: lastToolCalls,
+    transcript: lastTranscript,
     agentReport: lastAgentReport,
     stoppedReason: lastStoppedReason,
   };

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -6,6 +6,7 @@ import type {
 
 export type {
   ScoreResult,
+  AssertionResult,
   ToolCallRecord,
   TranscriptPart,
   TranscriptSerializationOptions,
@@ -22,7 +23,10 @@ export type {
   ProjectScorer,
   ExperimentConfig,
 } from "@supabase-evals/core";
-export { judgeTranscript } from "@supabase-evals/core";
+export {
+  assertion,
+  judgeTranscript,
+} from "@supabase-evals/core";
 export type {
   EvalMetadata,
   EvalProduct,

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -7,6 +7,10 @@ import type {
 export type {
   ScoreResult,
   ToolCallRecord,
+  TranscriptPart,
+  TranscriptSerializationOptions,
+  JudgeInput,
+  JudgeResult,
   CommandResult,
   VitestResult,
   ProjectResult,
@@ -18,6 +22,7 @@ export type {
   ProjectScorer,
   ExperimentConfig,
 } from "@supabase-evals/core";
+export { judgeTranscript } from "@supabase-evals/core";
 export type {
   EvalMetadata,
   EvalProduct,

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -25,7 +25,8 @@ export type {
 } from "@supabase-evals/core";
 export {
   check,
-  judgeTranscript,
+  judge,
+  serializeTranscript,
 } from "@supabase-evals/core";
 export type {
   EvalMetadata,

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -24,7 +24,6 @@ export type {
   ExperimentConfig,
 } from "@supabase-evals/core";
 export {
-  check,
   judge,
   serializeTranscript,
 } from "@supabase-evals/core";

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -6,7 +6,7 @@ import type {
 
 export type {
   ScoreResult,
-  AssertionResult,
+  CheckResult,
   ToolCallRecord,
   TranscriptPart,
   TranscriptSerializationOptions,
@@ -24,7 +24,7 @@ export type {
   ExperimentConfig,
 } from "@supabase-evals/core";
 export {
-  assertion,
+  check,
   judgeTranscript,
 } from "@supabase-evals/core";
 export type {

--- a/apps/framework/package.json
+++ b/apps/framework/package.json
@@ -10,7 +10,7 @@
     "eval:smoke": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --smoke",
     "eval:force": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --force",
     "typecheck": "tsc --noEmit",
-    "test:framework": "node --import tsx/esm scripts/smoke-framework.ts",
+    "test:framework": "node --env-file-if-exists=../../.env --import tsx/esm scripts/smoke-framework.ts",
     "export-results": "node --import tsx/esm scripts/export-results.ts",
     "demo:mcp": "node --env-file=../../.env --import tsx/esm scripts/mcp-demo.ts",
     "demo:executor": "node --env-file=../../.env --import tsx/esm scripts/executor-demo.ts"

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -31,7 +31,8 @@ function scorerCtx(backend: PlatformBackend, extra?: { agentReport?: string }) {
     getClient: backend.getClient,
     query: backend.query,
     invokeFunction: backend.invokeFunction,
-    toolCalls: [] as never[],
+    toolCalls: [],
+    transcript: [],
     agentReport: extra?.agentReport,
   };
 }

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -37,8 +37,8 @@ function scorerCtx(backend: PlatformBackend, extra?: { agentReport?: string }) {
   };
 }
 
-function assertionsMessage(result: { assertions?: unknown[] }) {
-  return JSON.stringify(result.assertions ?? []);
+function checksMessage(result: { checks?: unknown[] }) {
+  return JSON.stringify(result.checks ?? []);
 }
 
 async function withBackend<T>(
@@ -66,10 +66,10 @@ async function smokeDesignEval() {
       const before = await scorer(scorerCtx(backend));
       assert.equal(before.passed, false);
       assert(
-        before.assertions?.some(
-          (assertion) =>
-            assertion.name === "RLS enabled on notes" &&
-            assertion.passed === false
+        before.checks?.some(
+          (check) =>
+            check.name === "RLS enabled on notes" &&
+            check.passed === false
         )
       );
 
@@ -117,7 +117,7 @@ USING (author_id = auth.uid());
       `);
 
       const after = await scorer(scorerCtx(backend));
-      assert.equal(after.passed, true, assertionsMessage(after));
+      assert.equal(after.passed, true, checksMessage(after));
     }
   );
 
@@ -140,7 +140,7 @@ CREATE POLICY "users can delete own todos" ON todos FOR DELETE TO authenticated 
       `);
 
       const result = await scorer(scorerCtx(backend));
-      assert.equal(result.passed, true, assertionsMessage(result));
+      assert.equal(result.passed, true, checksMessage(result));
     }
   );
 
@@ -153,7 +153,7 @@ async function smokeFunctionsEval() {
   await withBackend({}, async (backend) => {
     const before = await scorer(scorerCtx(backend));
     assert.equal(before.passed, false);
-    assert.match(assertionsMessage(before), /function not found/i);
+    assert.match(checksMessage(before), /function not found/i);
 
     const deployUrl = `${backend.url}/v1/projects/${backend.ref}/functions/deploy?slug=order-total`;
     const form = new FormData();
@@ -168,7 +168,7 @@ async function smokeFunctionsEval() {
     assert.equal(deployRes.status, 201, `deploy failed: ${await deployRes.text()}`);
 
     const after = await scorer(scorerCtx(backend));
-    assert.equal(after.passed, true, assertionsMessage(after));
+    assert.equal(after.passed, true, checksMessage(after));
   });
 
   console.log("PASS functions scorer + edge-functions dispatcher");
@@ -246,7 +246,7 @@ async function smokeEdgeAuthDbEval() {
       assert.equal(deployRes.status, 201, `deploy failed: ${await deployRes.text()}`);
 
       const result = await scorer(scorerCtx(backend));
-      assert.equal(result.passed, true, assertionsMessage(result));
+      assert.equal(result.passed, true, checksMessage(result));
     }
   );
 
@@ -276,7 +276,7 @@ async function smokeObserveEval() {
       const result = await scorer(
         scorerCtx(backend, { agentReport: "stripe-webhook had the most errors with 9 errors out of 50 events." })
       );
-      assert.equal(result.passed, true, assertionsMessage(result));
+      assert.equal(result.passed, true, checksMessage(result));
     }
   );
 
@@ -305,7 +305,7 @@ ORDER BY grantee;
       ].join(" ");
 
       const result = await scorer(scorerCtx(backend, { agentReport: report }));
-      assert.equal(result.passed, true, assertionsMessage(result));
+      assert.equal(result.passed, true, checksMessage(result));
     }
   );
 

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { bootPlatformBackend } from "../harness/platform-backend.js";
 import { viteBuild, vitestRun } from "../harness/project-runner.js";
-import type { ToolScorer } from "../harness/types.js";
+import type { ToolScorer, TranscriptPart } from "../harness/types.js";
 import type { PlatformBackend } from "../harness/platform-backend.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -23,7 +23,10 @@ async function loadScorer(relDir: string): Promise<ToolScorer> {
   return mod.default as ToolScorer;
 }
 
-function scorerCtx(backend: PlatformBackend, extra?: { agentReport?: string }) {
+function scorerCtx(
+  backend: PlatformBackend,
+  extra?: { agentReport?: string; transcript?: TranscriptPart[] }
+) {
   return {
     mgmt: backend.mgmt,
     ref: backend.ref,
@@ -32,7 +35,7 @@ function scorerCtx(backend: PlatformBackend, extra?: { agentReport?: string }) {
     query: backend.query,
     invokeFunction: backend.invokeFunction,
     toolCalls: [],
-    transcript: [],
+    transcript: extra?.transcript ?? [],
     agentReport: extra?.agentReport,
   };
 }
@@ -304,7 +307,14 @@ ORDER BY grantee;
         "Fix by REVOKE SELECT ON customer_payment_methods FROM anon and enable row level security.",
       ].join(" ");
 
-      const result = await scorer(scorerCtx(backend, { agentReport: report }));
+      // The judge reads the transcript, so surface the report as assistant text.
+      const transcript: TranscriptPart[] = [
+        { type: "message", role: "assistant", content: report },
+      ];
+
+      const result = await scorer(
+        scorerCtx(backend, { agentReport: report, transcript })
+      );
       assert.equal(result.passed, true, checksMessage(result));
     }
   );

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -37,6 +37,10 @@ function scorerCtx(backend: PlatformBackend, extra?: { agentReport?: string }) {
   };
 }
 
+function assertionsMessage(result: { assertions?: unknown[] }) {
+  return JSON.stringify(result.assertions ?? []);
+}
+
 async function withBackend<T>(
   opts: { projectSeedSql?: string; logsSeedJsonl?: string },
   fn: (backend: PlatformBackend) => Promise<T>
@@ -61,7 +65,13 @@ async function smokeDesignEval() {
     async (backend) => {
       const before = await scorer(scorerCtx(backend));
       assert.equal(before.passed, false);
-      assert.match(before.notes ?? "", /RLS not enabled/i);
+      assert(
+        before.assertions?.some(
+          (assertion) =>
+            assertion.name === "RLS enabled on notes" &&
+            assertion.passed === false
+        )
+      );
 
       await backend.query(`
 ALTER TABLE notes ENABLE ROW LEVEL SECURITY;
@@ -107,7 +117,7 @@ USING (author_id = auth.uid());
       `);
 
       const after = await scorer(scorerCtx(backend));
-      assert.equal(after.passed, true, after.notes);
+      assert.equal(after.passed, true, assertionsMessage(after));
     }
   );
 
@@ -129,8 +139,8 @@ CREATE POLICY "users can update own todos" ON todos FOR UPDATE TO authenticated 
 CREATE POLICY "users can delete own todos" ON todos FOR DELETE TO authenticated USING (user_id = auth.uid());
       `);
 
-      const score = await scorer(scorerCtx(backend));
-      assert.equal(score.passed, true, score.notes);
+      const result = await scorer(scorerCtx(backend));
+      assert.equal(result.passed, true, assertionsMessage(result));
     }
   );
 
@@ -143,7 +153,7 @@ async function smokeFunctionsEval() {
   await withBackend({}, async (backend) => {
     const before = await scorer(scorerCtx(backend));
     assert.equal(before.passed, false);
-    assert.match(before.notes ?? "", /function not found/i);
+    assert.match(assertionsMessage(before), /function not found/i);
 
     const deployUrl = `${backend.url}/v1/projects/${backend.ref}/functions/deploy?slug=order-total`;
     const form = new FormData();
@@ -158,7 +168,7 @@ async function smokeFunctionsEval() {
     assert.equal(deployRes.status, 201, `deploy failed: ${await deployRes.text()}`);
 
     const after = await scorer(scorerCtx(backend));
-    assert.equal(after.passed, true, after.notes);
+    assert.equal(after.passed, true, assertionsMessage(after));
   });
 
   console.log("PASS functions scorer + edge-functions dispatcher");
@@ -235,8 +245,8 @@ async function smokeEdgeAuthDbEval() {
       });
       assert.equal(deployRes.status, 201, `deploy failed: ${await deployRes.text()}`);
 
-      const score = await scorer(scorerCtx(backend));
-      assert.equal(score.passed, true, score.notes);
+      const result = await scorer(scorerCtx(backend));
+      assert.equal(result.passed, true, assertionsMessage(result));
     }
   );
 
@@ -263,10 +273,10 @@ async function smokeObserveEval() {
   await withBackend(
     { logsSeedJsonl: seedPath(OBSERVE_EVAL, "logs.jsonl") },
     async (backend) => {
-      const score = await scorer(
+      const result = await scorer(
         scorerCtx(backend, { agentReport: "stripe-webhook had the most errors with 9 errors out of 50 events." })
       );
-      assert.equal(score.passed, true, score.notes);
+      assert.equal(result.passed, true, assertionsMessage(result));
     }
   );
 
@@ -294,8 +304,8 @@ ORDER BY grantee;
         "Fix by REVOKE SELECT ON customer_payment_methods FROM anon and enable row level security.",
       ].join(" ");
 
-      const score = await scorer(scorerCtx(backend, { agentReport: report }));
-      assert.equal(score.passed, true, score.notes);
+      const result = await scorer(scorerCtx(backend, { agentReport: report }));
+      assert.equal(result.passed, true, assertionsMessage(result));
     }
   );
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,6 +70,8 @@ type ParsedResult = Omit<EvalResult, "product" | "topic"> & {
   primaryCategory: string
 }
 
+type AssertionResult = NonNullable<ParsedResult["assertions"]>[number]
+
 type ExperimentStageSummary = {
   experiment: string
   category: JourneyStage | "overall"
@@ -323,60 +325,46 @@ function EvalMetadataRow({
   )
 }
 
-function ResultDetails({ notes }: { notes: string }) {
-  const lines = notes.split("\n")
-
+function ResultAssertions({ assertions }: { assertions: AssertionResult[] }) {
   return (
     <div className="flex flex-col gap-1 leading-relaxed text-foreground">
-      {lines.map((line, index) => {
-        const match = /^(PASS|FAIL)\s+(.*)$/.exec(line)
-
-        if (line.startsWith("Judge:")) {
-          return (
-            <details
-              key={`${index}-${line}`}
-              className="ml-6 text-muted-foreground"
-            >
-              <summary className="cursor-pointer text-xs uppercase tracking-wide">
-                <span className="inline-flex items-center gap-1.5">
-                  <BotIcon className="size-3.5 text-muted-foreground/70" />
-                  Judge notes
-                </span>
-              </summary>
-              <p className="mt-1 whitespace-pre-wrap text-foreground">
-                {line.replace(/^Judge:\s*/, "")}
-              </p>
-            </details>
-          )
-        }
-
-        if (!match) {
-          return (
-            <p key={`${index}-${line}`} className="whitespace-pre-wrap">
-              {line}
-            </p>
-          )
-        }
-
-        const [, status, detail] = match
-        const passed = status === "PASS"
-        const StatusIcon = passed ? CheckIcon : XIcon
+      {assertions.map((assertion, index) => {
+        const StatusIcon = assertion.passed ? CheckIcon : XIcon
 
         return (
-          <div key={`${index}-${line}`} className="flex items-start gap-2">
-            <StatusIcon
-              className={cn(
-                "mt-0.5 size-4 shrink-0",
-                passed
-                  ? "text-emerald-600 dark:text-emerald-400"
-                  : "text-red-600 dark:text-red-400"
-              )}
-              aria-hidden
-            />
-            <span className="sr-only">{passed ? "Pass" : "Fail"}: </span>
-            <span className="min-w-0 whitespace-pre-wrap">
-              {detail.replace(/\bllm judge\s+/i, "")}
-            </span>
+          <div key={`${index}-${assertion.type}-${assertion.name}`}>
+            <div className="flex items-start gap-2">
+              <StatusIcon
+                className={cn(
+                  "mt-0.5 size-4 shrink-0",
+                  assertion.passed
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-red-600 dark:text-red-400"
+                )}
+                aria-hidden
+              />
+              <span className="sr-only">
+                {assertion.passed ? "Pass" : "Fail"}:{" "}
+              </span>
+              <span className="min-w-0 whitespace-pre-wrap">
+                {assertion.name}
+              </span>
+            </div>
+            {assertion.notes ? (
+              <details className="mt-1 ml-6 text-muted-foreground">
+                <summary className="cursor-pointer text-xs uppercase tracking-wide">
+                  <span className="inline-flex items-center gap-1.5">
+                    {assertion.type === "llm" ? (
+                      <BotIcon className="size-3.5 text-muted-foreground/70" />
+                    ) : null}
+                    {assertion.type === "llm" ? "Judge notes" : "Notes"}
+                  </span>
+                </summary>
+                <p className="mt-1 whitespace-pre-wrap text-foreground">
+                  {assertion.notes}
+                </p>
+              </details>
+            ) : null}
           </div>
         )
       })}
@@ -776,10 +764,6 @@ function ExperimentSheet({
                           >
                             <dl className={evalMetaGridClassName}>
                               <EvalMetadataRow
-                                label="Score"
-                                value={result.score ?? "-"}
-                              />
-                              <EvalMetadataRow
                                 label="Attempts"
                                 value={result.attempts ?? "-"}
                               />
@@ -799,10 +783,14 @@ function ExperimentSheet({
                                 label="Topic"
                                 value={result.topic.join(", ") || "-"}
                               />
-                              {result.notes ? (
+                              {result.assertions?.length ? (
                                 <EvalMetadataRow
-                                  label="Result details"
-                                  value={<ResultDetails notes={result.notes} />}
+                                  label="Assertions"
+                                  value={
+                                    <ResultAssertions
+                                      assertions={result.assertions}
+                                    />
+                                  }
                                 />
                               ) : null}
                               {result.prompt ? (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import rawResults, { type EvalResult } from "virtual:supabase-eval-results"
 import { useEffect, useRef, useState, type ReactNode } from "react"
-import { CheckIcon, CopyIcon, XIcon } from "lucide-react"
+import { BotIcon, CheckIcon, CopyIcon, XIcon } from "lucide-react"
 
 import {
   Accordion,
@@ -324,10 +324,31 @@ function EvalMetadataRow({
 }
 
 function ResultDetails({ notes }: { notes: string }) {
+  const lines = notes.split("\n")
+
   return (
     <div className="flex flex-col gap-1 leading-relaxed text-foreground">
-      {notes.split("\n").map((line, index) => {
+      {lines.map((line, index) => {
         const match = /^(PASS|FAIL)\s+(.*)$/.exec(line)
+
+        if (line.startsWith("Judge:")) {
+          return (
+            <details
+              key={`${index}-${line}`}
+              className="ml-6 text-muted-foreground"
+            >
+              <summary className="cursor-pointer text-xs uppercase tracking-wide">
+                <span className="inline-flex items-center gap-1.5">
+                  <BotIcon className="size-3.5 text-muted-foreground/70" />
+                  Judge notes
+                </span>
+              </summary>
+              <p className="mt-1 whitespace-pre-wrap text-foreground">
+                {line.replace(/^Judge:\s*/, "")}
+              </p>
+            </details>
+          )
+        }
 
         if (!match) {
           return (
@@ -353,7 +374,9 @@ function ResultDetails({ notes }: { notes: string }) {
               aria-hidden
             />
             <span className="sr-only">{passed ? "Pass" : "Fail"}: </span>
-            <span className="min-w-0 whitespace-pre-wrap">{detail}</span>
+            <span className="min-w-0 whitespace-pre-wrap">
+              {detail.replace(/\bllm judge\s+/i, "")}
+            </span>
           </div>
         )
       })}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,7 +70,7 @@ type ParsedResult = Omit<EvalResult, "product" | "topic"> & {
   primaryCategory: string
 }
 
-type AssertionResult = NonNullable<ParsedResult["assertions"]>[number]
+type CheckResult = NonNullable<ParsedResult["checks"]>[number]
 
 type ExperimentStageSummary = {
   experiment: string
@@ -325,43 +325,43 @@ function EvalMetadataRow({
   )
 }
 
-function ResultAssertions({ assertions }: { assertions: AssertionResult[] }) {
+function ResultChecks({ checks }: { checks: CheckResult[] }) {
   return (
     <div className="flex flex-col gap-1 leading-relaxed text-foreground">
-      {assertions.map((assertion, index) => {
-        const StatusIcon = assertion.passed ? CheckIcon : XIcon
+      {checks.map((check, index) => {
+        const StatusIcon = check.passed ? CheckIcon : XIcon
 
         return (
-          <div key={`${index}-${assertion.type}-${assertion.name}`}>
+          <div key={`${index}-${check.type}-${check.name}`}>
             <div className="flex items-start gap-2">
               <StatusIcon
                 className={cn(
                   "mt-0.5 size-4 shrink-0",
-                  assertion.passed
+                  check.passed
                     ? "text-emerald-600 dark:text-emerald-400"
                     : "text-red-600 dark:text-red-400"
                 )}
                 aria-hidden
               />
               <span className="sr-only">
-                {assertion.passed ? "Pass" : "Fail"}:{" "}
+                {check.passed ? "Pass" : "Fail"}:{" "}
               </span>
               <span className="min-w-0 whitespace-pre-wrap">
-                {assertion.name}
+                {check.name}
               </span>
             </div>
-            {assertion.notes ? (
+            {check.notes ? (
               <details className="mt-1 ml-6 text-muted-foreground">
                 <summary className="cursor-pointer text-xs uppercase tracking-wide">
                   <span className="inline-flex items-center gap-1.5">
-                    {assertion.type === "llm" ? (
+                    {check.type === "llm" ? (
                       <BotIcon className="size-3.5 text-muted-foreground/70" />
                     ) : null}
-                    {assertion.type === "llm" ? "Judge notes" : "Notes"}
+                    {check.type === "llm" ? "Judge notes" : "Notes"}
                   </span>
                 </summary>
                 <p className="mt-1 whitespace-pre-wrap text-foreground">
-                  {assertion.notes}
+                  {check.notes}
                 </p>
               </details>
             ) : null}
@@ -783,12 +783,12 @@ function ExperimentSheet({
                                 label="Topic"
                                 value={result.topic.join(", ") || "-"}
                               />
-                              {result.assertions?.length ? (
+                              {result.checks?.length ? (
                                 <EvalMetadataRow
-                                  label="Assertions"
+                                  label="Checks"
                                   value={
-                                    <ResultAssertions
-                                      assertions={result.assertions}
+                                    <ResultChecks
+                                      checks={result.checks}
                                     />
                                   }
                                 />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -330,9 +330,11 @@ function ResultChecks({ checks }: { checks: CheckResult[] }) {
     <div className="flex flex-col gap-1 leading-relaxed text-foreground">
       {checks.map((check, index) => {
         const StatusIcon = check.passed ? CheckIcon : XIcon
+        const notes = check.judgeNotes ?? check.notes
+        const hasJudgeNotes = check.judgeNotes !== undefined
 
         return (
-          <div key={`${index}-${check.type}-${check.name}`}>
+          <div key={`${index}-${check.name}`}>
             <div className="flex items-start gap-2">
               <StatusIcon
                 className={cn(
@@ -350,18 +352,18 @@ function ResultChecks({ checks }: { checks: CheckResult[] }) {
                 {check.name}
               </span>
             </div>
-            {check.notes ? (
+            {notes ? (
               <details className="mt-1 ml-6 text-muted-foreground">
                 <summary className="cursor-pointer text-xs uppercase tracking-wide">
                   <span className="inline-flex items-center gap-1.5">
-                    {check.type === "llm" ? (
+                    {hasJudgeNotes ? (
                       <BotIcon className="size-3.5 text-muted-foreground/70" />
                     ) : null}
-                    {check.type === "llm" ? "Judge notes" : "Notes"}
+                    {hasJudgeNotes ? "Judge notes" : "Notes"}
                   </span>
                 </summary>
                 <p className="mt-1 whitespace-pre-wrap text-foreground">
-                  {check.notes}
+                  {notes}
                 </p>
               </details>
             ) : null}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -785,7 +785,7 @@ function ExperimentSheet({
                               />
                               {result.checks?.length ? (
                                 <EvalMetadataRow
-                                  label="Checks"
+                                  label="Result details"
                                   value={
                                     <ResultChecks
                                       checks={result.checks}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 declare module "virtual:supabase-eval-results" {
-  type AssertionResult = {
+  type CheckResult = {
     type: "deterministic" | "llm"
     name: string
     passed: boolean
@@ -15,7 +15,7 @@ declare module "virtual:supabase-eval-results" {
     product?: string[]
     topic?: string[]
     passed: boolean
-    assertions?: AssertionResult[]
+    checks?: CheckResult[]
     prompt?: string
     promptSourcePath?: string
     attempts?: number

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -2,10 +2,10 @@
 
 declare module "virtual:supabase-eval-results" {
   type CheckResult = {
-    type: "deterministic" | "llm"
     name: string
     passed: boolean
     notes?: string
+    judgeNotes?: string
   }
 
   type EvalResult = {

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,6 +1,13 @@
 /// <reference types="vite/client" />
 
 declare module "virtual:supabase-eval-results" {
+  type AssertionResult = {
+    type: "deterministic" | "llm"
+    name: string
+    passed: boolean
+    notes?: string
+  }
+
   type EvalResult = {
     experiment: string
     eval: string
@@ -8,8 +15,7 @@ declare module "virtual:supabase-eval-results" {
     product?: string[]
     topic?: string[]
     passed: boolean
-    score?: number
-    notes?: string
+    assertions?: AssertionResult[]
     prompt?: string
     promptSourcePath?: string
     attempts?: number

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -84,13 +84,12 @@ function readCheck(value: unknown): CheckResult | undefined {
     return undefined
   }
 
-  const type = value.type
   const name = value.name
   const passed = value.passed
   const notes = value.notes
+  const judgeNotes = value.judgeNotes
 
   if (
-    (type !== "deterministic" && type !== "llm") ||
     typeof name !== "string" ||
     typeof passed !== "boolean"
   ) {
@@ -98,10 +97,10 @@ function readCheck(value: unknown): CheckResult | undefined {
   }
 
   return {
-    type,
     name,
     passed,
     notes: typeof notes === "string" ? notes : undefined,
+    judgeNotes: typeof judgeNotes === "string" ? judgeNotes : undefined,
   }
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
-import type { EvalResult } from "@supabase-evals/core"
+import type { EvalResult, AssertionResult } from "@supabase-evals/core"
 import { parseEvalMarkdown } from "../../packages/core/src/eval-metadata"
 
 const RESULTS_MODULE_ID = "virtual:supabase-eval-results"
@@ -54,12 +54,54 @@ function readResultFile(
     product: promptData?.product ?? parsed.product,
     topic: promptData?.topic ?? parsed.topic,
     passed: Boolean(parsed.passed),
-    score: typeof parsed.score === "number" ? parsed.score : undefined,
-    notes: typeof parsed.notes === "string" ? parsed.notes : undefined,
+    assertions: readAssertions(parsed.assertions),
     prompt: promptData?.prompt,
     promptSourcePath: promptData?.promptSourcePath,
     attempts: typeof parsed.attempts === "number" ? parsed.attempts : undefined,
     sourcePath,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function readAssertions(value: unknown): AssertionResult[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const assertions = value.flatMap((item) => {
+    const assertion = readAssertion(item)
+    return assertion ? [assertion] : []
+  })
+
+  return assertions.length > 0 ? assertions : undefined
+}
+
+function readAssertion(value: unknown): AssertionResult | undefined {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  const type = value.type
+  const name = value.name
+  const passed = value.passed
+  const notes = value.notes
+
+  if (
+    (type !== "deterministic" && type !== "llm") ||
+    typeof name !== "string" ||
+    typeof passed !== "boolean"
+  ) {
+    return undefined
+  }
+
+  return {
+    type,
+    name,
+    passed,
+    notes: typeof notes === "string" ? notes : undefined,
   }
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
-import type { EvalResult, AssertionResult } from "@supabase-evals/core"
+import type { EvalResult, CheckResult } from "@supabase-evals/core"
 import { parseEvalMarkdown } from "../../packages/core/src/eval-metadata"
 
 const RESULTS_MODULE_ID = "virtual:supabase-eval-results"
@@ -54,7 +54,7 @@ function readResultFile(
     product: promptData?.product ?? parsed.product,
     topic: promptData?.topic ?? parsed.topic,
     passed: Boolean(parsed.passed),
-    assertions: readAssertions(parsed.assertions),
+    checks: readChecks(parsed.checks),
     prompt: promptData?.prompt,
     promptSourcePath: promptData?.promptSourcePath,
     attempts: typeof parsed.attempts === "number" ? parsed.attempts : undefined,
@@ -66,20 +66,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function readAssertions(value: unknown): AssertionResult[] | undefined {
+function readChecks(value: unknown): CheckResult[] | undefined {
   if (!Array.isArray(value)) {
     return undefined
   }
 
-  const assertions = value.flatMap((item) => {
-    const assertion = readAssertion(item)
-    return assertion ? [assertion] : []
+  const checks = value.flatMap((item) => {
+    const check = readCheck(item)
+    return check ? [check] : []
   })
 
-  return assertions.length > 0 ? assertions : undefined
+  return checks.length > 0 ? checks : undefined
 }
 
-function readAssertion(value: unknown): AssertionResult | undefined {
+function readCheck(value: unknown): CheckResult | undefined {
   if (!isRecord(value)) {
     return undefined
   }

--- a/evals/design-frontend-001-todos-app/EVAL.ts
+++ b/evals/design-frontend-001-todos-app/EVAL.ts
@@ -6,28 +6,39 @@ const scorer: ProjectScorer = async (ctx) => {
   if (!build.ok) {
     return {
       passed: false,
-      score: 0,
-      notes: `vite build failed:\n${trimOutput(build.stderr || build.stdout)}`,
+      assertions: [
+        {
+          type: "deterministic",
+          name: "vite build passed",
+          passed: false,
+          notes: trimOutput(build.stderr || build.stdout),
+        },
+      ],
     };
   }
 
   if (!vitest) {
-    return { passed: false, score: 0.25, notes: "vitest did not run" };
+    return {
+      passed: false,
+      assertions: [{ type: "deterministic", name: "vitest ran", passed: false }],
+    };
   }
 
-  const total = (vitest.passed ?? 0) + (vitest.failed ?? 0);
-  const score = total > 0 ? (vitest.passed ?? 0) / total : vitest.ok ? 1 : 0.25;
   return {
     passed: vitest.ok,
-    score,
-    notes: vitest.ok
-      ? "vite build and vitest passed"
-      : [
-          "vitest failed:",
-          ...((vitest.failures?.length ? vitest.failures : [vitest.stderr || vitest.stdout]).map(
-            trimOutput
-          )),
-        ].join("\n"),
+    assertions: [
+      { type: "deterministic", name: "vite build passed", passed: true },
+      {
+        type: "deterministic",
+        name: "vitest passed",
+        passed: vitest.ok,
+        notes: vitest.ok
+          ? undefined
+          : (vitest.failures?.length ? vitest.failures : [vitest.stderr || vitest.stdout])
+              .map(trimOutput)
+              .join("\n"),
+      },
+    ],
   };
 };
 

--- a/evals/design-frontend-001-todos-app/EVAL.ts
+++ b/evals/design-frontend-001-todos-app/EVAL.ts
@@ -6,7 +6,7 @@ const scorer: ProjectScorer = async (ctx) => {
   if (!build.ok) {
     return {
       passed: false,
-      assertions: [
+      checks: [
         {
           type: "deterministic",
           name: "vite build passed",
@@ -20,13 +20,13 @@ const scorer: ProjectScorer = async (ctx) => {
   if (!vitest) {
     return {
       passed: false,
-      assertions: [{ type: "deterministic", name: "vitest ran", passed: false }],
+      checks: [{ type: "deterministic", name: "vitest ran", passed: false }],
     };
   }
 
   return {
     passed: vitest.ok,
-    assertions: [
+    checks: [
       { type: "deterministic", name: "vite build passed", passed: true },
       {
         type: "deterministic",

--- a/evals/design-frontend-001-todos-app/EVAL.ts
+++ b/evals/design-frontend-001-todos-app/EVAL.ts
@@ -1,46 +1,49 @@
-import type { ProjectScorer } from "@supabase-evals/core";
+import type {
+  CheckResult,
+  ProjectScorer,
+  VitestResult,
+} from "@supabase-evals/core";
 
 const scorer: ProjectScorer = async (ctx) => {
   const { build, vitest } = ctx.projectResult;
 
-  if (!build.ok) {
-    return {
-      passed: false,
-      checks: [
-        {
-          type: "deterministic",
-          name: "vite build passed",
-          passed: false,
-          notes: trimOutput(build.stderr || build.stdout),
-        },
-      ],
-    };
-  }
-
-  if (!vitest) {
-    return {
-      passed: false,
-      checks: [{ type: "deterministic", name: "vitest ran", passed: false }],
-    };
-  }
+  const checks: CheckResult[] = [
+    {
+      type: "deterministic",
+      name: "vite build passed",
+      passed: build.ok,
+      notes: build.ok ? undefined : trimOutput(build.stderr || build.stdout),
+    },
+    {
+      type: "deterministic",
+      name: "vitest passed",
+      passed: build.ok && vitest?.ok === true,
+      notes: getVitestNotes(build.ok, vitest),
+    },
+  ];
 
   return {
-    passed: vitest.ok,
-    checks: [
-      { type: "deterministic", name: "vite build passed", passed: true },
-      {
-        type: "deterministic",
-        name: "vitest passed",
-        passed: vitest.ok,
-        notes: vitest.ok
-          ? undefined
-          : (vitest.failures?.length ? vitest.failures : [vitest.stderr || vitest.stdout])
-              .map(trimOutput)
-              .join("\n"),
-      },
-    ],
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
+
+function getVitestNotes(buildPassed: boolean, vitest?: VitestResult) {
+  if (!buildPassed) {
+    return "not run because vite build failed";
+  }
+  if (!vitest) {
+    return "vitest did not run";
+  }
+  if (vitest.ok) {
+    return undefined;
+  }
+
+  const failures = vitest.failures?.length
+    ? vitest.failures
+    : [vitest.stderr || vitest.stdout];
+  return failures.map(trimOutput).join("\n");
+}
 
 function trimOutput(output: string) {
   return output.trim().slice(0, 4000);

--- a/evals/design-frontend-001-todos-app/EVAL.ts
+++ b/evals/design-frontend-001-todos-app/EVAL.ts
@@ -9,13 +9,11 @@ const scorer: ProjectScorer = async (ctx) => {
 
   const checks: CheckResult[] = [
     {
-      type: "deterministic",
       name: "vite build passed",
       passed: build.ok,
       notes: build.ok ? undefined : trimOutput(build.stderr || build.stdout),
     },
     {
-      type: "deterministic",
       name: "vitest passed",
       passed: build.ok && vitest?.ok === true,
       notes: getVitestNotes(build.ok, vitest),

--- a/evals/design-functions-001-order-total/EVAL.ts
+++ b/evals/design-functions-001-order-total/EVAL.ts
@@ -37,14 +37,12 @@ const scorer: ToolScorer = async (ctx) => {
   try {
     const methodCheck = await invoke(ctx, undefined, "GET");
     checks.push({
-      type: "deterministic",
       name: "rejects non-POST requests",
       passed: methodCheck.status === 405,
     });
 
     const invalidJson = await invoke(ctx, "{");
     checks.push({
-      type: "deterministic",
       name: "rejects invalid JSON",
       passed: invalidJson.status === 400,
     });
@@ -53,7 +51,6 @@ const scorer: ToolScorer = async (ctx) => {
       items: [{ sku: "bad", unit_price_cents: 0, quantity: 1 }],
     });
     checks.push({
-      type: "deterministic",
       name: "rejects invalid item values",
       passed: invalidItem.status === 400,
     });
@@ -68,7 +65,6 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const welcomeJson = parseJson(welcome);
     checks.push({
-      type: "deterministic",
       name: "calculates WELCOME10 totals",
       passed:
         welcome.status === 200 &&
@@ -85,7 +81,6 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const enterpriseJson = parseJson(enterprise);
     checks.push({
-      type: "deterministic",
       name: "chooses enterprise discount over capped coupon",
       passed:
         enterprise.status === 200 &&
@@ -102,7 +97,6 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const cappedCouponJson = parseJson(cappedCoupon);
     checks.push({
-      type: "deterministic",
       name: "caps WELCOME10 discount at 2000 cents",
       passed:
         cappedCoupon.status === 200 &&
@@ -114,7 +108,6 @@ const scorer: ToolScorer = async (ctx) => {
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: `scorer could invoke ${FUNCTION_NAME}`,
       passed: false,
       notes: msg,

--- a/evals/design-functions-001-order-total/EVAL.ts
+++ b/evals/design-functions-001-order-total/EVAL.ts
@@ -1,4 +1,8 @@
-import type { ToolScorer, ToolEvalContext } from "@supabase-evals/core";
+import {
+  type AssertionResult,
+  type ToolEvalContext,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const FUNCTION_NAME = "order-total";
 
@@ -28,19 +32,31 @@ const parseJson = (result: InvokeResult) => {
 };
 
 const scorer: ToolScorer = async (ctx) => {
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
 
   try {
     const methodCheck = await invoke(ctx, undefined, "GET");
-    checks.push({ name: "rejects non-POST requests", ok: methodCheck.status === 405 });
+    assertions.push({
+      type: "deterministic",
+      name: "rejects non-POST requests",
+      passed: methodCheck.status === 405,
+    });
 
     const invalidJson = await invoke(ctx, "{");
-    checks.push({ name: "rejects invalid JSON", ok: invalidJson.status === 400 });
+    assertions.push({
+      type: "deterministic",
+      name: "rejects invalid JSON",
+      passed: invalidJson.status === 400,
+    });
 
     const invalidItem = await invoke(ctx, {
       items: [{ sku: "bad", unit_price_cents: 0, quantity: 1 }],
     });
-    checks.push({ name: "rejects invalid item values", ok: invalidItem.status === 400 });
+    assertions.push({
+      type: "deterministic",
+      name: "rejects invalid item values",
+      passed: invalidItem.status === 400,
+    });
 
     const welcome = await invoke(ctx, {
       items: [
@@ -51,9 +67,10 @@ const scorer: ToolScorer = async (ctx) => {
       coupon: "WELCOME10",
     });
     const welcomeJson = parseJson(welcome);
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "calculates WELCOME10 totals",
-      ok:
+      passed:
         welcome.status === 200 &&
         welcomeJson?.subtotal_cents === 3450 &&
         welcomeJson?.discount_cents === 345 &&
@@ -67,9 +84,10 @@ const scorer: ToolScorer = async (ctx) => {
       coupon: "WELCOME10",
     });
     const enterpriseJson = parseJson(enterprise);
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "chooses enterprise discount over capped coupon",
-      ok:
+      passed:
         enterprise.status === 200 &&
         enterpriseJson?.subtotal_cents === 25000 &&
         enterpriseJson?.discount_cents === 3750 &&
@@ -83,9 +101,10 @@ const scorer: ToolScorer = async (ctx) => {
       coupon: "WELCOME10",
     });
     const cappedCouponJson = parseJson(cappedCoupon);
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "caps WELCOME10 discount at 2000 cents",
-      ok:
+      passed:
         cappedCoupon.status === 200 &&
         cappedCouponJson?.subtotal_cents === 50000 &&
         cappedCouponJson?.discount_cents === 2000 &&
@@ -94,22 +113,22 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    assertions.push({
+      type: "deterministic",
+      name: `scorer could invoke ${FUNCTION_NAME}`,
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 6,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not invoke ${FUNCTION_NAME}: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
-  const passed = checks.every((c) => c.ok);
-  const score = checks.filter((c) => c.ok).length / checks.length;
+  const passed = assertions.every((assertion) => assertion.passed);
   return {
     passed,
-    score,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/design-functions-001-order-total/EVAL.ts
+++ b/evals/design-functions-001-order-total/EVAL.ts
@@ -1,5 +1,5 @@
 import {
-  type AssertionResult,
+  type CheckResult,
   type ToolEvalContext,
   type ToolScorer,
 } from "@supabase-evals/core";
@@ -32,18 +32,18 @@ const parseJson = (result: InvokeResult) => {
 };
 
 const scorer: ToolScorer = async (ctx) => {
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
 
   try {
     const methodCheck = await invoke(ctx, undefined, "GET");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "rejects non-POST requests",
       passed: methodCheck.status === 405,
     });
 
     const invalidJson = await invoke(ctx, "{");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "rejects invalid JSON",
       passed: invalidJson.status === 400,
@@ -52,7 +52,7 @@ const scorer: ToolScorer = async (ctx) => {
     const invalidItem = await invoke(ctx, {
       items: [{ sku: "bad", unit_price_cents: 0, quantity: 1 }],
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "rejects invalid item values",
       passed: invalidItem.status === 400,
@@ -67,7 +67,7 @@ const scorer: ToolScorer = async (ctx) => {
       coupon: "WELCOME10",
     });
     const welcomeJson = parseJson(welcome);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "calculates WELCOME10 totals",
       passed:
@@ -84,7 +84,7 @@ const scorer: ToolScorer = async (ctx) => {
       coupon: "WELCOME10",
     });
     const enterpriseJson = parseJson(enterprise);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "chooses enterprise discount over capped coupon",
       passed:
@@ -101,7 +101,7 @@ const scorer: ToolScorer = async (ctx) => {
       coupon: "WELCOME10",
     });
     const cappedCouponJson = parseJson(cappedCoupon);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "caps WELCOME10 discount at 2000 cents",
       passed:
@@ -113,7 +113,7 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: `scorer could invoke ${FUNCTION_NAME}`,
       passed: false,
@@ -121,14 +121,14 @@ const scorer: ToolScorer = async (ctx) => {
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
-  const passed = assertions.every((assertion) => assertion.passed);
+  const passed = checks.every((check) => check.passed);
   return {
     passed,
-    assertions,
+    checks,
   };
 };
 

--- a/evals/design-functions-002-edge-auth-db/EVAL.ts
+++ b/evals/design-functions-002-edge-auth-db/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -21,7 +22,7 @@ const parseJson = (result: InvokeResult) => {
 };
 
 const scorer: ToolScorer = async (ctx) => {
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
 
   try {
     const { data: signup, error: signupError } = await ctx.client.auth.signUp({
@@ -47,9 +48,10 @@ const scorer: ToolScorer = async (ctx) => {
       method: "POST",
       body: { body: TODO_BODY },
     })) as InvokeResult;
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "rejects missing auth",
-      ok: missingAuth.status >= 400,
+      passed: missingAuth.status >= 400,
     });
 
     const inserted = (await ctx.invokeFunction({
@@ -61,22 +63,25 @@ const scorer: ToolScorer = async (ctx) => {
       body: { body: TODO_BODY },
     })) as InvokeResult;
     const insertedJson = parseJson(inserted);
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "authenticated request succeeds",
-      ok: inserted.status === 201 || inserted.status === 200,
+      passed: inserted.status === 201 || inserted.status === 200,
     });
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "returns inserted todo body",
-      ok: insertedJson?.body === TODO_BODY || (insertedJson?.todo as any)?.body === TODO_BODY,
+      passed: insertedJson?.body === TODO_BODY || (insertedJson?.todo as any)?.body === TODO_BODY,
     });
 
     const { data: todos, error: selectError } = await ctx.client
       .from("todos")
       .select("body,user_id")
       .eq("body", TODO_BODY);
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "row exists through supabase-js",
-      ok:
+      passed:
         !selectError &&
         Array.isArray(todos) &&
         todos.length === 1 &&
@@ -85,8 +90,7 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
@@ -98,9 +102,8 @@ const scorer: ToolScorer = async (ctx) => {
     };
   }
 
-  const passed = checks.every((c) => c.ok);
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
+  const passed = assertions.every((assertion) => assertion.passed);
+    return {
     passed,
     assertions,
   };

--- a/evals/design-functions-002-edge-auth-db/EVAL.ts
+++ b/evals/design-functions-002-edge-auth-db/EVAL.ts
@@ -30,7 +30,6 @@ const scorer: ToolScorer = async (ctx) => {
         passed: false,
         checks: [
           {
-            type: "deterministic",
             name: "created auth session",
             passed: false,
             notes: signupError?.message ?? "missing session",
@@ -45,7 +44,6 @@ const scorer: ToolScorer = async (ctx) => {
       body: { body: TODO_BODY },
     })) as InvokeResult;
     checks.push({
-      type: "deterministic",
       name: "rejects missing auth",
       passed: missingAuth.status >= 400,
     });
@@ -60,12 +58,10 @@ const scorer: ToolScorer = async (ctx) => {
     })) as InvokeResult;
     const insertedJson = parseJson(inserted);
     checks.push({
-      type: "deterministic",
       name: "authenticated request succeeds",
       passed: inserted.status === 201 || inserted.status === 200,
     });
     checks.push({
-      type: "deterministic",
       name: "returns inserted todo body",
       passed: insertedJson?.body === TODO_BODY || (insertedJson?.todo as any)?.body === TODO_BODY,
     });
@@ -75,7 +71,6 @@ const scorer: ToolScorer = async (ctx) => {
       .select("body,user_id")
       .eq("body", TODO_BODY);
     checks.push({
-      type: "deterministic",
       name: "row exists through supabase-js",
       passed:
         !selectError &&
@@ -87,7 +82,6 @@ const scorer: ToolScorer = async (ctx) => {
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
       notes: msg,

--- a/evals/design-functions-002-edge-auth-db/EVAL.ts
+++ b/evals/design-functions-002-edge-auth-db/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const FUNCTION_NAME = "todo-create";
 const TODO_BODY = "verify edge auth database integration";
@@ -90,7 +86,7 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
@@ -103,7 +99,7 @@ const scorer: ToolScorer = async (ctx) => {
   }
 
   const passed = checks.every((check) => check.passed);
-    return {
+  return {
     passed,
     checks,
   };

--- a/evals/design-functions-002-edge-auth-db/EVAL.ts
+++ b/evals/design-functions-002-edge-auth-db/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -22,7 +22,7 @@ const parseJson = (result: InvokeResult) => {
 };
 
 const scorer: ToolScorer = async (ctx) => {
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
 
   try {
     const { data: signup, error: signupError } = await ctx.client.auth.signUp({
@@ -32,7 +32,7 @@ const scorer: ToolScorer = async (ctx) => {
     if (signupError || !signup.user || !signup.session?.access_token) {
       return {
         passed: false,
-        assertions: [
+        checks: [
           {
             type: "deterministic",
             name: "created auth session",
@@ -48,7 +48,7 @@ const scorer: ToolScorer = async (ctx) => {
       method: "POST",
       body: { body: TODO_BODY },
     })) as InvokeResult;
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "rejects missing auth",
       passed: missingAuth.status >= 400,
@@ -63,12 +63,12 @@ const scorer: ToolScorer = async (ctx) => {
       body: { body: TODO_BODY },
     })) as InvokeResult;
     const insertedJson = parseJson(inserted);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "authenticated request succeeds",
       passed: inserted.status === 201 || inserted.status === 200,
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "returns inserted todo body",
       passed: insertedJson?.body === TODO_BODY || (insertedJson?.todo as any)?.body === TODO_BODY,
@@ -78,7 +78,7 @@ const scorer: ToolScorer = async (ctx) => {
       .from("todos")
       .select("body,user_id")
       .eq("body", TODO_BODY);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "row exists through supabase-js",
       passed:
@@ -90,7 +90,7 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
@@ -98,14 +98,14 @@ const scorer: ToolScorer = async (ctx) => {
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
-  const passed = assertions.every((assertion) => assertion.passed);
+  const passed = checks.every((check) => check.passed);
     return {
     passed,
-    assertions,
+    checks,
   };
 };
 

--- a/evals/design-functions-002-edge-auth-db/EVAL.ts
+++ b/evals/design-functions-002-edge-auth-db/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const FUNCTION_NAME = "todo-create";
 const TODO_BODY = "verify edge auth database integration";
@@ -28,8 +31,14 @@ const scorer: ToolScorer = async (ctx) => {
     if (signupError || !signup.user || !signup.session?.access_token) {
       return {
         passed: false,
-        score: 0,
-        notes: `could not create auth session: ${signupError?.message ?? "missing session"}`,
+        assertions: [
+          {
+            type: "deterministic",
+            name: "created auth session",
+            passed: false,
+            notes: signupError?.message ?? "missing session",
+          },
+        ],
       };
     }
 
@@ -76,21 +85,24 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: `scorer evaluated ${FUNCTION_NAME}`,
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 4,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not evaluate ${FUNCTION_NAME}: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
   const passed = checks.every((c) => c.ok);
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed,
-    score: checks.filter((c) => c.ok).length / checks.length,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/design-functions-003-todos-crud-api/EVAL.ts
+++ b/evals/design-functions-003-todos-crud-api/EVAL.ts
@@ -47,7 +47,6 @@ const scorer: ToolScorer = async (ctx) => {
         passed: false,
         checks: [
           {
-            type: "deterministic",
             name: "created auth sessions",
             passed: false,
             notes: authAError?.message ?? authBError?.message ?? "missing session",
@@ -71,21 +70,21 @@ const scorer: ToolScorer = async (ctx) => {
     const authHeadersB = { authorization: `Bearer ${authB.session.access_token}` };
 
     const missingAuth = await invoke({ method: "GET" });
-    checks.push({ type: "deterministic", name: "rejects missing auth", passed: missingAuth.status === 401 });
+    checks.push({ name: "rejects missing auth", passed: missingAuth.status === 401 });
 
     const badLimit = await invoke({
       method: "GET",
       path: "?limit=200",
       headers: authHeadersA,
     });
-    checks.push({ type: "deterministic", name: "rejects invalid limit", passed: badLimit.status === 400 });
+    checks.push({ name: "rejects invalid limit", passed: badLimit.status === 400 });
 
     const invalidJson = await invoke({
       method: "POST",
       headers: authHeadersA,
       body: "{",
     });
-    checks.push({ type: "deterministic", name: "rejects invalid JSON", passed: invalidJson.status === 400 });
+    checks.push({ name: "rejects invalid JSON", passed: invalidJson.status === 400 });
 
     const created = await invoke({
       method: "POST",
@@ -94,7 +93,6 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const createdRow = rowFrom(parseJson(created));
     checks.push({
-      type: "deterministic",
       name: "creates todo for authenticated user",
       passed:
         created.status === 201 &&
@@ -117,7 +115,6 @@ const scorer: ToolScorer = async (ctx) => {
     const listJson = parseJson(listDone);
     const todos = Array.isArray(listJson) ? listJson : listJson?.todos;
     checks.push({
-      type: "deterministic",
       name: "filters todos by done",
       passed:
         listDone.status === 200 &&
@@ -133,7 +130,7 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersA,
       body: { done: true },
     });
-    checks.push({ type: "deterministic", name: "rejects invalid UUID", passed: invalidUuid.status === 400 });
+    checks.push({ name: "rejects invalid UUID", passed: invalidUuid.status === 400 });
 
     const patchOtherUser = await invoke({
       method: "PATCH",
@@ -142,7 +139,6 @@ const scorer: ToolScorer = async (ctx) => {
       body: { body: "stolen" },
     });
     checks.push({
-      type: "deterministic",
       name: "returns 404 when patching another user's todo",
       passed: patchOtherUser.status === 404,
     });
@@ -155,7 +151,6 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const ownPatchRow = rowFrom(parseJson(ownPatch));
     checks.push({
-      type: "deterministic",
       name: "updates own todo",
       passed: ownPatch.status === 200 && ownPatchRow?.id === createdRow?.id && ownPatchRow?.done === true,
     });
@@ -166,7 +161,6 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersB,
     });
     checks.push({
-      type: "deterministic",
       name: "returns 404 when deleting another user's todo",
       passed: deleteOtherUser.status === 404,
     });
@@ -177,14 +171,12 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersA,
     });
     checks.push({
-      type: "deterministic",
       name: "deletes own todo",
       passed: ownDelete.status === 200 && parseJson(ownDelete)?.deleted === true,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
       notes: msg,

--- a/evals/design-functions-003-todos-crud-api/EVAL.ts
+++ b/evals/design-functions-003-todos-crud-api/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -23,7 +24,7 @@ const parseJson = (result: InvokeResult) => {
 const rowFrom = (json: Record<string, any> | undefined) => json?.todo ?? json;
 
 const scorer: ToolScorer = async (ctx) => {
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
 
   try {
     const clientA = ctx.client;
@@ -74,21 +75,21 @@ const scorer: ToolScorer = async (ctx) => {
     const authHeadersB = { authorization: `Bearer ${authB.session.access_token}` };
 
     const missingAuth = await invoke({ method: "GET" });
-    checks.push({ name: "rejects missing auth", ok: missingAuth.status === 401 });
+    assertions.push(assertion("rejects missing auth", missingAuth.status === 401));
 
     const badLimit = await invoke({
       method: "GET",
       path: "?limit=200",
       headers: authHeadersA,
     });
-    checks.push({ name: "rejects invalid limit", ok: badLimit.status === 400 });
+    assertions.push(assertion("rejects invalid limit", badLimit.status === 400));
 
     const invalidJson = await invoke({
       method: "POST",
       headers: authHeadersA,
       body: "{",
     });
-    checks.push({ name: "rejects invalid JSON", ok: invalidJson.status === 400 });
+    assertions.push(assertion("rejects invalid JSON", invalidJson.status === 400));
 
     const created = await invoke({
       method: "POST",
@@ -96,9 +97,10 @@ const scorer: ToolScorer = async (ctx) => {
       body: { body: "buy milk", done: false },
     });
     const createdRow = rowFrom(parseJson(created));
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "creates todo for authenticated user",
-      ok:
+      passed:
         created.status === 201 &&
         createdRow?.body === "buy milk" &&
         createdRow?.user_id === authA.user.id &&
@@ -118,9 +120,10 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const listJson = parseJson(listDone);
     const todos = Array.isArray(listJson) ? listJson : listJson?.todos;
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "filters todos by done",
-      ok:
+      passed:
         listDone.status === 200 &&
         Array.isArray(todos) &&
         todos.length === 1 &&
@@ -134,7 +137,7 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersA,
       body: { done: true },
     });
-    checks.push({ name: "rejects invalid UUID", ok: invalidUuid.status === 400 });
+    assertions.push(assertion("rejects invalid UUID", invalidUuid.status === 400));
 
     const patchOtherUser = await invoke({
       method: "PATCH",
@@ -142,9 +145,10 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersB,
       body: { body: "stolen" },
     });
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "returns 404 when patching another user's todo",
-      ok: patchOtherUser.status === 404,
+      passed: patchOtherUser.status === 404,
     });
 
     const ownPatch = await invoke({
@@ -154,9 +158,10 @@ const scorer: ToolScorer = async (ctx) => {
       body: { done: true },
     });
     const ownPatchRow = rowFrom(parseJson(ownPatch));
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "updates own todo",
-      ok: ownPatch.status === 200 && ownPatchRow?.id === createdRow?.id && ownPatchRow?.done === true,
+      passed: ownPatch.status === 200 && ownPatchRow?.id === createdRow?.id && ownPatchRow?.done === true,
     });
 
     const deleteOtherUser = await invoke({
@@ -164,9 +169,10 @@ const scorer: ToolScorer = async (ctx) => {
       path: `/${createdRow?.id}`,
       headers: authHeadersB,
     });
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "returns 404 when deleting another user's todo",
-      ok: deleteOtherUser.status === 404,
+      passed: deleteOtherUser.status === 404,
     });
 
     const ownDelete = await invoke({
@@ -174,14 +180,14 @@ const scorer: ToolScorer = async (ctx) => {
       path: `/${createdRow?.id}`,
       headers: authHeadersA,
     });
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "deletes own todo",
-      ok: ownDelete.status === 200 && parseJson(ownDelete)?.deleted === true,
+      passed: ownDelete.status === 200 && parseJson(ownDelete)?.deleted === true,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
@@ -193,9 +199,8 @@ const scorer: ToolScorer = async (ctx) => {
     };
   }
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
-    passed: checks.every((c) => c.ok),
+    return {
+    passed: assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/design-functions-003-todos-crud-api/EVAL.ts
+++ b/evals/design-functions-003-todos-crud-api/EVAL.ts
@@ -187,7 +187,7 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
@@ -199,7 +199,7 @@ const scorer: ToolScorer = async (ctx) => {
     };
   }
 
-    return {
+  return {
     passed: checks.every((check) => check.passed),
     checks,
   };

--- a/evals/design-functions-003-todos-crud-api/EVAL.ts
+++ b/evals/design-functions-003-todos-crud-api/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -24,7 +24,7 @@ const parseJson = (result: InvokeResult) => {
 const rowFrom = (json: Record<string, any> | undefined) => json?.todo ?? json;
 
 const scorer: ToolScorer = async (ctx) => {
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
 
   try {
     const clientA = ctx.client;
@@ -49,7 +49,7 @@ const scorer: ToolScorer = async (ctx) => {
     ) {
       return {
         passed: false,
-        assertions: [
+        checks: [
           {
             type: "deterministic",
             name: "created auth sessions",
@@ -75,21 +75,21 @@ const scorer: ToolScorer = async (ctx) => {
     const authHeadersB = { authorization: `Bearer ${authB.session.access_token}` };
 
     const missingAuth = await invoke({ method: "GET" });
-    assertions.push(assertion("rejects missing auth", missingAuth.status === 401));
+    checks.push(check("rejects missing auth", missingAuth.status === 401));
 
     const badLimit = await invoke({
       method: "GET",
       path: "?limit=200",
       headers: authHeadersA,
     });
-    assertions.push(assertion("rejects invalid limit", badLimit.status === 400));
+    checks.push(check("rejects invalid limit", badLimit.status === 400));
 
     const invalidJson = await invoke({
       method: "POST",
       headers: authHeadersA,
       body: "{",
     });
-    assertions.push(assertion("rejects invalid JSON", invalidJson.status === 400));
+    checks.push(check("rejects invalid JSON", invalidJson.status === 400));
 
     const created = await invoke({
       method: "POST",
@@ -97,7 +97,7 @@ const scorer: ToolScorer = async (ctx) => {
       body: { body: "buy milk", done: false },
     });
     const createdRow = rowFrom(parseJson(created));
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "creates todo for authenticated user",
       passed:
@@ -120,7 +120,7 @@ const scorer: ToolScorer = async (ctx) => {
     });
     const listJson = parseJson(listDone);
     const todos = Array.isArray(listJson) ? listJson : listJson?.todos;
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "filters todos by done",
       passed:
@@ -137,7 +137,7 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersA,
       body: { done: true },
     });
-    assertions.push(assertion("rejects invalid UUID", invalidUuid.status === 400));
+    checks.push(check("rejects invalid UUID", invalidUuid.status === 400));
 
     const patchOtherUser = await invoke({
       method: "PATCH",
@@ -145,7 +145,7 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersB,
       body: { body: "stolen" },
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "returns 404 when patching another user's todo",
       passed: patchOtherUser.status === 404,
@@ -158,7 +158,7 @@ const scorer: ToolScorer = async (ctx) => {
       body: { done: true },
     });
     const ownPatchRow = rowFrom(parseJson(ownPatch));
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "updates own todo",
       passed: ownPatch.status === 200 && ownPatchRow?.id === createdRow?.id && ownPatchRow?.done === true,
@@ -169,7 +169,7 @@ const scorer: ToolScorer = async (ctx) => {
       path: `/${createdRow?.id}`,
       headers: authHeadersB,
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "returns 404 when deleting another user's todo",
       passed: deleteOtherUser.status === 404,
@@ -180,14 +180,14 @@ const scorer: ToolScorer = async (ctx) => {
       path: `/${createdRow?.id}`,
       headers: authHeadersA,
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "deletes own todo",
       passed: ownDelete.status === 200 && parseJson(ownDelete)?.deleted === true,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: `scorer evaluated ${FUNCTION_NAME}`,
       passed: false,
@@ -195,13 +195,13 @@ const scorer: ToolScorer = async (ctx) => {
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
     return {
-    passed: assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/evals/design-functions-003-todos-crud-api/EVAL.ts
+++ b/evals/design-functions-003-todos-crud-api/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const FUNCTION_NAME = "todos-api";
 const PASSWORD = "secret123";
@@ -75,21 +71,21 @@ const scorer: ToolScorer = async (ctx) => {
     const authHeadersB = { authorization: `Bearer ${authB.session.access_token}` };
 
     const missingAuth = await invoke({ method: "GET" });
-    checks.push(check("rejects missing auth", missingAuth.status === 401));
+    checks.push({ type: "deterministic", name: "rejects missing auth", passed: missingAuth.status === 401 });
 
     const badLimit = await invoke({
       method: "GET",
       path: "?limit=200",
       headers: authHeadersA,
     });
-    checks.push(check("rejects invalid limit", badLimit.status === 400));
+    checks.push({ type: "deterministic", name: "rejects invalid limit", passed: badLimit.status === 400 });
 
     const invalidJson = await invoke({
       method: "POST",
       headers: authHeadersA,
       body: "{",
     });
-    checks.push(check("rejects invalid JSON", invalidJson.status === 400));
+    checks.push({ type: "deterministic", name: "rejects invalid JSON", passed: invalidJson.status === 400 });
 
     const created = await invoke({
       method: "POST",
@@ -137,7 +133,7 @@ const scorer: ToolScorer = async (ctx) => {
       headers: authHeadersA,
       body: { done: true },
     });
-    checks.push(check("rejects invalid UUID", invalidUuid.status === 400));
+    checks.push({ type: "deterministic", name: "rejects invalid UUID", passed: invalidUuid.status === 400 });
 
     const patchOtherUser = await invoke({
       method: "PATCH",

--- a/evals/design-functions-003-todos-crud-api/EVAL.ts
+++ b/evals/design-functions-003-todos-crud-api/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const FUNCTION_NAME = "todos-api";
 const PASSWORD = "secret123";
@@ -45,10 +48,14 @@ const scorer: ToolScorer = async (ctx) => {
     ) {
       return {
         passed: false,
-        score: 0,
-        notes: `could not create auth sessions: ${
-          authAError?.message ?? authBError?.message ?? "missing session"
-        }`,
+        assertions: [
+          {
+            type: "deterministic",
+            name: "created auth sessions",
+            passed: false,
+            notes: authAError?.message ?? authBError?.message ?? "missing session",
+          },
+        ],
       };
     }
 
@@ -173,20 +180,23 @@ const scorer: ToolScorer = async (ctx) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: `scorer evaluated ${FUNCTION_NAME}`,
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 10,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not evaluate ${FUNCTION_NAME}: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks.every((c) => c.ok),
-    score: checks.filter((c) => c.ok).length / checks.length,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/design-rls-001-tenant-isolation/EVAL.ts
+++ b/evals/design-rls-001-tenant-isolation/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const ORG_A = "11111111-1111-1111-1111-111111111111";
 const USER_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
@@ -44,12 +40,12 @@ const scorer: ToolScorer = async (ctx) => {
   const checks: CheckResult[] = [];
   try {
     const { rows: aReads } = await q(asUser(USER_A, `SELECT count(*)::int AS n FROM notes;`));
-    checks.push(check("tenant A sees only org A notes (n=2)", aReads[0]?.n === 2));
+    checks.push({ type: "deterministic", name: "tenant A sees only org A notes (n=2)", passed: aReads[0]?.n === 2 });
 
     const { rows: bCross } = await q(
       asUser(USER_B, `SELECT count(*)::int AS n FROM notes WHERE org_id = '${ORG_A}';`)
     );
-    checks.push(check("tenant B blocked from org A reads", bCross[0]?.n === 0));
+    checks.push({ type: "deterministic", name: "tenant B blocked from org A reads", passed: bCross[0]?.n === 0 });
 
     let insertBlocked = false;
     try {
@@ -61,7 +57,7 @@ const scorer: ToolScorer = async (ctx) => {
       insertBlocked = true;
       await resetTx();
     }
-    checks.push(check("insert into non-member org blocked", insertBlocked));
+    checks.push({ type: "deterministic", name: "insert into non-member org blocked", passed: insertBlocked });
 
     const { rows: ownUpdate } = await q(
       asUser(
@@ -75,7 +71,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push(check("author can update own note", ownUpdate.length === 1));
+    checks.push({ type: "deterministic", name: "author can update own note", passed: ownUpdate.length === 1 });
 
     const { rows: crossUpdate } = await q(
       asUser(
@@ -89,7 +85,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push(check("non-member cannot update org A note", crossUpdate.length === 0));
+    checks.push({ type: "deterministic", name: "non-member cannot update org A note", passed: crossUpdate.length === 0 });
 
     const { rows: ownDelete } = await q(
       asUser(
@@ -102,7 +98,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push(check("author can delete own note", ownDelete.length === 1));
+    checks.push({ type: "deterministic", name: "author can delete own note", passed: ownDelete.length === 1 });
 
     const { rows: crossDelete } = await q(
       asUser(
@@ -115,7 +111,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push(check("non-member cannot delete org A note", crossDelete.length === 0));
+    checks.push({ type: "deterministic", name: "non-member cannot delete org A note", passed: crossDelete.length === 0 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({

--- a/evals/design-rls-001-tenant-isolation/EVAL.ts
+++ b/evals/design-rls-001-tenant-isolation/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -40,15 +41,15 @@ const scorer: ToolScorer = async (ctx) => {
     };
   }
 
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
   try {
     const { rows: aReads } = await q(asUser(USER_A, `SELECT count(*)::int AS n FROM notes;`));
-    checks.push({ name: "tenant A sees only org A notes (n=2)", ok: aReads[0]?.n === 2 });
+    assertions.push(assertion("tenant A sees only org A notes (n=2)", aReads[0]?.n === 2));
 
     const { rows: bCross } = await q(
       asUser(USER_B, `SELECT count(*)::int AS n FROM notes WHERE org_id = '${ORG_A}';`)
     );
-    checks.push({ name: "tenant B blocked from org A reads", ok: bCross[0]?.n === 0 });
+    assertions.push(assertion("tenant B blocked from org A reads", bCross[0]?.n === 0));
 
     let insertBlocked = false;
     try {
@@ -60,7 +61,7 @@ const scorer: ToolScorer = async (ctx) => {
       insertBlocked = true;
       await resetTx();
     }
-    checks.push({ name: "insert into non-member org blocked", ok: insertBlocked });
+    assertions.push(assertion("insert into non-member org blocked", insertBlocked));
 
     const { rows: ownUpdate } = await q(
       asUser(
@@ -74,7 +75,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ name: "author can update own note", ok: ownUpdate.length === 1 });
+    assertions.push(assertion("author can update own note", ownUpdate.length === 1));
 
     const { rows: crossUpdate } = await q(
       asUser(
@@ -88,7 +89,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ name: "non-member cannot update org A note", ok: crossUpdate.length === 0 });
+    assertions.push(assertion("non-member cannot update org A note", crossUpdate.length === 0));
 
     const { rows: ownDelete } = await q(
       asUser(
@@ -101,7 +102,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ name: "author can delete own note", ok: ownDelete.length === 1 });
+    assertions.push(assertion("author can delete own note", ownDelete.length === 1));
 
     const { rows: crossDelete } = await q(
       asUser(
@@ -114,11 +115,10 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ name: "non-member cannot delete org A note", ok: crossDelete.length === 0 });
+    assertions.push(assertion("non-member cannot delete org A note", crossDelete.length === 0));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: "scorer evaluated policy behavior",
       passed: false,
@@ -130,9 +130,8 @@ const scorer: ToolScorer = async (ctx) => {
     };
   }
 
-  const passed = checks.every((c) => c.ok);
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
+  const passed = assertions.every((assertion) => assertion.passed);
+    return {
     passed,
     assertions,
   };

--- a/evals/design-rls-001-tenant-isolation/EVAL.ts
+++ b/evals/design-rls-001-tenant-isolation/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const ORG_A = "11111111-1111-1111-1111-111111111111";
 const USER_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
@@ -31,7 +34,10 @@ const scorer: ToolScorer = async (ctx) => {
     `SELECT relrowsecurity FROM pg_class WHERE relname = 'notes';`
   );
   if (!rls[0]?.relrowsecurity) {
-    return { passed: false, score: 0, notes: "RLS not enabled on notes" };
+    return {
+      passed: false,
+      assertions: [{ type: "deterministic", name: "RLS enabled on notes", passed: false }],
+    };
   }
 
   const checks: Array<{ name: string; ok: boolean }> = [];
@@ -111,19 +117,24 @@ const scorer: ToolScorer = async (ctx) => {
     checks.push({ name: "non-member cannot delete org A note", ok: crossDelete.length === 0 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: "scorer evaluated policy behavior",
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: 0,
-      notes: `scorer could not evaluate policy behavior: ${msg}`,
+      assertions,
     };
   }
 
   const passed = checks.every((c) => c.ok);
-  const score = checks.filter((c) => c.ok).length / checks.length;
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed,
-    score,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/design-rls-001-tenant-isolation/EVAL.ts
+++ b/evals/design-rls-001-tenant-isolation/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -37,19 +37,19 @@ const scorer: ToolScorer = async (ctx) => {
   if (!rls[0]?.relrowsecurity) {
     return {
       passed: false,
-      assertions: [{ type: "deterministic", name: "RLS enabled on notes", passed: false }],
+      checks: [{ type: "deterministic", name: "RLS enabled on notes", passed: false }],
     };
   }
 
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
   try {
     const { rows: aReads } = await q(asUser(USER_A, `SELECT count(*)::int AS n FROM notes;`));
-    assertions.push(assertion("tenant A sees only org A notes (n=2)", aReads[0]?.n === 2));
+    checks.push(check("tenant A sees only org A notes (n=2)", aReads[0]?.n === 2));
 
     const { rows: bCross } = await q(
       asUser(USER_B, `SELECT count(*)::int AS n FROM notes WHERE org_id = '${ORG_A}';`)
     );
-    assertions.push(assertion("tenant B blocked from org A reads", bCross[0]?.n === 0));
+    checks.push(check("tenant B blocked from org A reads", bCross[0]?.n === 0));
 
     let insertBlocked = false;
     try {
@@ -61,7 +61,7 @@ const scorer: ToolScorer = async (ctx) => {
       insertBlocked = true;
       await resetTx();
     }
-    assertions.push(assertion("insert into non-member org blocked", insertBlocked));
+    checks.push(check("insert into non-member org blocked", insertBlocked));
 
     const { rows: ownUpdate } = await q(
       asUser(
@@ -75,7 +75,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("author can update own note", ownUpdate.length === 1));
+    checks.push(check("author can update own note", ownUpdate.length === 1));
 
     const { rows: crossUpdate } = await q(
       asUser(
@@ -89,7 +89,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("non-member cannot update org A note", crossUpdate.length === 0));
+    checks.push(check("non-member cannot update org A note", crossUpdate.length === 0));
 
     const { rows: ownDelete } = await q(
       asUser(
@@ -102,7 +102,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("author can delete own note", ownDelete.length === 1));
+    checks.push(check("author can delete own note", ownDelete.length === 1));
 
     const { rows: crossDelete } = await q(
       asUser(
@@ -115,10 +115,10 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("non-member cannot delete org A note", crossDelete.length === 0));
+    checks.push(check("non-member cannot delete org A note", crossDelete.length === 0));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: "scorer evaluated policy behavior",
       passed: false,
@@ -126,14 +126,14 @@ const scorer: ToolScorer = async (ctx) => {
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
-  const passed = assertions.every((assertion) => assertion.passed);
+  const passed = checks.every((check) => check.passed);
     return {
     passed,
-    assertions,
+    checks,
   };
 };
 

--- a/evals/design-rls-001-tenant-isolation/EVAL.ts
+++ b/evals/design-rls-001-tenant-isolation/EVAL.ts
@@ -33,19 +33,19 @@ const scorer: ToolScorer = async (ctx) => {
   if (!rls[0]?.relrowsecurity) {
     return {
       passed: false,
-      checks: [{ type: "deterministic", name: "RLS enabled on notes", passed: false }],
+      checks: [{ name: "RLS enabled on notes", passed: false }],
     };
   }
 
   const checks: CheckResult[] = [];
   try {
     const { rows: aReads } = await q(asUser(USER_A, `SELECT count(*)::int AS n FROM notes;`));
-    checks.push({ type: "deterministic", name: "tenant A sees only org A notes (n=2)", passed: aReads[0]?.n === 2 });
+    checks.push({ name: "tenant A sees only org A notes (n=2)", passed: aReads[0]?.n === 2 });
 
     const { rows: bCross } = await q(
       asUser(USER_B, `SELECT count(*)::int AS n FROM notes WHERE org_id = '${ORG_A}';`)
     );
-    checks.push({ type: "deterministic", name: "tenant B blocked from org A reads", passed: bCross[0]?.n === 0 });
+    checks.push({ name: "tenant B blocked from org A reads", passed: bCross[0]?.n === 0 });
 
     let insertBlocked = false;
     try {
@@ -57,7 +57,7 @@ const scorer: ToolScorer = async (ctx) => {
       insertBlocked = true;
       await resetTx();
     }
-    checks.push({ type: "deterministic", name: "insert into non-member org blocked", passed: insertBlocked });
+    checks.push({ name: "insert into non-member org blocked", passed: insertBlocked });
 
     const { rows: ownUpdate } = await q(
       asUser(
@@ -71,7 +71,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "author can update own note", passed: ownUpdate.length === 1 });
+    checks.push({ name: "author can update own note", passed: ownUpdate.length === 1 });
 
     const { rows: crossUpdate } = await q(
       asUser(
@@ -85,7 +85,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "non-member cannot update org A note", passed: crossUpdate.length === 0 });
+    checks.push({ name: "non-member cannot update org A note", passed: crossUpdate.length === 0 });
 
     const { rows: ownDelete } = await q(
       asUser(
@@ -98,7 +98,7 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "author can delete own note", passed: ownDelete.length === 1 });
+    checks.push({ name: "author can delete own note", passed: ownDelete.length === 1 });
 
     const { rows: crossDelete } = await q(
       asUser(
@@ -111,11 +111,10 @@ const scorer: ToolScorer = async (ctx) => {
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "non-member cannot delete org A note", passed: crossDelete.length === 0 });
+    checks.push({ name: "non-member cannot delete org A note", passed: crossDelete.length === 0 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: "scorer evaluated policy behavior",
       passed: false,
       notes: msg,

--- a/evals/design-rls-001-tenant-isolation/EVAL.ts
+++ b/evals/design-rls-001-tenant-isolation/EVAL.ts
@@ -118,7 +118,7 @@ const scorer: ToolScorer = async (ctx) => {
     checks.push(check("non-member cannot delete org A note", crossDelete.length === 0));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: "scorer evaluated policy behavior",
       passed: false,
@@ -131,7 +131,7 @@ const scorer: ToolScorer = async (ctx) => {
   }
 
   const passed = checks.every((check) => check.passed);
-    return {
+  return {
     passed,
     checks,
   };

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const USER_A_EMAIL = "todo-user-a@example.com";
 const USER_B_EMAIL = "todo-user-b@example.com";
@@ -57,7 +53,7 @@ INSERT INTO todos (user_id, body, done) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'todos';`
     );
-    checks.push(check("RLS enabled on todos", rls[0]?.relrowsecurity === true));
+    checks.push({ type: "deterministic", name: "RLS enabled on todos", passed: rls[0]?.relrowsecurity === true });
 
     const { data: aTodos, error: aTodosError } = await clientA
       .from("todos")

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -11,7 +11,7 @@ const PASSWORD = "secret123";
 const scorer: ToolScorer = async (ctx) => {
   const clientA = ctx.client;
   const clientB = ctx.getClient();
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
   const q = ctx.query;
 
   try {
@@ -34,7 +34,7 @@ const scorer: ToolScorer = async (ctx) => {
     ) {
       return {
         passed: false,
-        assertions: [
+        checks: [
           {
             type: "deterministic",
             name: "created auth sessions",
@@ -57,13 +57,13 @@ INSERT INTO todos (user_id, body, done) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'todos';`
     );
-    assertions.push(assertion("RLS enabled on todos", rls[0]?.relrowsecurity === true));
+    checks.push(check("RLS enabled on todos", rls[0]?.relrowsecurity === true));
 
     const { data: aTodos, error: aTodosError } = await clientA
       .from("todos")
       .select("body,user_id")
       .order("body");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user A sees only own todos",
       passed:
@@ -77,7 +77,7 @@ INSERT INTO todos (user_id, body, done) VALUES
       .from("todos")
       .select("id")
       .eq("body", "a private todo");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user B cannot read user A todos",
       passed: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
@@ -88,7 +88,7 @@ INSERT INTO todos (user_id, body, done) VALUES
       .insert({ body: "a client insert" })
       .select("body,user_id")
       .single();
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user A can insert own todo through supabase-js",
       passed:
@@ -103,7 +103,7 @@ INSERT INTO todos (user_id, body, done) VALUES
         .insert({ user_id: userAId, body: "b spoofed as a" })
         .select("id")
     );
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user B cannot insert todo for user A",
       passed: Boolean(spoofInsertError) || !spoofInsert || spoofInsert.length === 0,
@@ -114,7 +114,7 @@ INSERT INTO todos (user_id, body, done) VALUES
       .update({ done: true })
       .eq("body", "a private todo")
       .select("body,done");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user A can update own todo",
       passed: !ownUpdateError && ownUpdate?.length === 1 && ownUpdate[0]?.done === true,
@@ -125,7 +125,7 @@ INSERT INTO todos (user_id, body, done) VALUES
       .update({ body: "b changed a todo" })
       .eq("body", "a done todo")
       .select("id");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user B cannot update user A todo",
       passed: Boolean(crossUpdateError) || !crossUpdate || crossUpdate.length === 0,
@@ -136,7 +136,7 @@ INSERT INTO todos (user_id, body, done) VALUES
       .delete()
       .eq("body", "b private todo")
       .select("id");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user B can delete own todo",
       passed: !ownDeleteError && ownDelete?.length === 1,
@@ -147,14 +147,14 @@ INSERT INTO todos (user_id, body, done) VALUES
       .delete()
       .eq("body", "a done todo")
       .select("id");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user B cannot delete user A todo",
       passed: Boolean(crossDeleteError) || !crossDelete || crossDelete.length === 0,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: "scorer evaluated client RLS behavior",
       passed: false,
@@ -162,14 +162,14 @@ INSERT INTO todos (user_id, body, done) VALUES
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
-  const passed = assertions.every((assertion) => assertion.passed);
+  const passed = checks.every((check) => check.passed);
     return {
     passed,
-    assertions,
+    checks,
   };
 };
 

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -154,7 +154,7 @@ INSERT INTO todos (user_id, body, done) VALUES
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: "scorer evaluated client RLS behavior",
       passed: false,
@@ -167,7 +167,7 @@ INSERT INTO todos (user_id, body, done) VALUES
   }
 
   const passed = checks.every((check) => check.passed);
-    return {
+  return {
     passed,
     checks,
   };

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -10,7 +11,7 @@ const PASSWORD = "secret123";
 const scorer: ToolScorer = async (ctx) => {
   const clientA = ctx.client;
   const clientB = ctx.getClient();
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
   const q = ctx.query;
 
   try {
@@ -56,15 +57,16 @@ INSERT INTO todos (user_id, body, done) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'todos';`
     );
-    checks.push({ name: "RLS enabled on todos", ok: rls[0]?.relrowsecurity === true });
+    assertions.push(assertion("RLS enabled on todos", rls[0]?.relrowsecurity === true));
 
     const { data: aTodos, error: aTodosError } = await clientA
       .from("todos")
       .select("body,user_id")
       .order("body");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user A sees only own todos",
-      ok:
+      passed:
         !aTodosError &&
         aTodos?.length === 2 &&
         aTodos.every((todo) => todo.user_id === userAId) &&
@@ -75,9 +77,10 @@ INSERT INTO todos (user_id, body, done) VALUES
       .from("todos")
       .select("id")
       .eq("body", "a private todo");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user B cannot read user A todos",
-      ok: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
+      passed: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
     });
 
     const { data: ownInsert, error: ownInsertError } = await clientA
@@ -85,9 +88,10 @@ INSERT INTO todos (user_id, body, done) VALUES
       .insert({ body: "a client insert" })
       .select("body,user_id")
       .single();
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user A can insert own todo through supabase-js",
-      ok:
+      passed:
         !ownInsertError &&
         ownInsert?.body === "a client insert" &&
         ownInsert.user_id === userAId,
@@ -99,9 +103,10 @@ INSERT INTO todos (user_id, body, done) VALUES
         .insert({ user_id: userAId, body: "b spoofed as a" })
         .select("id")
     );
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user B cannot insert todo for user A",
-      ok: Boolean(spoofInsertError) || !spoofInsert || spoofInsert.length === 0,
+      passed: Boolean(spoofInsertError) || !spoofInsert || spoofInsert.length === 0,
     });
 
     const { data: ownUpdate, error: ownUpdateError } = await clientA
@@ -109,9 +114,10 @@ INSERT INTO todos (user_id, body, done) VALUES
       .update({ done: true })
       .eq("body", "a private todo")
       .select("body,done");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user A can update own todo",
-      ok: !ownUpdateError && ownUpdate?.length === 1 && ownUpdate[0]?.done === true,
+      passed: !ownUpdateError && ownUpdate?.length === 1 && ownUpdate[0]?.done === true,
     });
 
     const { data: crossUpdate, error: crossUpdateError } = await clientB
@@ -119,9 +125,10 @@ INSERT INTO todos (user_id, body, done) VALUES
       .update({ body: "b changed a todo" })
       .eq("body", "a done todo")
       .select("id");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user B cannot update user A todo",
-      ok: Boolean(crossUpdateError) || !crossUpdate || crossUpdate.length === 0,
+      passed: Boolean(crossUpdateError) || !crossUpdate || crossUpdate.length === 0,
     });
 
     const { data: ownDelete, error: ownDeleteError } = await clientB
@@ -129,9 +136,10 @@ INSERT INTO todos (user_id, body, done) VALUES
       .delete()
       .eq("body", "b private todo")
       .select("id");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user B can delete own todo",
-      ok: !ownDeleteError && ownDelete?.length === 1,
+      passed: !ownDeleteError && ownDelete?.length === 1,
     });
 
     const { data: crossDelete, error: crossDeleteError } = await clientB
@@ -139,14 +147,14 @@ INSERT INTO todos (user_id, body, done) VALUES
       .delete()
       .eq("body", "a done todo")
       .select("id");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user B cannot delete user A todo",
-      ok: Boolean(crossDeleteError) || !crossDelete || crossDelete.length === 0,
+      passed: Boolean(crossDeleteError) || !crossDelete || crossDelete.length === 0,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: "scorer evaluated client RLS behavior",
       passed: false,
@@ -158,9 +166,8 @@ INSERT INTO todos (user_id, body, done) VALUES
     };
   }
 
-  const passed = checks.every((c) => c.ok);
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
+  const passed = assertions.every((assertion) => assertion.passed);
+    return {
     passed,
     assertions,
   };

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -32,7 +32,6 @@ const scorer: ToolScorer = async (ctx) => {
         passed: false,
         checks: [
           {
-            type: "deterministic",
             name: "created auth sessions",
             passed: false,
             notes: authAError?.message ?? authBError?.message ?? "missing session",
@@ -53,14 +52,13 @@ INSERT INTO todos (user_id, body, done) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'todos';`
     );
-    checks.push({ type: "deterministic", name: "RLS enabled on todos", passed: rls[0]?.relrowsecurity === true });
+    checks.push({ name: "RLS enabled on todos", passed: rls[0]?.relrowsecurity === true });
 
     const { data: aTodos, error: aTodosError } = await clientA
       .from("todos")
       .select("body,user_id")
       .order("body");
     checks.push({
-      type: "deterministic",
       name: "user A sees only own todos",
       passed:
         !aTodosError &&
@@ -74,7 +72,6 @@ INSERT INTO todos (user_id, body, done) VALUES
       .select("id")
       .eq("body", "a private todo");
     checks.push({
-      type: "deterministic",
       name: "user B cannot read user A todos",
       passed: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
     });
@@ -85,7 +82,6 @@ INSERT INTO todos (user_id, body, done) VALUES
       .select("body,user_id")
       .single();
     checks.push({
-      type: "deterministic",
       name: "user A can insert own todo through supabase-js",
       passed:
         !ownInsertError &&
@@ -100,7 +96,6 @@ INSERT INTO todos (user_id, body, done) VALUES
         .select("id")
     );
     checks.push({
-      type: "deterministic",
       name: "user B cannot insert todo for user A",
       passed: Boolean(spoofInsertError) || !spoofInsert || spoofInsert.length === 0,
     });
@@ -111,7 +106,6 @@ INSERT INTO todos (user_id, body, done) VALUES
       .eq("body", "a private todo")
       .select("body,done");
     checks.push({
-      type: "deterministic",
       name: "user A can update own todo",
       passed: !ownUpdateError && ownUpdate?.length === 1 && ownUpdate[0]?.done === true,
     });
@@ -122,7 +116,6 @@ INSERT INTO todos (user_id, body, done) VALUES
       .eq("body", "a done todo")
       .select("id");
     checks.push({
-      type: "deterministic",
       name: "user B cannot update user A todo",
       passed: Boolean(crossUpdateError) || !crossUpdate || crossUpdate.length === 0,
     });
@@ -133,7 +126,6 @@ INSERT INTO todos (user_id, body, done) VALUES
       .eq("body", "b private todo")
       .select("id");
     checks.push({
-      type: "deterministic",
       name: "user B can delete own todo",
       passed: !ownDeleteError && ownDelete?.length === 1,
     });
@@ -144,14 +136,12 @@ INSERT INTO todos (user_id, body, done) VALUES
       .eq("body", "a done todo")
       .select("id");
     checks.push({
-      type: "deterministic",
       name: "user B cannot delete user A todo",
       passed: Boolean(crossDeleteError) || !crossDelete || crossDelete.length === 0,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: "scorer evaluated client RLS behavior",
       passed: false,
       notes: msg,

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const USER_A_EMAIL = "todo-user-a@example.com";
 const USER_B_EMAIL = "todo-user-b@example.com";
@@ -30,10 +33,14 @@ const scorer: ToolScorer = async (ctx) => {
     ) {
       return {
         passed: false,
-        score: 0,
-        notes: `could not create auth sessions: ${
-          authAError?.message ?? authBError?.message ?? "missing session"
-        }`,
+        assertions: [
+          {
+            type: "deterministic",
+            name: "created auth sessions",
+            passed: false,
+            notes: authAError?.message ?? authBError?.message ?? "missing session",
+          },
+        ],
       };
     }
     const userAId = authA.user.id;
@@ -138,21 +145,24 @@ INSERT INTO todos (user_id, body, done) VALUES
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: "scorer evaluated client RLS behavior",
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 9,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not evaluate client RLS behavior: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
   const passed = checks.every((c) => c.ok);
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed,
-    score: checks.filter((c) => c.ok).length / checks.length,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/design-rls-003-org-roles-permissions/EVAL.ts
+++ b/evals/design-rls-003-org-roles-permissions/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -22,7 +22,7 @@ ${finish};
 const scorer: ToolScorer = async (ctx) => {
   const q = (sql: string) =>
     ctx.query(sql);
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
 
   const resetTx = async () => {
     try {
@@ -36,7 +36,7 @@ const scorer: ToolScorer = async (ctx) => {
     const { rows: rls } = await q(
       `SELECT relname, relrowsecurity FROM pg_class WHERE relname IN ('documents', 'document_audit');`
     );
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "RLS enabled on documents",
       passed: rls.some((row) => row.relname === "documents" && row.relrowsecurity === true),
@@ -48,7 +48,7 @@ const scorer: ToolScorer = async (ctx) => {
         `SELECT title FROM documents ORDER BY title;`
       )
     );
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "viewer sees active org documents only",
       passed:
@@ -71,7 +71,7 @@ VALUES ('${ORG_A}', '${VIEWER_A}', 'viewer insert', 'should fail');
       viewerInsertBlocked = true;
       await resetTx();
     }
-    assertions.push(assertion("viewer cannot insert", viewerInsertBlocked));
+    checks.push(check("viewer cannot insert", viewerInsertBlocked));
 
     const { rows: editorInsert } = await q(
       asUser(
@@ -84,7 +84,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("editor can insert own org document", editorInsert.length === 1));
+    checks.push(check("editor can insert own org document", editorInsert.length === 1));
 
     const { rows: editorOwnUpdate } = await q(
       asUser(
@@ -98,7 +98,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("editor can update own document", editorOwnUpdate.length === 1));
+    checks.push(check("editor can update own document", editorOwnUpdate.length === 1));
 
     const { rows: editorUpdatesAdmin } = await q(
       asUser(
@@ -112,7 +112,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "editor cannot update another user's document",
       passed: editorUpdatesAdmin.length === 0,
@@ -130,7 +130,7 @@ WHERE id = '10000000-0000-0000-0000-000000000001';
     const { rows: adminSoftDelete } = await q(
       `SELECT id, deleted_at FROM documents WHERE id = '10000000-0000-0000-0000-000000000001';`
     );
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "admin delete soft-deletes document in org",
       passed:
@@ -151,7 +151,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    assertions.push(assertion("admin cannot affect another org", adminCrossOrg.length === 0));
+    checks.push(check("admin cannot affect another org", adminCrossOrg.length === 0));
 
     let orgReassignmentBlocked = false;
     try {
@@ -172,7 +172,7 @@ RETURNING id;
       orgReassignmentBlocked = true;
       await resetTx();
     }
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "WITH CHECK blocks editor from moving document to another org",
       passed: orgReassignmentBlocked,
@@ -192,7 +192,7 @@ RETURNING id;
     const { rows: auditRows } = await q(
       `SELECT actor_id, document_id FROM document_audit WHERE document_id = '10000000-0000-0000-0000-000000000002';`
     );
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "write creates audit row with acting user",
       passed:
@@ -205,7 +205,7 @@ RETURNING id;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: "scorer evaluated org role RLS",
       passed: false,
@@ -213,13 +213,13 @@ RETURNING id;
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
     return {
-    passed: assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/evals/design-rls-003-org-roles-permissions/EVAL.ts
+++ b/evals/design-rls-003-org-roles-permissions/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const ORG_A = "11111111-1111-1111-1111-111111111111";
 const ORG_B = "22222222-2222-2222-2222-222222222222";
@@ -195,20 +198,23 @@ RETURNING id;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: "scorer evaluated org role RLS",
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 10,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not evaluate org role RLS: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks.every((c) => c.ok),
-    score: checks.filter((c) => c.ok).length / checks.length,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/design-rls-003-org-roles-permissions/EVAL.ts
+++ b/evals/design-rls-003-org-roles-permissions/EVAL.ts
@@ -205,7 +205,7 @@ RETURNING id;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: "scorer evaluated org role RLS",
       passed: false,
@@ -217,7 +217,7 @@ RETURNING id;
     };
   }
 
-    return {
+  return {
     passed: checks.every((check) => check.passed),
     checks,
   };

--- a/evals/design-rls-003-org-roles-permissions/EVAL.ts
+++ b/evals/design-rls-003-org-roles-permissions/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -21,7 +22,7 @@ ${finish};
 const scorer: ToolScorer = async (ctx) => {
   const q = (sql: string) =>
     ctx.query(sql);
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
 
   const resetTx = async () => {
     try {
@@ -35,9 +36,10 @@ const scorer: ToolScorer = async (ctx) => {
     const { rows: rls } = await q(
       `SELECT relname, relrowsecurity FROM pg_class WHERE relname IN ('documents', 'document_audit');`
     );
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "RLS enabled on documents",
-      ok: rls.some((row) => row.relname === "documents" && row.relrowsecurity === true),
+      passed: rls.some((row) => row.relname === "documents" && row.relrowsecurity === true),
     });
 
     const { rows: viewerReads } = await q(
@@ -46,9 +48,10 @@ const scorer: ToolScorer = async (ctx) => {
         `SELECT title FROM documents ORDER BY title;`
       )
     );
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "viewer sees active org documents only",
-      ok:
+      passed:
         viewerReads.length === 2 &&
         viewerReads.map((row) => row.title).join(",") === "Admin plan,Editor draft",
     });
@@ -68,7 +71,7 @@ VALUES ('${ORG_A}', '${VIEWER_A}', 'viewer insert', 'should fail');
       viewerInsertBlocked = true;
       await resetTx();
     }
-    checks.push({ name: "viewer cannot insert", ok: viewerInsertBlocked });
+    assertions.push(assertion("viewer cannot insert", viewerInsertBlocked));
 
     const { rows: editorInsert } = await q(
       asUser(
@@ -81,7 +84,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({ name: "editor can insert own org document", ok: editorInsert.length === 1 });
+    assertions.push(assertion("editor can insert own org document", editorInsert.length === 1));
 
     const { rows: editorOwnUpdate } = await q(
       asUser(
@@ -95,7 +98,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({ name: "editor can update own document", ok: editorOwnUpdate.length === 1 });
+    assertions.push(assertion("editor can update own document", editorOwnUpdate.length === 1));
 
     const { rows: editorUpdatesAdmin } = await q(
       asUser(
@@ -109,9 +112,10 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "editor cannot update another user's document",
-      ok: editorUpdatesAdmin.length === 0,
+      passed: editorUpdatesAdmin.length === 0,
     });
 
     await q(
@@ -126,9 +130,10 @@ WHERE id = '10000000-0000-0000-0000-000000000001';
     const { rows: adminSoftDelete } = await q(
       `SELECT id, deleted_at FROM documents WHERE id = '10000000-0000-0000-0000-000000000001';`
     );
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "admin delete soft-deletes document in org",
-      ok:
+      passed:
         adminSoftDelete.length === 1 &&
         adminSoftDelete[0]?.id === "10000000-0000-0000-0000-000000000001" &&
         Boolean(adminSoftDelete[0]?.deleted_at),
@@ -146,7 +151,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({ name: "admin cannot affect another org", ok: adminCrossOrg.length === 0 });
+    assertions.push(assertion("admin cannot affect another org", adminCrossOrg.length === 0));
 
     let orgReassignmentBlocked = false;
     try {
@@ -167,9 +172,10 @@ RETURNING id;
       orgReassignmentBlocked = true;
       await resetTx();
     }
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "WITH CHECK blocks editor from moving document to another org",
-      ok: orgReassignmentBlocked,
+      passed: orgReassignmentBlocked,
     });
 
     const { rows: auditedUpdate } = await q(
@@ -186,9 +192,10 @@ RETURNING id;
     const { rows: auditRows } = await q(
       `SELECT actor_id, document_id FROM document_audit WHERE document_id = '10000000-0000-0000-0000-000000000002';`
     );
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "write creates audit row with acting user",
-      ok:
+      passed:
         auditedUpdate.length === 1 &&
         auditRows.some(
           (row) =>
@@ -198,8 +205,7 @@ RETURNING id;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: "scorer evaluated org role RLS",
       passed: false,
@@ -211,9 +217,8 @@ RETURNING id;
     };
   }
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
-    passed: checks.every((c) => c.ok),
+    return {
+    passed: assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/design-rls-003-org-roles-permissions/EVAL.ts
+++ b/evals/design-rls-003-org-roles-permissions/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const ORG_A = "11111111-1111-1111-1111-111111111111";
 const ORG_B = "22222222-2222-2222-2222-222222222222";
@@ -71,7 +67,7 @@ VALUES ('${ORG_A}', '${VIEWER_A}', 'viewer insert', 'should fail');
       viewerInsertBlocked = true;
       await resetTx();
     }
-    checks.push(check("viewer cannot insert", viewerInsertBlocked));
+    checks.push({ type: "deterministic", name: "viewer cannot insert", passed: viewerInsertBlocked });
 
     const { rows: editorInsert } = await q(
       asUser(
@@ -84,7 +80,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push(check("editor can insert own org document", editorInsert.length === 1));
+    checks.push({ type: "deterministic", name: "editor can insert own org document", passed: editorInsert.length === 1 });
 
     const { rows: editorOwnUpdate } = await q(
       asUser(
@@ -98,7 +94,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push(check("editor can update own document", editorOwnUpdate.length === 1));
+    checks.push({ type: "deterministic", name: "editor can update own document", passed: editorOwnUpdate.length === 1 });
 
     const { rows: editorUpdatesAdmin } = await q(
       asUser(
@@ -151,7 +147,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push(check("admin cannot affect another org", adminCrossOrg.length === 0));
+    checks.push({ type: "deterministic", name: "admin cannot affect another org", passed: adminCrossOrg.length === 0 });
 
     let orgReassignmentBlocked = false;
     try {

--- a/evals/design-rls-003-org-roles-permissions/EVAL.ts
+++ b/evals/design-rls-003-org-roles-permissions/EVAL.ts
@@ -33,7 +33,6 @@ const scorer: ToolScorer = async (ctx) => {
       `SELECT relname, relrowsecurity FROM pg_class WHERE relname IN ('documents', 'document_audit');`
     );
     checks.push({
-      type: "deterministic",
       name: "RLS enabled on documents",
       passed: rls.some((row) => row.relname === "documents" && row.relrowsecurity === true),
     });
@@ -45,7 +44,6 @@ const scorer: ToolScorer = async (ctx) => {
       )
     );
     checks.push({
-      type: "deterministic",
       name: "viewer sees active org documents only",
       passed:
         viewerReads.length === 2 &&
@@ -67,7 +65,7 @@ VALUES ('${ORG_A}', '${VIEWER_A}', 'viewer insert', 'should fail');
       viewerInsertBlocked = true;
       await resetTx();
     }
-    checks.push({ type: "deterministic", name: "viewer cannot insert", passed: viewerInsertBlocked });
+    checks.push({ name: "viewer cannot insert", passed: viewerInsertBlocked });
 
     const { rows: editorInsert } = await q(
       asUser(
@@ -80,7 +78,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "editor can insert own org document", passed: editorInsert.length === 1 });
+    checks.push({ name: "editor can insert own org document", passed: editorInsert.length === 1 });
 
     const { rows: editorOwnUpdate } = await q(
       asUser(
@@ -94,7 +92,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "editor can update own document", passed: editorOwnUpdate.length === 1 });
+    checks.push({ name: "editor can update own document", passed: editorOwnUpdate.length === 1 });
 
     const { rows: editorUpdatesAdmin } = await q(
       asUser(
@@ -109,7 +107,6 @@ RETURNING id;
       )
     );
     checks.push({
-      type: "deterministic",
       name: "editor cannot update another user's document",
       passed: editorUpdatesAdmin.length === 0,
     });
@@ -127,7 +124,6 @@ WHERE id = '10000000-0000-0000-0000-000000000001';
       `SELECT id, deleted_at FROM documents WHERE id = '10000000-0000-0000-0000-000000000001';`
     );
     checks.push({
-      type: "deterministic",
       name: "admin delete soft-deletes document in org",
       passed:
         adminSoftDelete.length === 1 &&
@@ -147,7 +143,7 @@ RETURNING id;
         "ROLLBACK"
       )
     );
-    checks.push({ type: "deterministic", name: "admin cannot affect another org", passed: adminCrossOrg.length === 0 });
+    checks.push({ name: "admin cannot affect another org", passed: adminCrossOrg.length === 0 });
 
     let orgReassignmentBlocked = false;
     try {
@@ -169,7 +165,6 @@ RETURNING id;
       await resetTx();
     }
     checks.push({
-      type: "deterministic",
       name: "WITH CHECK blocks editor from moving document to another org",
       passed: orgReassignmentBlocked,
     });
@@ -189,7 +184,6 @@ RETURNING id;
       `SELECT actor_id, document_id FROM document_audit WHERE document_id = '10000000-0000-0000-0000-000000000002';`
     );
     checks.push({
-      type: "deterministic",
       name: "write creates audit row with acting user",
       passed:
         auditedUpdate.length === 1 &&
@@ -202,7 +196,6 @@ RETURNING id;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: "scorer evaluated org role RLS",
       passed: false,
       notes: msg,

--- a/evals/detect-reliability-001-error-rate-spike/EVAL.ts
+++ b/evals/detect-reliability-001-error-rate-spike/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 function reportedErrorRateAboveFivePercent(report: string): boolean {
   const percentMatches = report.matchAll(/\b(\d+(?:\.\d+)?)\s*%/g);

--- a/evals/detect-reliability-001-error-rate-spike/EVAL.ts
+++ b/evals/detect-reliability-001-error-rate-spike/EVAL.ts
@@ -18,19 +18,16 @@ const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
 
   const checks: CheckResult[] = [
-    { type: "deterministic", name: "named the affected function", passed: /process-payment/i.test(report) },
+    { name: "named the affected function", passed: /process-payment/i.test(report) },
     {
-      type: "deterministic",
       name: "reported an error rate above 5%",
       passed: reportedErrorRateAboveFivePercent(report),
     },
     {
-      type: "deterministic",
       name: "described the rate as elevated",
       passed: /(spike|elevated|abnormal|exceeds|high error rate|concerning)/i.test(report),
     },
     {
-      type: "deterministic",
       name: "proposed a concrete next step",
       passed: /(investigate|rollback|inspect|trace|mitigate|check|review)/i.test(report),
     },

--- a/evals/detect-reliability-001-error-rate-spike/EVAL.ts
+++ b/evals/detect-reliability-001-error-rate-spike/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -20,25 +21,27 @@ function reportedErrorRateAboveFivePercent(report: string): boolean {
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
 
-  const checks = [
-    { name: "named the affected function", ok: /process-payment/i.test(report) },
+  const assertions: AssertionResult[] = [
+    { type: "deterministic", name: "named the affected function", passed: /process-payment/i.test(report) },
     {
+      type: "deterministic",
       name: "reported an error rate above 5%",
-      ok: reportedErrorRateAboveFivePercent(report),
+      passed: reportedErrorRateAboveFivePercent(report),
     },
     {
+      type: "deterministic",
       name: "described the rate as elevated",
-      ok: /(spike|elevated|abnormal|exceeds|high error rate|concerning)/i.test(report),
+      passed: /(spike|elevated|abnormal|exceeds|high error rate|concerning)/i.test(report),
     },
     {
+      type: "deterministic",
       name: "proposed a concrete next step",
-      ok: /(investigate|rollback|inspect|trace|mitigate|check|review)/i.test(report),
+      passed: /(investigate|rollback|inspect|trace|mitigate|check|review)/i.test(report),
     },
   ];
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
-    passed: checks[0].ok && checks[1].ok && checks[2].ok,
+    passed: assertions[0]?.passed === true && assertions[1]?.passed === true && assertions[2]?.passed === true,
     assertions,
   };
 };

--- a/evals/detect-reliability-001-error-rate-spike/EVAL.ts
+++ b/evals/detect-reliability-001-error-rate-spike/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -21,7 +21,7 @@ function reportedErrorRateAboveFivePercent(report: string): boolean {
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
 
-  const assertions: AssertionResult[] = [
+  const checks: CheckResult[] = [
     { type: "deterministic", name: "named the affected function", passed: /process-payment/i.test(report) },
     {
       type: "deterministic",
@@ -41,8 +41,8 @@ const scorer: ToolScorer = async (ctx) => {
   ];
 
   return {
-    passed: assertions[0]?.passed === true && assertions[1]?.passed === true && assertions[2]?.passed === true,
-    assertions,
+    passed: checks[0]?.passed === true && checks[1]?.passed === true && checks[2]?.passed === true,
+    checks,
   };
 };
 

--- a/evals/detect-reliability-001-error-rate-spike/EVAL.ts
+++ b/evals/detect-reliability-001-error-rate-spike/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 function reportedErrorRateAboveFivePercent(report: string): boolean {
   const percentMatches = report.matchAll(/\b(\d+(?:\.\d+)?)\s*%/g);
@@ -33,11 +36,10 @@ const scorer: ToolScorer = async (ctx) => {
     },
   ];
 
-  const score = checks.filter((c) => c.ok).length / checks.length;
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks[0].ok && checks[1].ok && checks[2].ok,
-    score,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
+++ b/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";

--- a/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
+++ b/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
@@ -14,15 +17,18 @@ const scorer: ToolScorer = async (ctx) => {
     },
   ];
   const flagsWrongFunction = /(auth-callback|image-resize|daily-digest)/i.test(report) && !checks[0].ok;
-  const score = flagsWrongFunction ? 0 : checks.filter((c) => c.ok).length / checks.length;
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
+  if (flagsWrongFunction) {
+    assertions.push({
+      type: "deterministic",
+      name: "did not flag a non-planted function",
+      passed: false,
+    });
+  }
 
   return {
     passed: !flagsWrongFunction && checks.every((c) => c.ok),
-    score,
-    notes: [
-      ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-      flagsWrongFunction ? "FAIL flagged a non-planted function" : undefined,
-    ].filter(Boolean).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
+++ b/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
@@ -3,14 +3,12 @@ import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
   const checks: CheckResult[] = [
-    { type: "deterministic", name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
+    { name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
     {
-      type: "deterministic",
       name: "used recent or per-function framing",
       passed: /(last\s+15|recent|window|per[- ]function|by\s+function|group(ed)?\s+by\s+function)/i.test(report),
     },
     {
-      type: "deterministic",
       name: "described elevated error rate",
       passed: /(spike|elevated|abnormal|high error rate|concerning|18%|0\.18|9\s*\/\s*50)/i.test(report),
     },
@@ -20,7 +18,6 @@ const scorer: ToolScorer = async (ctx) => {
     checks[0]?.passed !== true;
   if (flagsWrongFunction) {
     checks.push({
-      type: "deterministic",
       name: "did not flag a non-planted function",
       passed: false,
     });

--- a/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
+++ b/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
@@ -1,23 +1,27 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
-  const checks = [
-    { name: "named stripe-webhook", ok: /stripe-webhook/i.test(report) },
+  const assertions: AssertionResult[] = [
+    { type: "deterministic", name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
     {
+      type: "deterministic",
       name: "used recent or per-function framing",
-      ok: /(last\s+15|recent|window|per[- ]function|by\s+function|group(ed)?\s+by\s+function)/i.test(report),
+      passed: /(last\s+15|recent|window|per[- ]function|by\s+function|group(ed)?\s+by\s+function)/i.test(report),
     },
     {
+      type: "deterministic",
       name: "described elevated error rate",
-      ok: /(spike|elevated|abnormal|high error rate|concerning|18%|0\.18|9\s*\/\s*50)/i.test(report),
+      passed: /(spike|elevated|abnormal|high error rate|concerning|18%|0\.18|9\s*\/\s*50)/i.test(report),
     },
   ];
-  const flagsWrongFunction = /(auth-callback|image-resize|daily-digest)/i.test(report) && !checks[0].ok;
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
+  const flagsWrongFunction =
+    /(auth-callback|image-resize|daily-digest)/i.test(report) &&
+    assertions[0]?.passed !== true;
   if (flagsWrongFunction) {
     assertions.push({
       type: "deterministic",
@@ -27,7 +31,7 @@ const scorer: ToolScorer = async (ctx) => {
   }
 
   return {
-    passed: !flagsWrongFunction && checks.every((c) => c.ok),
+    passed: !flagsWrongFunction && assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
+++ b/evals/detect-reliability-002-subtle-error-spike/EVAL.ts
@@ -1,12 +1,12 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
-  const assertions: AssertionResult[] = [
+  const checks: CheckResult[] = [
     { type: "deterministic", name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
     {
       type: "deterministic",
@@ -21,9 +21,9 @@ const scorer: ToolScorer = async (ctx) => {
   ];
   const flagsWrongFunction =
     /(auth-callback|image-resize|daily-digest)/i.test(report) &&
-    assertions[0]?.passed !== true;
+    checks[0]?.passed !== true;
   if (flagsWrongFunction) {
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "did not flag a non-planted function",
       passed: false,
@@ -31,8 +31,8 @@ const scorer: ToolScorer = async (ctx) => {
   }
 
   return {
-    passed: !flagsWrongFunction && assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: !flagsWrongFunction && checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -4,6 +4,7 @@ import {
   type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
+import { stripIndent } from "common-tags";
 
 // Planted issue: `customer_payment_methods` is GRANTed to anon and has no RLS.
 // The agent must name this specific table in its final report.
@@ -30,11 +31,11 @@ const scorer: ToolScorer = async (ctx) => {
           input: serializeTranscript(ctx.transcript, {
             includeToolCallInputs: true,
           }),
-          rubric: `
-Pass if the agent identifies public.customer_payment_methods as exposed to anon/public access without proper RLS protection and proposes a concrete Supabase-compatible fix such as revoking anon access, enabling RLS, or adding a restrictive policy.
+          rubric: stripIndent`
+            Pass if the agent identifies public.customer_payment_methods as exposed to anon/public access without proper RLS protection and proposes a concrete Supabase-compatible fix such as revoking anon access, enabling RLS, or adding a restrictive policy.
 
-Fail if it names the wrong table, misses the anon/public exposure, or only gives vague advice.
-    `,
+            Fail if it names the wrong table, misses the anon/public exposure, or only gives vague advice.
+          `,
         })
       : undefined;
 

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -1,4 +1,4 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import { judgeTranscript, type ToolScorer } from "@supabase-evals/core";
 
 // Planted issue: `customer_payment_methods` is GRANTed to anon and has no RLS.
 // The agent must name this specific table in its final report.
@@ -18,13 +18,36 @@ const scorer: ToolScorer = async (ctx) => {
     },
   ];
 
+  const judge =
+    ctx.transcript.length > 0
+      ? await judgeTranscript({
+          transcript: ctx.transcript,
+          includeToolCallInputs: true,
+          rubric: `
+Pass if the agent identifies public.customer_payment_methods as exposed to anon/public access without proper RLS protection and proposes a concrete Supabase-compatible fix such as revoking anon access, enabling RLS, or adding a restrictive policy.
+
+Fail if it names the wrong table, misses the anon/public exposure, or only gives vague advice.
+    `,
+        })
+      : undefined;
+
+  if (judge) {
+    checks.push({
+      name: "llm judge verified the exposed table and fix",
+      ok: judge.passed,
+    });
+  }
+
   const namedTable = checks[0].ok;
   const proposedFix = checks[2].ok;
   const score = checks.filter((c) => c.ok).length / checks.length;
   return {
-    passed: namedTable && proposedFix,
+    passed: namedTable && proposedFix && (judge?.passed ?? true),
     score,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    notes: [
+      ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
+      ...(judge ? [`Judge: ${judge.notes}`] : []),
+    ].join("\n"),
   };
 };
 

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -1,6 +1,6 @@
 import {
   judgeTranscript,
-  type AssertionResult,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -10,7 +10,7 @@ import {
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
 
-  const assertions: AssertionResult[] = [
+  const checks: CheckResult[] = [
     { type: "deterministic", name: "named the vulnerable table", passed: /customer_payment_methods/i.test(report) },
     { type: "deterministic", name: "mentioned the anon role", passed: /\banon\b/i.test(report) },
     {
@@ -37,7 +37,7 @@ Fail if it names the wrong table, misses the anon/public exposure, or only gives
       : undefined;
 
   if (judge) {
-    assertions.push({
+    checks.push({
       type: "llm",
       name: "verified the exposed table and fix",
       passed: judge.passed,
@@ -45,11 +45,11 @@ Fail if it names the wrong table, misses the anon/public exposure, or only gives
     });
   }
 
-  const namedTable = assertions[0]?.passed === true;
-  const proposedFix = assertions[2]?.passed === true;
+  const namedTable = checks[0]?.passed === true;
+  const proposedFix = checks[2]?.passed === true;
   return {
     passed: namedTable && proposedFix && (judge?.passed ?? true),
-    assertions,
+    checks,
   };
 };
 

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -1,5 +1,6 @@
 import {
-  judgeTranscript,
+  judge,
+  serializeTranscript,
   type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
@@ -23,11 +24,12 @@ const scorer: ToolScorer = async (ctx) => {
     },
   ];
 
-  const judge =
+  const verdict =
     ctx.transcript.length > 0
-      ? await judgeTranscript({
-          transcript: ctx.transcript,
-          includeToolCallInputs: true,
+      ? await judge({
+          input: serializeTranscript(ctx.transcript, {
+            includeToolCallInputs: true,
+          }),
           rubric: `
 Pass if the agent identifies public.customer_payment_methods as exposed to anon/public access without proper RLS protection and proposes a concrete Supabase-compatible fix such as revoking anon access, enabling RLS, or adding a restrictive policy.
 
@@ -36,19 +38,19 @@ Fail if it names the wrong table, misses the anon/public exposure, or only gives
         })
       : undefined;
 
-  if (judge) {
+  if (verdict) {
     checks.push({
       type: "llm",
       name: "verified the exposed table and fix",
-      passed: judge.passed,
-      notes: judge.notes,
+      passed: verdict.passed,
+      notes: verdict.notes,
     });
   }
 
   const namedTable = checks[0]?.passed === true;
   const proposedFix = checks[2]?.passed === true;
   return {
-    passed: namedTable && proposedFix && (judge?.passed ?? true),
+    passed: namedTable && proposedFix && (verdict?.passed ?? true),
     checks,
   };
 };

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -1,4 +1,8 @@
-import { judgeTranscript, type ToolScorer } from "@supabase-evals/core";
+import {
+  judgeTranscript,
+  type AssertionResult,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 // Planted issue: `customer_payment_methods` is GRANTed to anon and has no RLS.
 // The agent must name this specific table in its final report.
@@ -31,23 +35,26 @@ Fail if it names the wrong table, misses the anon/public exposure, or only gives
         })
       : undefined;
 
+  const assertions: AssertionResult[] = checks.map((check) => ({
+    type: "deterministic",
+    name: check.name,
+    passed: check.ok,
+  }));
+
   if (judge) {
-    checks.push({
-      name: "llm judge verified the exposed table and fix",
-      ok: judge.passed,
+    assertions.push({
+      type: "llm",
+      name: "verified the exposed table and fix",
+      passed: judge.passed,
+      notes: judge.notes,
     });
   }
 
   const namedTable = checks[0].ok;
   const proposedFix = checks[2].ok;
-  const score = checks.filter((c) => c.ok).length / checks.length;
   return {
     passed: namedTable && proposedFix && (judge?.passed ?? true),
-    score,
-    notes: [
-      ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-      ...(judge ? [`Judge: ${judge.notes}`] : []),
-    ].join("\n"),
+    assertions,
   };
 };
 

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -13,10 +13,9 @@ const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
 
   const checks: CheckResult[] = [
-    { type: "deterministic", name: "named the vulnerable table", passed: /customer_payment_methods/i.test(report) },
-    { type: "deterministic", name: "mentioned the anon role", passed: /\banon\b/i.test(report) },
+    { name: "named the vulnerable table", passed: /customer_payment_methods/i.test(report) },
+    { name: "mentioned the anon role", passed: /\banon\b/i.test(report) },
     {
-      type: "deterministic",
       name: "proposed a concrete fix",
       passed:
         /enable\s+row\s+level\s+security/i.test(report) ||
@@ -37,10 +36,9 @@ const scorer: ToolScorer = async (ctx) => {
   });
 
   checks.push({
-    type: "llm",
     name: "verified the exposed table and fix",
     passed: verdict.passed,
-    notes: verdict.notes,
+    judgeNotes: verdict.notes,
   });
 
   const namedTable = checks[0].passed;

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -25,33 +25,28 @@ const scorer: ToolScorer = async (ctx) => {
     },
   ];
 
-  const verdict =
-    ctx.transcript.length > 0
-      ? await judge({
-          input: serializeTranscript(ctx.transcript, {
-            includeToolCallInputs: true,
-          }),
-          rubric: stripIndent`
-            Pass if the agent identifies public.customer_payment_methods as exposed to anon/public access without proper RLS protection and proposes a concrete Supabase-compatible fix such as revoking anon access, enabling RLS, or adding a restrictive policy.
+  const verdict = await judge({
+    input: serializeTranscript(ctx.transcript, {
+      includeToolCallInputs: true,
+    }),
+    rubric: stripIndent`
+      Pass if the agent identifies public.customer_payment_methods as exposed to anon/public access without proper RLS protection and proposes a concrete Supabase-compatible fix such as revoking anon access, enabling RLS, or adding a restrictive policy.
 
-            Fail if it names the wrong table, misses the anon/public exposure, or only gives vague advice.
-          `,
-        })
-      : undefined;
+      Fail if it names the wrong table, misses the anon/public exposure, or only gives vague advice.
+    `,
+  });
 
-  if (verdict) {
-    checks.push({
-      type: "llm",
-      name: "verified the exposed table and fix",
-      passed: verdict.passed,
-      notes: verdict.notes,
-    });
-  }
+  checks.push({
+    type: "llm",
+    name: "verified the exposed table and fix",
+    passed: verdict.passed,
+    notes: verdict.notes,
+  });
 
-  const namedTable = checks[0]?.passed === true;
-  const proposedFix = checks[2]?.passed === true;
+  const namedTable = checks[0].passed;
+  const proposedFix = checks[2].passed;
   return {
-    passed: namedTable && proposedFix && (verdict?.passed ?? true),
+    passed: namedTable && proposedFix && verdict.passed,
     checks,
   };
 };

--- a/evals/detect-security-001-public-table/EVAL.ts
+++ b/evals/detect-security-001-public-table/EVAL.ts
@@ -10,12 +10,13 @@ import {
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
 
-  const checks = [
-    { name: "named the vulnerable table", ok: /customer_payment_methods/i.test(report) },
-    { name: "mentioned the anon role",    ok: /\banon\b/i.test(report) },
+  const assertions: AssertionResult[] = [
+    { type: "deterministic", name: "named the vulnerable table", passed: /customer_payment_methods/i.test(report) },
+    { type: "deterministic", name: "mentioned the anon role", passed: /\banon\b/i.test(report) },
     {
+      type: "deterministic",
       name: "proposed a concrete fix",
-      ok:
+      passed:
         /enable\s+row\s+level\s+security/i.test(report) ||
         /CREATE\s+POLICY/i.test(report) ||
         /REVOKE\s+.*\s+FROM\s+anon/i.test(report),
@@ -35,12 +36,6 @@ Fail if it names the wrong table, misses the anon/public exposure, or only gives
         })
       : undefined;
 
-  const assertions: AssertionResult[] = checks.map((check) => ({
-    type: "deterministic",
-    name: check.name,
-    passed: check.ok,
-  }));
-
   if (judge) {
     assertions.push({
       type: "llm",
@@ -50,8 +45,8 @@ Fail if it names the wrong table, misses the anon/public exposure, or only gives
     });
   }
 
-  const namedTable = checks[0].ok;
-  const proposedFix = checks[2].ok;
+  const namedTable = assertions[0]?.passed === true;
+  const proposedFix = assertions[2]?.passed === true;
   return {
     passed: namedTable && proposedFix && (judge?.passed ?? true),
     assertions,

--- a/evals/observe-db-001-table-row-counts/EVAL.ts
+++ b/evals/observe-db-001-table-row-counts/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
@@ -8,11 +11,10 @@ const scorer: ToolScorer = async (ctx) => {
     { name: "reported events count", ok: /events[\s\S]{0,80}\b453\b/i.test(report) },
   ];
 
-  const score = checks.filter((c) => c.ok).length / checks.length;
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks.every((c) => c.ok),
-    score,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/observe-db-001-table-row-counts/EVAL.ts
+++ b/evals/observe-db-001-table-row-counts/EVAL.ts
@@ -1,20 +1,20 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
-  const assertions: AssertionResult[] = [
+  const checks: CheckResult[] = [
     { type: "deterministic", name: "reported users count", passed: /users[\s\S]{0,80}\b12\b/i.test(report) },
     { type: "deterministic", name: "reported orders count", passed: /orders[\s\S]{0,80}\b87\b/i.test(report) },
     { type: "deterministic", name: "reported events count", passed: /events[\s\S]{0,80}\b453\b/i.test(report) },
   ];
 
     return {
-    passed: assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/evals/observe-db-001-table-row-counts/EVAL.ts
+++ b/evals/observe-db-001-table-row-counts/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
@@ -12,7 +8,7 @@ const scorer: ToolScorer = async (ctx) => {
     { type: "deterministic", name: "reported events count", passed: /events[\s\S]{0,80}\b453\b/i.test(report) },
   ];
 
-    return {
+  return {
     passed: checks.every((check) => check.passed),
     checks,
   };

--- a/evals/observe-db-001-table-row-counts/EVAL.ts
+++ b/evals/observe-db-001-table-row-counts/EVAL.ts
@@ -1,19 +1,19 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
-  const checks = [
-    { name: "reported users count", ok: /users[\s\S]{0,80}\b12\b/i.test(report) },
-    { name: "reported orders count", ok: /orders[\s\S]{0,80}\b87\b/i.test(report) },
-    { name: "reported events count", ok: /events[\s\S]{0,80}\b453\b/i.test(report) },
+  const assertions: AssertionResult[] = [
+    { type: "deterministic", name: "reported users count", passed: /users[\s\S]{0,80}\b12\b/i.test(report) },
+    { type: "deterministic", name: "reported orders count", passed: /orders[\s\S]{0,80}\b87\b/i.test(report) },
+    { type: "deterministic", name: "reported events count", passed: /events[\s\S]{0,80}\b453\b/i.test(report) },
   ];
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
-    passed: checks.every((c) => c.ok),
+    return {
+    passed: assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/observe-db-001-table-row-counts/EVAL.ts
+++ b/evals/observe-db-001-table-row-counts/EVAL.ts
@@ -3,9 +3,9 @@ import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
   const checks: CheckResult[] = [
-    { type: "deterministic", name: "reported users count", passed: /users[\s\S]{0,80}\b12\b/i.test(report) },
-    { type: "deterministic", name: "reported orders count", passed: /orders[\s\S]{0,80}\b87\b/i.test(report) },
-    { type: "deterministic", name: "reported events count", passed: /events[\s\S]{0,80}\b453\b/i.test(report) },
+    { name: "reported users count", passed: /users[\s\S]{0,80}\b12\b/i.test(report) },
+    { name: "reported orders count", passed: /orders[\s\S]{0,80}\b87\b/i.test(report) },
+    { name: "reported events count", passed: /events[\s\S]{0,80}\b453\b/i.test(report) },
   ];
 
   return {

--- a/evals/observe-logs-001-top-error-function/EVAL.ts
+++ b/evals/observe-logs-001-top-error-function/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
@@ -14,11 +17,10 @@ const scorer: ToolScorer = async (ctx) => {
     },
   ];
 
-  const score = checks.filter((c) => c.ok).length / checks.length;
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks.every((c) => c.ok),
-    score,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/observe-logs-001-top-error-function/EVAL.ts
+++ b/evals/observe-logs-001-top-error-function/EVAL.ts
@@ -3,14 +3,12 @@ import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
   const checks: CheckResult[] = [
-    { type: "deterministic", name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
+    { name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
     {
-      type: "deterministic",
       name: "reported 9 errors",
       passed: /\b9\b/.test(report),
     },
     {
-      type: "deterministic",
       name: "reported 50 total events",
       passed: /\b50\b/.test(report) || /\b9\s*\/\s*50\b/.test(report),
     },

--- a/evals/observe-logs-001-top-error-function/EVAL.ts
+++ b/evals/observe-logs-001-top-error-function/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";

--- a/evals/observe-logs-001-top-error-function/EVAL.ts
+++ b/evals/observe-logs-001-top-error-function/EVAL.ts
@@ -1,25 +1,27 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
-  const checks = [
-    { name: "named stripe-webhook", ok: /stripe-webhook/i.test(report) },
+  const assertions: AssertionResult[] = [
+    { type: "deterministic", name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
     {
+      type: "deterministic",
       name: "reported 9 errors",
-      ok: /\b9\b/.test(report),
+      passed: /\b9\b/.test(report),
     },
     {
+      type: "deterministic",
       name: "reported 50 total events",
-      ok: /\b50\b/.test(report) || /\b9\s*\/\s*50\b/.test(report),
+      passed: /\b50\b/.test(report) || /\b9\s*\/\s*50\b/.test(report),
     },
   ];
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
-    passed: checks.every((c) => c.ok),
+    passed: assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/observe-logs-001-top-error-function/EVAL.ts
+++ b/evals/observe-logs-001-top-error-function/EVAL.ts
@@ -1,12 +1,12 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
 const scorer: ToolScorer = async (ctx) => {
   const report = ctx.agentReport ?? "";
-  const assertions: AssertionResult[] = [
+  const checks: CheckResult[] = [
     { type: "deterministic", name: "named stripe-webhook", passed: /stripe-webhook/i.test(report) },
     {
       type: "deterministic",
@@ -21,8 +21,8 @@ const scorer: ToolScorer = async (ctx) => {
   ];
 
   return {
-    passed: assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/evals/resolve-performance-001-slow-query-index/EVAL.ts
+++ b/evals/resolve-performance-001-slow-query-index/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const TARGET_USER = "00000000-0000-0000-0000-000000000001";
 
@@ -48,20 +51,23 @@ RETURNING id;
     checks.push({ name: "inserts still work", ok: inserted.length === 1 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: "scorer evaluated performance fix",
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 4,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not evaluate performance fix: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks.every((c) => c.ok),
-    score: checks.filter((c) => c.ok).length / checks.length,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/resolve-performance-001-slow-query-index/EVAL.ts
+++ b/evals/resolve-performance-001-slow-query-index/EVAL.ts
@@ -55,7 +55,7 @@ RETURNING id;
     checks.push(check("inserts still work", inserted.length === 1));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: "scorer evaluated performance fix",
       passed: false,
@@ -67,7 +67,7 @@ RETURNING id;
     };
   }
 
-    return {
+  return {
     passed: checks.every((check) => check.passed),
     checks,
   };

--- a/evals/resolve-performance-001-slow-query-index/EVAL.ts
+++ b/evals/resolve-performance-001-slow-query-index/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -9,7 +9,7 @@ const TARGET_USER = "00000000-0000-0000-0000-000000000001";
 const scorer: ToolScorer = async (ctx) => {
   const q = (sql: string) =>
     ctx.query(sql);
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
 
   try {
     const { rows: indexes } = await q(`
@@ -22,7 +22,7 @@ WHERE schemaname = 'public'
       const def = row.indexdef;
       return typeof def === "string" && /ON\s+(?:public\.)?events\s+.*\(\s*user_id\s*,\s*created_at/i.test(def);
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "created index covering user_id and created_at",
       passed: hasCoveringIndex,
@@ -36,12 +36,12 @@ ORDER BY created_at DESC
 LIMIT 50;
     `);
     const plan = planRows.map((row) => Object.values(row).join(" ")).join("\n");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "query plan uses an index",
       passed: /(Index Scan|Index Only Scan|Bitmap Index Scan)/i.test(plan),
     });
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "query plan avoids sequential scan on events",
       passed: !/Seq Scan on events/i.test(plan),
@@ -52,10 +52,10 @@ INSERT INTO events (user_id, kind, payload)
 VALUES ('${TARGET_USER}', 'insert_probe', '{"ok": true}'::jsonb)
 RETURNING id;
     `);
-    assertions.push(assertion("inserts still work", inserted.length === 1));
+    checks.push(check("inserts still work", inserted.length === 1));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: "scorer evaluated performance fix",
       passed: false,
@@ -63,13 +63,13 @@ RETURNING id;
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
     return {
-    passed: assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/evals/resolve-performance-001-slow-query-index/EVAL.ts
+++ b/evals/resolve-performance-001-slow-query-index/EVAL.ts
@@ -19,7 +19,6 @@ WHERE schemaname = 'public'
       return typeof def === "string" && /ON\s+(?:public\.)?events\s+.*\(\s*user_id\s*,\s*created_at/i.test(def);
     });
     checks.push({
-      type: "deterministic",
       name: "created index covering user_id and created_at",
       passed: hasCoveringIndex,
     });
@@ -33,12 +32,10 @@ LIMIT 50;
     `);
     const plan = planRows.map((row) => Object.values(row).join(" ")).join("\n");
     checks.push({
-      type: "deterministic",
       name: "query plan uses an index",
       passed: /(Index Scan|Index Only Scan|Bitmap Index Scan)/i.test(plan),
     });
     checks.push({
-      type: "deterministic",
       name: "query plan avoids sequential scan on events",
       passed: !/Seq Scan on events/i.test(plan),
     });
@@ -48,11 +45,10 @@ INSERT INTO events (user_id, kind, payload)
 VALUES ('${TARGET_USER}', 'insert_probe', '{"ok": true}'::jsonb)
 RETURNING id;
     `);
-    checks.push({ type: "deterministic", name: "inserts still work", passed: inserted.length === 1 });
+    checks.push({ name: "inserts still work", passed: inserted.length === 1 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: "scorer evaluated performance fix",
       passed: false,
       notes: msg,

--- a/evals/resolve-performance-001-slow-query-index/EVAL.ts
+++ b/evals/resolve-performance-001-slow-query-index/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -8,7 +9,7 @@ const TARGET_USER = "00000000-0000-0000-0000-000000000001";
 const scorer: ToolScorer = async (ctx) => {
   const q = (sql: string) =>
     ctx.query(sql);
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
 
   try {
     const { rows: indexes } = await q(`
@@ -21,9 +22,10 @@ WHERE schemaname = 'public'
       const def = row.indexdef;
       return typeof def === "string" && /ON\s+(?:public\.)?events\s+.*\(\s*user_id\s*,\s*created_at/i.test(def);
     });
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "created index covering user_id and created_at",
-      ok: hasCoveringIndex,
+      passed: hasCoveringIndex,
     });
 
     const { rows: planRows } = await q(`
@@ -34,13 +36,15 @@ ORDER BY created_at DESC
 LIMIT 50;
     `);
     const plan = planRows.map((row) => Object.values(row).join(" ")).join("\n");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "query plan uses an index",
-      ok: /(Index Scan|Index Only Scan|Bitmap Index Scan)/i.test(plan),
+      passed: /(Index Scan|Index Only Scan|Bitmap Index Scan)/i.test(plan),
     });
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "query plan avoids sequential scan on events",
-      ok: !/Seq Scan on events/i.test(plan),
+      passed: !/Seq Scan on events/i.test(plan),
     });
 
     const { rows: inserted } = await q(`
@@ -48,11 +52,10 @@ INSERT INTO events (user_id, kind, payload)
 VALUES ('${TARGET_USER}', 'insert_probe', '{"ok": true}'::jsonb)
 RETURNING id;
     `);
-    checks.push({ name: "inserts still work", ok: inserted.length === 1 });
+    assertions.push(assertion("inserts still work", inserted.length === 1));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: "scorer evaluated performance fix",
       passed: false,
@@ -64,9 +67,8 @@ RETURNING id;
     };
   }
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
-    passed: checks.every((c) => c.ok),
+    return {
+    passed: assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/resolve-performance-001-slow-query-index/EVAL.ts
+++ b/evals/resolve-performance-001-slow-query-index/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const TARGET_USER = "00000000-0000-0000-0000-000000000001";
 
@@ -52,7 +48,7 @@ INSERT INTO events (user_id, kind, payload)
 VALUES ('${TARGET_USER}', 'insert_probe', '{"ok": true}'::jsonb)
 RETURNING id;
     `);
-    checks.push(check("inserts still work", inserted.length === 1));
+    checks.push({ type: "deterministic", name: "inserts still work", passed: inserted.length === 1 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -30,7 +30,6 @@ const scorer: ToolScorer = async (ctx) => {
         passed: false,
         checks: [
           {
-            type: "deterministic",
             name: "created auth sessions",
             passed: false,
             notes: authAError?.message ?? authBError?.message ?? "missing session",
@@ -51,14 +50,13 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'notes';`
     );
-    checks.push({ type: "deterministic", name: "RLS still enabled on notes", passed: rls[0]?.relrowsecurity === true });
+    checks.push({ name: "RLS still enabled on notes", passed: rls[0]?.relrowsecurity === true });
 
     const { data: aNotes, error: aNotesError } = await clientA
       .from("notes")
       .select("body,user_id")
       .order("body");
     checks.push({
-      type: "deterministic",
       name: "user A reads only own note",
       passed:
         !aNotesError &&
@@ -72,7 +70,6 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
       .select("id")
       .eq("body", "a private note");
     checks.push({
-      type: "deterministic",
       name: "user B cannot read user A note",
       passed: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
     });
@@ -83,7 +80,6 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
       .eq("body", "a private note")
       .select("body,user_id");
     checks.push({
-      type: "deterministic",
       name: "user A can still update own note",
       passed:
         !ownUpdateError &&
@@ -106,7 +102,6 @@ WHERE body IN ('b private note', 'stolen by reassignment')
 ORDER BY body;
     `);
     checks.push({
-      type: "deterministic",
       name: "WITH CHECK prevents user_id reassignment",
       passed:
         reassignedRows.length === 1 &&
@@ -116,7 +111,6 @@ ORDER BY body;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     checks.push({
-      type: "deterministic",
       name: "scorer evaluated RLS fix",
       passed: false,
       notes: msg,

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -119,7 +119,7 @@ ORDER BY body;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        checks.push({
+    checks.push({
       type: "deterministic",
       name: "scorer evaluated RLS fix",
       passed: false,
@@ -131,7 +131,7 @@ ORDER BY body;
     };
   }
 
-    return {
+  return {
     passed: checks.every((check) => check.passed),
     checks,
   };

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -1,8 +1,4 @@
-import {
-  check,
-  type CheckResult,
-  type ToolScorer,
-} from "@supabase-evals/core";
+import type { CheckResult, ToolScorer } from "@supabase-evals/core";
 
 const PASSWORD = "secret123";
 
@@ -55,7 +51,7 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'notes';`
     );
-    checks.push(check("RLS still enabled on notes", rls[0]?.relrowsecurity === true));
+    checks.push({ type: "deterministic", name: "RLS still enabled on notes", passed: rls[0]?.relrowsecurity === true });
 
     const { data: aNotes, error: aNotesError } = await clientA
       .from("notes")

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -1,5 +1,6 @@
 import {
   assertion,
+  type AssertionResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -8,7 +9,7 @@ const PASSWORD = "secret123";
 const scorer: ToolScorer = async (ctx) => {
   const clientA = ctx.client;
   const clientB = ctx.getClient();
-  const checks: Array<{ name: string; ok: boolean }> = [];
+  const assertions: AssertionResult[] = [];
   const q = ctx.query;
 
   try {
@@ -54,15 +55,16 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'notes';`
     );
-    checks.push({ name: "RLS still enabled on notes", ok: rls[0]?.relrowsecurity === true });
+    assertions.push(assertion("RLS still enabled on notes", rls[0]?.relrowsecurity === true));
 
     const { data: aNotes, error: aNotesError } = await clientA
       .from("notes")
       .select("body,user_id")
       .order("body");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user A reads only own note",
-      ok:
+      passed:
         !aNotesError &&
         aNotes?.length === 1 &&
         aNotes[0]?.body === "a private note" &&
@@ -73,9 +75,10 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
       .from("notes")
       .select("id")
       .eq("body", "a private note");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user B cannot read user A note",
-      ok: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
+      passed: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
     });
 
     const { data: ownUpdate, error: ownUpdateError } = await clientA
@@ -83,9 +86,10 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
       .update({ body: "a updated note" })
       .eq("body", "a private note")
       .select("body,user_id");
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "user A can still update own note",
-      ok:
+      passed:
         !ownUpdateError &&
         ownUpdate?.length === 1 &&
         ownUpdate[0]?.body === "a updated note" &&
@@ -105,17 +109,17 @@ FROM notes
 WHERE body IN ('b private note', 'stolen by reassignment')
 ORDER BY body;
     `);
-    checks.push({
+    assertions.push({
+      type: "deterministic",
       name: "WITH CHECK prevents user_id reassignment",
-      ok:
+      passed:
         reassignedRows.length === 1 &&
         reassignedRows[0]?.body === "b private note" &&
         reassignedRows[0]?.user_id === userBId,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    const assertions = checks.map((c) => assertion(c.name, c.ok));
-    assertions.push({
+        assertions.push({
       type: "deterministic",
       name: "scorer evaluated RLS fix",
       passed: false,
@@ -127,9 +131,8 @@ ORDER BY body;
     };
   }
 
-  const assertions = checks.map((c) => assertion(c.name, c.ok));
-  return {
-    passed: checks.every((c) => c.ok),
+    return {
+    passed: assertions.every((assertion) => assertion.passed),
     assertions,
   };
 };

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -1,4 +1,7 @@
-import type { ToolScorer } from "@supabase-evals/core";
+import {
+  assertion,
+  type ToolScorer,
+} from "@supabase-evals/core";
 
 const PASSWORD = "secret123";
 
@@ -28,10 +31,14 @@ const scorer: ToolScorer = async (ctx) => {
     ) {
       return {
         passed: false,
-        score: 0,
-        notes: `could not create auth sessions: ${
-          authAError?.message ?? authBError?.message ?? "missing session"
-        }`,
+        assertions: [
+          {
+            type: "deterministic",
+            name: "created auth sessions",
+            passed: false,
+            notes: authAError?.message ?? authBError?.message ?? "missing session",
+          },
+        ],
       };
     }
 
@@ -107,20 +114,23 @@ ORDER BY body;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
+    const assertions = checks.map((c) => assertion(c.name, c.ok));
+    assertions.push({
+      type: "deterministic",
+      name: "scorer evaluated RLS fix",
+      passed: false,
+      notes: msg,
+    });
     return {
       passed: false,
-      score: checks.filter((c) => c.ok).length / 5,
-      notes: [
-        ...checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`),
-        `FAIL scorer could not evaluate RLS fix: ${msg}`,
-      ].join("\n"),
+      assertions,
     };
   }
 
+  const assertions = checks.map((c) => assertion(c.name, c.ok));
   return {
     passed: checks.every((c) => c.ok),
-    score: checks.filter((c) => c.ok).length / checks.length,
-    notes: checks.map((c) => `${c.ok ? "PASS" : "FAIL"} ${c.name}`).join("\n"),
+    assertions,
   };
 };
 

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -1,6 +1,6 @@
 import {
-  assertion,
-  type AssertionResult,
+  check,
+  type CheckResult,
   type ToolScorer,
 } from "@supabase-evals/core";
 
@@ -9,7 +9,7 @@ const PASSWORD = "secret123";
 const scorer: ToolScorer = async (ctx) => {
   const clientA = ctx.client;
   const clientB = ctx.getClient();
-  const assertions: AssertionResult[] = [];
+  const checks: CheckResult[] = [];
   const q = ctx.query;
 
   try {
@@ -32,7 +32,7 @@ const scorer: ToolScorer = async (ctx) => {
     ) {
       return {
         passed: false,
-        assertions: [
+        checks: [
           {
             type: "deterministic",
             name: "created auth sessions",
@@ -55,13 +55,13 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
     const { rows: rls } = await q(
       `SELECT relrowsecurity FROM pg_class WHERE relname = 'notes';`
     );
-    assertions.push(assertion("RLS still enabled on notes", rls[0]?.relrowsecurity === true));
+    checks.push(check("RLS still enabled on notes", rls[0]?.relrowsecurity === true));
 
     const { data: aNotes, error: aNotesError } = await clientA
       .from("notes")
       .select("body,user_id")
       .order("body");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user A reads only own note",
       passed:
@@ -75,7 +75,7 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
       .from("notes")
       .select("id")
       .eq("body", "a private note");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user B cannot read user A note",
       passed: !bReadsAError && Array.isArray(bReadsA) && bReadsA.length === 0,
@@ -86,7 +86,7 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
       .update({ body: "a updated note" })
       .eq("body", "a private note")
       .select("body,user_id");
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "user A can still update own note",
       passed:
@@ -109,7 +109,7 @@ FROM notes
 WHERE body IN ('b private note', 'stolen by reassignment')
 ORDER BY body;
     `);
-    assertions.push({
+    checks.push({
       type: "deterministic",
       name: "WITH CHECK prevents user_id reassignment",
       passed:
@@ -119,7 +119,7 @@ ORDER BY body;
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-        assertions.push({
+        checks.push({
       type: "deterministic",
       name: "scorer evaluated RLS fix",
       passed: false,
@@ -127,13 +127,13 @@ ORDER BY body;
     });
     return {
       passed: false,
-      assertions,
+      checks,
     };
   }
 
     return {
-    passed: assertions.every((assertion) => assertion.passed),
-    assertions,
+    passed: checks.every((check) => check.passed),
+    checks,
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
         "apps/*",
         "packages/*"
       ],
+      "dependencies": {
+        "common-tags": "^1.8.2"
+      },
       "devDependencies": {
+        "@types/common-tags": "^1.8.4",
         "typescript": "^5.6.0"
       }
     },
@@ -4512,6 +4516,13 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/common-tags": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.4.tgz",
+      "integrity": "sha512-S+1hLDJPjWNDhcGxsxEbepzaxWqURP/o+3cP4aa2w7yBXgdcmKGQtZzP8JbyfOd0m+33nh+8+kvxYE2UJtBDkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5607,7 +5618,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
       "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.64",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.64.tgz",
-      "integrity": "sha512-epO4iS6QwktaY2PF6uBcPnDTJ3BxPOfsGS7/OEtBe3GtNj7C8h8gMDVtIe5K8W16HNDbn0tbR4dcQfpfs+XVFg==",
+      "version": "3.0.66",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.66.tgz",
+      "integrity": "sha512-n9mZ7PbU7O2zN8UMcx495Gfx7sE/rL4KS+o5JzBOUbYJCuwEIxKO6yJaUkxa4r6IyiLxyGib0jegZw91Hh0diA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -11733,11 +11733,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.39",
+        "@ai-sdk/openai": "^3.0.66",
         "@supabase-evals/platform-lite": "*",
         "@supabase/supabase-js": "^2.105.1",
         "ai": "^6.0.174",
         "executor": "1.4.29",
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "zod": "^4.4.3"
       }
     },
     "packages/platform-lite": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "demo:mcp": "npm run -w @supabase-evals/framework demo:mcp",
     "demo:executor": "npm run -w @supabase-evals/framework demo:executor"
   },
+  "dependencies": {
+    "common-tags": "^1.8.2"
+  },
   "devDependencies": {
+    "@types/common-tags": "^1.8.4",
     "typescript": "^5.6.0"
   },
   "packageManager": "npm@10.8.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.39",
-    "@supabase/supabase-js": "^2.105.1",
+    "@ai-sdk/openai": "^3.0.66",
     "@supabase-evals/platform-lite": "*",
+    "@supabase/supabase-js": "^2.105.1",
     "ai": "^6.0.174",
     "executor": "1.4.29",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,6 @@ export type TranscriptPart =
       type: "message";
       role: "system" | "user" | "assistant";
       content: string;
-      ts: number;
     }
   | {
       type: "tool_call";
@@ -104,7 +103,6 @@ export type TranscriptPart =
       input: Record<string, unknown>;
       output?: unknown;
       error?: string;
-      ts: number;
     };
 
 export type TranscriptSerializationOptions = {
@@ -315,18 +313,8 @@ export function aiSdkAgent(options: {
         : [];
       const toolCalls: ToolCallRecord[] = [];
       const transcript: TranscriptPart[] = [
-        {
-          type: "message",
-          role: "system",
-          content: args.systemPrompt,
-          ts: Date.now(),
-        },
-        {
-          type: "message",
-          role: "user",
-          content: args.userPrompt,
-          ts: Date.now(),
-        },
+        { type: "message", role: "system", content: args.systemPrompt },
+        { type: "message", role: "user", content: args.userPrompt },
       ];
       const tools =
         args.tools ?? mergeToolSets(mcpHandles.map((handle) => handle.tools));
@@ -345,33 +333,61 @@ export function aiSdkAgent(options: {
             options.providerOptions,
           ),
           experimental_onToolCallFinish: (event) => {
-            const input = isRecord(event.toolCall.input)
-              ? event.toolCall.input
-              : {};
-            const toolCall = {
+            toolCalls.push({
               endpoint: event.toolCall.toolName,
-              body: input,
+              body: isRecord(event.toolCall.input) ? event.toolCall.input : {},
               result: event.output,
               ts: Date.now(),
-            };
-            toolCalls.push(toolCall);
-            transcript.push({
-              type: "tool_call",
-              name: toolCall.endpoint,
-              input: toolCall.body,
-              output: toolCall.result,
-              ts: toolCall.ts,
             });
           },
         });
 
+        // Build the transcript from every step's content so the judge sees
+        // all user-facing assistant text, not just the final step's text.
+        const toolOutputs = new Map<
+          string,
+          { output?: unknown; error?: string }
+        >();
+        for (const step of result.steps) {
+          for (const part of step.content) {
+            if (part.type === "tool-result") {
+              toolOutputs.set(part.toolCallId, { output: part.output });
+            } else if (part.type === "tool-error") {
+              toolOutputs.set(part.toolCallId, {
+                error:
+                  part.error instanceof Error
+                    ? part.error.message
+                    : String(part.error),
+              });
+            }
+          }
+        }
+
+        for (const step of result.steps) {
+          for (const part of step.content) {
+            if (part.type === "text") {
+              const content = part.text.trim();
+              if (content) {
+                transcript.push({
+                  type: "message",
+                  role: "assistant",
+                  content,
+                });
+              }
+            } else if (part.type === "tool-call") {
+              const resolved = toolOutputs.get(part.toolCallId);
+              transcript.push({
+                type: "tool_call",
+                name: part.toolName,
+                input: isRecord(part.input) ? part.input : {},
+                output: resolved?.output,
+                error: resolved?.error,
+              });
+            }
+          }
+        }
+
         const agentReport = result.text.trim();
-        transcript.push({
-          type: "message",
-          role: "assistant",
-          content: agentReport,
-          ts: Date.now(),
-        });
 
         return {
           agentReport,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,10 +110,10 @@ export type TranscriptSerializationOptions = {
   includeToolCallOutputs?: boolean;
 };
 
-export interface JudgeInput extends TranscriptSerializationOptions {
+export interface JudgeInput {
   model?: Exclude<LanguageModel, string>;
   providerOptions?: AiSdkProviderOptions;
-  transcript: TranscriptPart[];
+  input: string;
   rubric: string;
 }
 
@@ -271,20 +271,16 @@ const DEFAULT_JUDGE_PROVIDER_OPTIONS: AiSdkProviderOptions = {
   },
 };
 
-export async function judgeTranscript(input: JudgeInput): Promise<JudgeResult> {
-  const model = input.model ?? DEFAULT_JUDGE_MODEL;
+export async function judge(args: JudgeInput): Promise<JudgeResult> {
+  const model = args.model ?? DEFAULT_JUDGE_MODEL;
   const providerOptions =
-    input.providerOptions ?? DEFAULT_JUDGE_PROVIDER_OPTIONS;
+    args.providerOptions ?? DEFAULT_JUDGE_PROVIDER_OPTIONS;
   assertProviderReady(model.provider);
-  const transcript = serializeTranscript(input.transcript, {
-    includeToolCallInputs: input.includeToolCallInputs,
-    includeToolCallOutputs: input.includeToolCallOutputs,
-  });
   const { output } = await generateText({
     model,
     system:
       "You are a strict eval judge. Return only the requested structured judgment.",
-    prompt: ["Rubric:", input.rubric, "", "Transcript:", transcript].join("\n"),
+    prompt: ["Rubric:", args.rubric, "", "Input:", args.input].join("\n"),
     output: Output.object({ schema: judgeOutputSchema }),
     maxOutputTokens: MAX_OUTPUT_TOKENS,
     providerOptions: withProviderDefaults(model.provider, providerOptions),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,10 +72,10 @@ export interface ScoreResult {
 }
 
 export type CheckResult = {
-  type: "deterministic" | "llm";
   name: string;
   passed: boolean;
   notes?: string;
+  judgeNotes?: string;
 };
 
 export type TranscriptPart =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,19 +78,6 @@ export type CheckResult = {
   notes?: string;
 };
 
-export function check(
-  name: string,
-  passed: boolean,
-  notes?: string,
-): CheckResult {
-  return {
-    type: "deterministic",
-    name,
-    passed,
-    notes,
-  };
-}
-
 export type TranscriptPart =
   | {
       type: "message";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,9 @@ import { fileURLToPath } from "node:url";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport as StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { openai } from "@ai-sdk/openai";
 import {
+  Output,
   generateText,
   stepCountIs,
   type JSONValue,
@@ -18,6 +20,7 @@ import {
   type ToolSet,
 } from "ai";
 import ts from "typescript";
+import { z } from "zod";
 import {
   createManagementApiClient,
   createPlatform,
@@ -69,6 +72,36 @@ export interface ScoreResult {
   score: number;
   notes?: string;
 }
+
+export type TranscriptPart =
+  | {
+      type: "message";
+      role: "system" | "user" | "assistant";
+      content: string;
+      ts: number;
+    }
+  | {
+      type: "tool_call";
+      name: string;
+      input: Record<string, unknown>;
+      output?: unknown;
+      error?: string;
+      ts: number;
+    };
+
+export type TranscriptSerializationOptions = {
+  includeToolCallInputs?: boolean;
+  includeToolCallOutputs?: boolean;
+};
+
+export interface JudgeInput extends TranscriptSerializationOptions {
+  model?: Exclude<LanguageModel, string>;
+  providerOptions?: AiSdkProviderOptions;
+  transcript: TranscriptPart[];
+  rubric: string;
+}
+
+export type JudgeResult = ScoreResult;
 
 export interface ToolCallRecord {
   endpoint: string;
@@ -129,6 +162,7 @@ export interface ToolScoringContext {
 
 export interface ToolEvalContext extends ToolScoringContext {
   toolCalls: ToolCallRecord[];
+  transcript: TranscriptPart[];
   agentReport?: string;
 }
 
@@ -136,6 +170,7 @@ export interface ProjectEvalContext {
   workspace: string;
   projectResult: ProjectResult;
   toolCalls: ToolCallRecord[];
+  transcript: TranscriptPart[];
   agentReport?: string;
 }
 
@@ -153,6 +188,7 @@ export type AgentRunArgs = {
 export type AgentRunResult = {
   agentReport: string;
   toolCalls: ToolCallRecord[];
+  transcript: TranscriptPart[];
   steps: number;
   stoppedReason: string;
 };
@@ -174,7 +210,73 @@ export function defineExperiment(config: ExperimentConfig): ExperimentConfig {
   return config;
 }
 
+export function serializeTranscript(
+  transcript: TranscriptPart[],
+  options: TranscriptSerializationOptions = {},
+): string {
+  const parts = transcript.flatMap((event) => {
+    if (event.type === "message") {
+      const content = event.content.trim();
+      return content ? [`[${event.role}]\n${content}`] : [];
+    }
+
+    const lines = [`[called ${event.name}]`];
+    if (options.includeToolCallInputs) {
+      lines.push(`input:\n${JSON.stringify(event.input, null, 2)}`);
+    }
+    if (options.includeToolCallOutputs) {
+      if (event.error) {
+        lines.push(`error:\n${event.error}`);
+      } else if (event.output !== undefined) {
+        lines.push(`output:\n${JSON.stringify(event.output, null, 2)}`);
+      }
+    }
+    return [lines.join("\n")];
+  });
+
+  return parts.join("\n\n");
+}
+
 export type AiSdkProviderOptions = Record<string, Record<string, JSONValue>>;
+
+const judgeOutputSchema = z.object({
+  passed: z.boolean(),
+  notes: z.string(),
+});
+
+const DEFAULT_JUDGE_MODEL = openai("gpt-5.5");
+const DEFAULT_JUDGE_PROVIDER_OPTIONS: AiSdkProviderOptions = {
+  openai: {
+    reasoningEffort: "medium",
+    textVerbosity: "low",
+  },
+};
+
+export async function judgeTranscript(input: JudgeInput): Promise<JudgeResult> {
+  const model = input.model ?? DEFAULT_JUDGE_MODEL;
+  const providerOptions =
+    input.providerOptions ?? DEFAULT_JUDGE_PROVIDER_OPTIONS;
+  assertProviderReady(model.provider);
+  const transcript = serializeTranscript(input.transcript, {
+    includeToolCallInputs: input.includeToolCallInputs,
+    includeToolCallOutputs: input.includeToolCallOutputs,
+  });
+  const { output } = await generateText({
+    model,
+    system:
+      "You are a strict eval judge. Return only the requested structured judgment.",
+    prompt: ["Rubric:", input.rubric, "", "Transcript:", transcript].join("\n"),
+    output: Output.object({ schema: judgeOutputSchema }),
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+    providerOptions: withProviderDefaults(model.provider, providerOptions),
+  });
+
+  return {
+    passed: output.passed,
+    score: output.passed ? 1 : 0,
+    notes: output.notes,
+  };
+}
 
 export function aiSdkAgent(options: {
   model: Exclude<LanguageModel, string>;
@@ -192,6 +294,20 @@ export function aiSdkAgent(options: {
         ? await createAiSdkTools(args.mcpServers)
         : [];
       const toolCalls: ToolCallRecord[] = [];
+      const transcript: TranscriptPart[] = [
+        {
+          type: "message",
+          role: "system",
+          content: args.systemPrompt,
+          ts: Date.now(),
+        },
+        {
+          type: "message",
+          role: "user",
+          content: args.userPrompt,
+          ts: Date.now(),
+        },
+      ];
       const tools =
         args.tools ?? mergeToolSets(mcpHandles.map((handle) => handle.tools));
 
@@ -209,18 +325,38 @@ export function aiSdkAgent(options: {
             options.providerOptions,
           ),
           experimental_onToolCallFinish: (event) => {
-            toolCalls.push({
+            const input = isRecord(event.toolCall.input)
+              ? event.toolCall.input
+              : {};
+            const toolCall = {
               endpoint: event.toolCall.toolName,
-              body: isRecord(event.toolCall.input) ? event.toolCall.input : {},
+              body: input,
               result: event.output,
               ts: Date.now(),
+            };
+            toolCalls.push(toolCall);
+            transcript.push({
+              type: "tool_call",
+              name: toolCall.endpoint,
+              input: toolCall.body,
+              output: toolCall.result,
+              ts: toolCall.ts,
             });
           },
         });
 
+        const agentReport = result.text.trim();
+        transcript.push({
+          type: "message",
+          role: "assistant",
+          content: agentReport,
+          ts: Date.now(),
+        });
+
         return {
-          agentReport: result.text.trim(),
+          agentReport,
           toolCalls,
+          transcript,
           steps: result.steps.length,
           stoppedReason:
             result.steps.length >= MAX_STEPS

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -247,7 +247,7 @@ const judgeOutputSchema = z.object({
 const DEFAULT_JUDGE_MODEL = openai("gpt-5.5");
 const DEFAULT_JUDGE_PROVIDER_OPTIONS: AiSdkProviderOptions = {
   openai: {
-    reasoningEffort: "medium",
+    reasoningEffort: "low",
     textVerbosity: "low",
   },
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,8 +59,7 @@ export type EvalResult = {
   product?: EvalProduct[];
   topic?: string[];
   passed: boolean;
-  score?: number;
-  notes?: string;
+  assertions?: AssertionResult[];
   prompt?: string;
   promptSourcePath?: string;
   attempts?: number;
@@ -69,8 +68,27 @@ export type EvalResult = {
 
 export interface ScoreResult {
   passed: boolean;
-  score: number;
+  assertions?: AssertionResult[];
+}
+
+export type AssertionResult = {
+  type: "deterministic" | "llm";
+  name: string;
+  passed: boolean;
   notes?: string;
+};
+
+export function assertion(
+  name: string,
+  passed: boolean,
+  notes?: string,
+): AssertionResult {
+  return {
+    type: "deterministic",
+    name,
+    passed,
+    notes,
+  };
 }
 
 export type TranscriptPart =
@@ -101,7 +119,10 @@ export interface JudgeInput extends TranscriptSerializationOptions {
   rubric: string;
 }
 
-export type JudgeResult = ScoreResult;
+export interface JudgeResult {
+  passed: boolean;
+  notes?: string;
+}
 
 export interface ToolCallRecord {
   endpoint: string;
@@ -273,7 +294,6 @@ export async function judgeTranscript(input: JudgeInput): Promise<JudgeResult> {
 
   return {
     passed: output.passed,
-    score: output.passed ? 1 : 0,
     notes: output.notes,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,7 @@ export type EvalResult = {
   product?: EvalProduct[];
   topic?: string[];
   passed: boolean;
-  assertions?: AssertionResult[];
+  checks?: CheckResult[];
   prompt?: string;
   promptSourcePath?: string;
   attempts?: number;
@@ -68,21 +68,21 @@ export type EvalResult = {
 
 export interface ScoreResult {
   passed: boolean;
-  assertions?: AssertionResult[];
+  checks?: CheckResult[];
 }
 
-export type AssertionResult = {
+export type CheckResult = {
   type: "deterministic" | "llm";
   name: string;
   passed: boolean;
   notes?: string;
 };
 
-export function assertion(
+export function check(
   name: string,
   passed: boolean,
   notes?: string,
-): AssertionResult {
+): CheckResult {
   return {
     type: "deterministic",
     name,


### PR DESCRIPTION
Some scenarios (e.g. regression case [AI-593](https://linear.app/supabase/issue/AI-593/add-eval-for-unhealthy-project-recovery-answer)) involve fuzzy scoring of the agent's response which may not be feasible with determinstic string checks.

- Adds `judge()` to `@supabase-evals/core` — runs a minimal LLM judge via AI SDK (`gpt-5.5` low reasoning / low verbosity by default) against an arbitrary input string and rubric. Compose with the exported `serializeTranscript()` to judge a full agent transcript, or pass `agentReport` to judge just the final report.
- Threads structured `transcript` through the harness so scorers can inspect the full agent conversation (every step's assistant text + tool calls).
- Replaces string result `notes` / scenario scores with structured `checks[]`, including deterministic checks and LLM-backed checks with collapsible notes in the web UI.
- Updates `detect-security-001-public-table` to demonstrate the workflow with an LLM check that verifies the exposed table and proposed fix (we can revert this part if desired, it mainly exists to demo LLM checks)

To run the example eval demoing the judge:

```
npm run eval -- --experiment openai-gpt-5.4-mini --eval detect-security-001-public-table --runs 1 --force
```

Output includes checks pass rate:
```
RUN  openai-gpt-5.4-mini x detect-security-001-public-table
  -> PASS (checks 4/4, attempts 1)
```

Rendered result in the web app:

<img width="621" height="218" alt="CleanShot 2026-05-29 at 15 00 40@2x" src="https://github.com/user-attachments/assets/1a5e6e00-cb75-42a2-be50-726023b4df95" />

Closes [AI-758](https://linear.app/supabase/issue/AI-758/support-llm-as-a-judge-assertions-in-evalts)