### PR TITLE
test: add unhealthy project recovery eval

### DIFF
--- a/evals/resolve-reliability-001-unhealthy-project-recovery/EVAL.ts
+++ b/evals/resolve-reliability-001-unhealthy-project-recovery/EVAL.ts
@@ -8,10 +8,7 @@ import { stripIndent } from "common-tags";
 
 const scorer: ToolScorer = async (ctx) => {
   const verdict = await judge({
-    input: serializeTranscript(ctx.transcript, {
-      includeToolCallInputs: true,
-      includeToolCallOutputs: true,
-    }),
+    input: serializeTranscript(ctx.transcript),
     rubric: stripIndent`
       Pass if the assistant answers the support question with safe, docs-grounded unhealthy-project recovery guidance.
 

--- a/evals/resolve-reliability-001-unhealthy-project-recovery/EVAL.ts
+++ b/evals/resolve-reliability-001-unhealthy-project-recovery/EVAL.ts
@@ -1,0 +1,41 @@
+import {
+  judge,
+  serializeTranscript,
+  type CheckResult,
+  type ToolScorer,
+} from "@supabase-evals/core";
+import { stripIndent } from "common-tags";
+
+const scorer: ToolScorer = async (ctx) => {
+  const verdict = await judge({
+    input: serializeTranscript(ctx.transcript, {
+      includeToolCallInputs: true,
+      includeToolCallOutputs: true,
+    }),
+    rubric: stripIndent`
+      Pass if the assistant answers the support question with safe, docs-grounded unhealthy-project recovery guidance.
+
+      A passing answer should:
+      - Say that pausing and restoring/resuming the project is not the right first recovery step for an unhealthy or locked-up project.
+      - Distinguish restart from restore: restart/reboot is a recovery step for temporary unhealthy services; restore is backup/data recovery and should not be conflated with restart.
+      - Recommend practical first steps such as restarting the database/project, waiting a few minutes, checking logs/advisors/resource pressure, reducing workload or scaling if overloaded, reviewing the unhealthy-services troubleshooting guidance, and contacting Supabase support if the project remains unhealthy.
+
+      Fail if the assistant recommends pause plus restore/resume as the recovery path, presents pause/restore as a reliable fix for unhealthy services, conflates restore with restart, or gives only vague guidance without a concrete safe first step.
+    `,
+  });
+
+  const checks: CheckResult[] = [
+    {
+      name: "answered unhealthy project recovery question safely",
+      passed: verdict.passed,
+      judgeNotes: verdict.notes,
+    },
+  ];
+
+  return {
+    passed: checks.every((check) => check.passed),
+    checks,
+  };
+};
+
+export default scorer;

--- a/evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md
+++ b/evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md
@@ -1,0 +1,14 @@
+---
+stage: resolve
+product:
+  - database
+topic:
+  - reliability
+  - troubleshooting
+---
+
+# Unhealthy Project Recovery Question
+
+My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.
+
+Would restart or pause/restore be better?

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -524,6 +524,7 @@ export function supabaseMcpServer(
   } = {},
 ): McpServerDefinition {
   const features = options.features ?? [
+    "docs",
     "account",
     "database",
     "development",


### PR DESCRIPTION
According to the [team](https://supabase.slack.com/archives/C051L8U2EJF/p1776111289566319?thread_ts=1776106790.554459&cid=C051L8U2EJF):

> Pause/Resume quite literally is never a solution to any performance issue

**Changes**

Adds a regression case for the [report](https://supabase.slack.com/archives/C051L8U2EJF/p1776106790554459) of agents giving bad recommendations to pause/restore as solution for unhealthy projects, using LLM judge to score semantics of agent's transcript.

**Supporting Fixes**

Enables `docs` feature group for MCP so agents in those experiments can properly call `search_docs` to check best practices. Note the `-executor` experiments don't have a comparable tool for searching docs.

**Results**

From a single run pass, most experiments pass. Failures were from less capable models (5.4 nano, haiku) as well as `-executor` variants of experiments, likely due to the lack of docs access.

```bash
$ npm run eval --  --eval resolve-reliability-001-unhealthy-project-recovery --force --runs 1

> eval
> node --env-file=.env --import tsx/esm apps/framework/harness/run-eval.ts --eval resolve-reliability-001-unhealthy-project-recovery --force --runs 1

8 experiment(s), 15 eval(s), runs=1, timeout=720s, stop-on-pass
RUN  claude-haiku-4.5 x resolve-reliability-001-unhealthy-project-recovery
  -> FAIL (checks 0/1, attempts 1)
RUN  claude-opus-4.7 x resolve-reliability-001-unhealthy-project-recovery
  -> PASS (checks 1/1, attempts 1)
RUN  claude-sonnet-4.6-executor x resolve-reliability-001-unhealthy-project-recovery
  -> FAIL (checks 0/1, attempts 1)
RUN  claude-sonnet-4.6 x resolve-reliability-001-unhealthy-project-recovery
  -> PASS (checks 1/1, attempts 1)
RUN  openai-gpt-5.4-mini-executor x resolve-reliability-001-unhealthy-project-recovery
  -> FAIL (checks 0/1, attempts 1)
RUN  openai-gpt-5.4-mini x resolve-reliability-001-unhealthy-project-recovery
  -> PASS (checks 1/1, attempts 1)
RUN  openai-gpt-5.4-nano x resolve-reliability-001-unhealthy-project-recovery
  -> FAIL (checks 0/1, attempts 1)
RUN  openai-gpt-5.5 x resolve-reliability-001-unhealthy-project-recovery
  -> PASS (checks 1/1, attempts 1)
```

Closes AI-593