### PR TITLE
feat: add Data API empty results eval

### DIFF
--- a/evals/resolve-dataapi-001-empty-results/EVAL.ts
+++ b/evals/resolve-dataapi-001-empty-results/EVAL.ts
@@ -1,0 +1,237 @@
+import {
+  judge,
+  serializeTranscript,
+  type CheckResult,
+  type SupabaseClient,
+  type ToolEvalContext,
+  type ToolScorer,
+} from "@supabase-evals/core";
+import { stripIndent } from "common-tags";
+
+const PASSWORD = "secret123";
+const BOOKMARK_A1 = "a bookmark alpha";
+const BOOKMARK_A2 = "a bookmark beta";
+const BOOKMARK_B = "b bookmark gamma";
+
+const scorer: ToolScorer = async (ctx) => {
+  try {
+    const setup = await setupTestUsers(ctx);
+    if ("failure" in setup) {
+      return { passed: false, checks: [setup.failure] };
+    }
+    const users = setup.users;
+
+    const checks: CheckResult[] = [
+      await checkRlsStillEnabled(ctx),
+      await checkUserAReadsOwnBookmarks(users),
+      await checkUserBCannotReadUserABookmarks(users),
+      await checkAnonReadsNoBookmarks(ctx),
+      await checkUserACanSaveNewBookmark(users),
+      await checkUserBCannotInsertAsUserA(ctx, users),
+      await checkRlsDiagnosisAndOwnerPolicies(ctx),
+    ];
+
+    return {
+      passed: checks.every((check) => check.passed),
+      checks,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      passed: false,
+      checks: [
+        {
+          name: "scorer evaluated Data API fix",
+          passed: false,
+          notes: msg,
+        },
+      ],
+    };
+  }
+};
+
+export default scorer;
+
+type TestUsers = {
+  clientA: SupabaseClient;
+  clientB: SupabaseClient;
+  userAId: string;
+  userBId: string;
+};
+
+async function setupTestUsers(
+  ctx: ToolEvalContext,
+): Promise<{ users: TestUsers } | { failure: CheckResult }> {
+  const clientA = ctx.client;
+  const clientB = ctx.getClient();
+
+  const { data: authA, error: authAError } = await clientA.auth.signUp({
+    email: `empty-results-a-${Date.now()}@example.com`,
+    password: PASSWORD,
+  });
+  const { data: authB, error: authBError } = await clientB.auth.signUp({
+    email: `empty-results-b-${Date.now()}@example.com`,
+    password: PASSWORD,
+  });
+
+  if (
+    authAError ||
+    authBError ||
+    !authA.user?.id ||
+    !authA.session ||
+    !authB.user?.id ||
+    !authB.session
+  ) {
+    return {
+      failure: {
+        name: "created auth sessions",
+        passed: false,
+        notes: authAError?.message ?? authBError?.message ?? "missing session",
+      },
+    };
+  }
+
+  const userAId = authA.user.id;
+  const userBId = authB.user.id;
+
+  await ctx.query(`
+INSERT INTO bookmarks (user_id, title, url) VALUES
+  ('${userAId}', '${BOOKMARK_A1}', 'https://example.com/a1'),
+  ('${userAId}', '${BOOKMARK_A2}', 'https://example.com/a2'),
+  ('${userBId}', '${BOOKMARK_B}', 'https://example.com/b');
+  `);
+
+  return { users: { clientA, clientB, userAId, userBId } };
+}
+
+async function checkRlsStillEnabled(ctx: ToolEvalContext): Promise<CheckResult> {
+  const { rows } = await ctx.query(
+    `SELECT relrowsecurity FROM pg_class WHERE relname = 'bookmarks';`,
+  );
+
+  return {
+    name: "RLS still enabled on bookmarks",
+    passed: rows[0]?.relrowsecurity === true,
+  };
+}
+
+async function checkUserAReadsOwnBookmarks(users: TestUsers): Promise<CheckResult> {
+  const { data, error } = await users.clientA
+    .from("bookmarks")
+    .select("title,user_id")
+    .order("title");
+
+  return {
+    name: "user A reads own bookmarks",
+    passed:
+      !error &&
+      data?.length === 2 &&
+      data[0]?.title === BOOKMARK_A1 &&
+      data[1]?.title === BOOKMARK_A2 &&
+      data.every((row) => row.user_id === users.userAId),
+    notes: error?.message,
+  };
+}
+
+async function checkUserBCannotReadUserABookmarks(
+  users: TestUsers,
+): Promise<CheckResult> {
+  const { data, error } = await users.clientB
+    .from("bookmarks")
+    .select("id")
+    .eq("title", BOOKMARK_A1);
+
+  return {
+    name: "user B cannot read user A bookmarks",
+    passed: !error && Array.isArray(data) && data.length === 0,
+  };
+}
+
+async function checkAnonReadsNoBookmarks(ctx: ToolEvalContext): Promise<CheckResult> {
+  const { data, error } = await ctx.getClient().from("bookmarks").select("id");
+
+  return {
+    name: "anon reads no bookmarks",
+    passed: error !== null || data?.length === 0,
+  };
+}
+
+async function checkUserACanSaveNewBookmark(users: TestUsers): Promise<CheckResult> {
+  const { data, error } = await users.clientA
+    .from("bookmarks")
+    .insert({ title: "a bookmark delta", url: "https://example.com/a3" })
+    .select("title,user_id");
+
+  return {
+    name: "user A can save a new bookmark",
+    passed:
+      !error &&
+      data?.length === 1 &&
+      data[0]?.title === "a bookmark delta" &&
+      data[0]?.user_id === users.userAId,
+    notes: error?.message,
+  };
+}
+
+async function checkUserBCannotInsertAsUserA(
+  ctx: ToolEvalContext,
+  users: TestUsers,
+): Promise<CheckResult> {
+  await silenceExpectedError(() =>
+    users.clientB
+      .from("bookmarks")
+      .insert({
+        user_id: users.userAId,
+        title: "planted by user B",
+        url: "https://example.com/planted",
+      })
+      .select("id"),
+  );
+  const { rows } = await ctx.query(
+    `SELECT count(*)::int AS count FROM bookmarks WHERE title = 'planted by user B';`,
+  );
+
+  return {
+    name: "user B cannot insert a bookmark as user A",
+    passed: rows[0]?.count === 0,
+  };
+}
+
+async function checkRlsDiagnosisAndOwnerPolicies(
+  ctx: ToolEvalContext,
+): Promise<CheckResult> {
+  // AI-822: empty Data API results must be handled as an RLS issue, not a
+  // data/query problem, and fixed with owner-scoped policies.
+  const verdict = await judge({
+    input: serializeTranscript(ctx.transcript, {
+      includeToolCallInputs: true,
+    }),
+    rubric: stripIndent`
+      Pass if the assistant handles the empty Data API results as a Row Level Security issue and fixes it by creating RLS policies that let users read and insert only their own bookmarks.
+
+      A passing answer should:
+      - Diagnose that RLS is enabled on the bookmarks table with no policies, so the Data API returns zero rows to every user (deny-all by default).
+      - Create a SELECT policy for the authenticated role using USING (user_id = auth.uid()).
+      - Create an INSERT policy for the authenticated role that enforces user_id = auth.uid() via WITH CHECK.
+      - Keep RLS enabled on the bookmarks table.
+
+      Fail if the assistant disables RLS, creates permissive policies such as USING (true), scopes the policies to anon/public instead of authenticated, blames the empty results on data, query, or connection problems instead of RLS, or never creates the owner-scoped policies.
+    `,
+  });
+
+  return {
+    name: "diagnosed RLS and added owner-scoped policies",
+    passed: verdict.passed,
+    judgeNotes: verdict.notes,
+  };
+}
+
+async function silenceExpectedError<T>(fn: () => PromiseLike<T>): Promise<T> {
+  const original = console.error;
+  console.error = () => undefined;
+  try {
+    return await fn();
+  } finally {
+    console.error = original;
+  }
+}

