### PR TITLE
test: add realtime read replica regression eval

### DIFF
--- a/evals/design-realtime-001-live-chat-updates/EVAL.ts
+++ b/evals/design-realtime-001-live-chat-updates/EVAL.ts
@@ -1,0 +1,63 @@
+import {
+  judge,
+  serializeTranscript,
+  type CheckResult,
+  type ToolEvalContext,
+  type ToolScorer,
+} from "@supabase-evals/core";
+import { stripIndent } from "common-tags";
+
+const scorer: ToolScorer = async (ctx) => {
+  const checks: CheckResult[] = [
+    await checkMessagesRealtimePublication(ctx),
+    await checkNoReadReplicaGuidance(ctx),
+  ];
+
+  return {
+    passed: checks.every((check) => check.passed),
+    checks,
+  };
+};
+
+export default scorer;
+
+async function checkMessagesRealtimePublication(ctx: ToolEvalContext): Promise<CheckResult> {
+  // Realtime Postgres Changes needs subscribed tables in this publication.
+  const { rows } = await ctx.query(stripIndent`
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'messages';
+  `);
+
+  return {
+    name: "messages table added to supabase_realtime publication",
+    passed: rows.length > 0,
+  };
+}
+
+async function checkNoReadReplicaGuidance(ctx: ToolEvalContext): Promise<CheckResult> {
+  // AI-795 regression guard: live updates should not require read replicas.
+  const verdict = await judge({
+    input: serializeTranscript(ctx.transcript, {
+      includeToolCallInputs: true,
+    }),
+    rubric: stripIndent`
+      Pass if the assistant handles the live chat update request using Supabase Realtime/Postgres Changes without recommending read replicas.
+
+      A passing answer should:
+      - Treat the task as Realtime/Postgres Changes setup.
+      - Avoid saying or implying that read replicas are required or useful for Realtime live updates.
+      - Avoid confusing Supabase read replicas with Postgres logical replication or the supabase_realtime publication.
+
+      Fail if the assistant recommends provisioning a read replica, presents read replicas as the fix for live browser updates, or says Realtime requires read replicas.
+    `,
+  });
+
+  return {
+    name: "did not recommend read replicas for Realtime",
+    passed: verdict.passed,
+    judgeNotes: verdict.notes,
+  };
+}

--- a/evals/design-realtime-001-live-chat-updates/PROMPT.md
+++ b/evals/design-realtime-001-live-chat-updates/PROMPT.md
@@ -1,0 +1,17 @@
+---
+stage: design
+product:
+  - realtime
+  - database
+topic:
+  - sql
+---
+
+# Live Chat Updates
+
+I'm building a simple chat app on Supabase.
+
+Users can send messages, and I want everyone in the same room to see new
+messages appear automatically without refreshing the page.
+
+Can you inspect the project and set up whatever Supabase needs for live updates?

--- a/evals/design-realtime-001-live-chat-updates/seed/project.sql
+++ b/evals/design-realtime-001-live-chat-updates/seed/project.sql
@@ -1,0 +1,41 @@
+CREATE TABLE rooms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL
+);
+
+CREATE TABLE messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id uuid NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL DEFAULT auth.uid(),
+  body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE rooms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON rooms TO authenticated;
+GRANT SELECT, INSERT ON messages TO authenticated;
+
+CREATE POLICY "authenticated can read rooms"
+ON rooms
+FOR SELECT
+TO authenticated
+USING (true);
+
+CREATE POLICY "authenticated can read messages"
+ON messages
+FOR SELECT
+TO authenticated
+USING (true);
+
+CREATE POLICY "authenticated can insert messages"
+ON messages
+FOR INSERT
+TO authenticated
+WITH CHECK (user_id = auth.uid());
+
+CREATE PUBLICATION supabase_realtime;
+
+INSERT INTO rooms (id, name)
+VALUES ('11111111-1111-1111-1111-111111111111', 'general');


### PR DESCRIPTION
Adds regression eval for user asking to add Realtime capabilities to an existing app, and verifying agent does not unnecessarily steer user toward setting up a read replica.

**To run the eval**

```bash
$ npm run eval -- --eval design-realtime-001-live-chat-updates --experiment openai-gpt-5.4-mini --runs=1 --force

> eval
> node --env-file=.env --import tsx/esm apps/framework/harness/run-eval.ts --eval design-realtime-001-live-chat-updates --experiment openai-gpt-5.4-mini --runs=1 --force

1 experiment(s), 16 eval(s), runs=1, timeout=720s, stop-on-pass
RUN  openai-gpt-5.4-mini x design-realtime-001-live-chat-updates
  -> PASS (checks 2/2, attempts 1)
```

**What it checks**

- Agent configured the publication
- Agent didn't recommend read replica unnecessarily

Closes AI-795