### PR TITLE
ci: use app token for eval refresh PRs

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -208,10 +208,19 @@ jobs:
           path: apps/web/src/data/eval-results.json
           retention-days: 7
 
+      - name: Generate GitHub App token
+        id: generate-token
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Create results pull request
         if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           add-paths: apps/web/src/data/eval-results.json
           branch: chore/refresh-eval-results
           commit-message: "chore: refresh eval results"


### PR DESCRIPTION
This workflow requires a GH App in order to create PRs. The existing `GITHUB_TOKEN` was insufficient w/ the current repo settings.