--- a/evals/resolve-dataapi-001-empty-results/EVAL.ts
+++ b/evals/resolve-dataapi-001-empty-results/EVAL.ts
@@ -200,8 +200,6 @@ async function checkUserBCannotInsertAsUserA(
 async function checkRlsDiagnosisAndOwnerPolicies(
   ctx: ToolEvalContext,
 ): Promise<CheckResult> {
-  // AI-822: empty Data API results must be handled as an RLS issue, not a
-  // data/query problem, and fixed with owner-scoped policies.
   const verdict = await judge({
     input: serializeTranscript(ctx.transcript, {
       includeToolCallInputs: true,

--- a/evals/resolve-dataapi-001-empty-results/PROMPT.md
+++ b/evals/resolve-dataapi-001-empty-results/PROMPT.md
@@ -7,8 +7,8 @@ product:
   - auth
 topic:
   - rls
-  - policies
-  - supabase-js
+  - sdk
+motivation: AI-822, https://supabase.com/docs/guides/troubleshooting/why-is-my-select-returning-an-empty-data-array-and-i-have-data-in-the-table-xvOPgx
 ---
 
 # Bookmarks Dashboard Shows Nothing

--- a/evals/resolve-dataapi-001-empty-results/PROMPT.md
+++ b/evals/resolve-dataapi-001-empty-results/PROMPT.md
@@ -1,0 +1,21 @@
+---
+stage: resolve
+suite: benchmark
+product:
+  - data api
+  - database
+  - auth
+topic:
+  - rls
+  - policies
+  - supabase-js
+---
+
+# Bookmarks Dashboard Shows Nothing
+
+Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. 
+Users also need to be able to save new bookmarks from the app.
+
+I can see the rows when I query the table directly, but the dashboard shows an empty list for every user.
+
+Find out why the Data API returns nothing and fix it.

--- a/evals/resolve-dataapi-001-empty-results/seed/project.sql
+++ b/evals/resolve-dataapi-001-empty-results/seed/project.sql
@@ -1,0 +1,13 @@
+CREATE TABLE bookmarks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL DEFAULT auth.uid(),
+  title text NOT NULL,
+  url text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Bug: RLS is enabled and the grants are in place, but no policies were ever
+-- created, so the Data API silently returns zero rows to every user.
+ALTER TABLE bookmarks ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT ON bookmarks TO authenticated;


### PR DESCRIPTION
See "Diagnose empty Data API results" scenario from [Supa-bench (condensed)](https://app.notion.com/p/supabase/Supa-bench-condensed-3675004b775f8066824ce11e9fd06304?source=copy_link#37b5004b775f80cea8adfb03d512d2a7).

**Additions**
- Benchmark eval `resolve-dataapi-001-empty-results` for diagnosing why the Data API silently returns an empty array despite existing rows, tracing the cause to missing RLS policies on a table with RLS enabled, and fixing it with owner-scoped policies.

**To run the eval**
```bash
npm run eval -- --eval resolve-dataapi-001-empty-results --experiment claude-sonnet-4.6 --force --runs 1
```

**What the eval checks**
- RLS remains enabled on the `bookmarks` table after the fix.
- User A reads only their own bookmarks.
- User B cannot read user A's bookmarks.
- Anon reads no bookmarks.
- User A can save a new bookmark.
- User B cannot insert a bookmark as user A.
- Agent diagnosed the empty results as an RLS deny-all issue and added owner-scoped policies using `USING (user_id = auth.uid())`.

Closes AI-822