### PR TITLE
refactor: silence expected scorer logs in the framework

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -17,6 +17,7 @@ import {
   readRepeatedFlag,
   readSuiteFilters,
 } from "../lib/cli-args.js";
+import { runScorer } from "../lib/scorer.js";
 import { buildFileTools } from "./file-tools.js";
 import { viteBuild, vitestRun } from "./project-runner.js";
 import type {
@@ -45,6 +46,7 @@ const SUITE_FILTERS = readSuiteFilters(rawArgs);
 const RUNS = Number(readFlag("runs") ?? 4);
 const TIMEOUT_SEC = Number(readFlag("timeout-sec") ?? 720);
 const STOP_ON_PASS = !args.has("--run-all-attempts");
+const DEBUG = args.has("--debug");
 
 async function loadExperiments() {
   const dir = join(ROOT, "experiments");
@@ -235,13 +237,17 @@ async function runOne(
       lastTranscript = run.transcript;
       lastAgentReport = run.agentReport;
       lastStoppedReason = run.stoppedReason;
-      last = await (scorer as ProjectScorer)({
-        workspace,
-        projectResult: { build, vitest },
-        toolCalls: run.toolCalls,
-        transcript: run.transcript,
-        agentReport: run.agentReport,
-      });
+      last = await runScorer(
+        () =>
+          (scorer as ProjectScorer)({
+            workspace,
+            projectResult: { build, vitest },
+            toolCalls: run.toolCalls,
+            transcript: run.transcript,
+            agentReport: run.agentReport,
+          }),
+        { debug: DEBUG },
+      );
 
       if (STOP_ON_PASS && last.passed) {
         return {
@@ -284,12 +290,16 @@ async function runOne(
       lastTranscript = run.transcript;
       lastAgentReport = run.agentReport;
       lastStoppedReason = run.stoppedReason;
-      last = await (scorer as ToolScorer)({
-        ...session.scoringContext,
-        toolCalls: run.toolCalls,
-        transcript: run.transcript,
-        agentReport: run.agentReport,
-      });
+      last = await runScorer(
+        () =>
+          (scorer as ToolScorer)({
+            ...session.scoringContext,
+            toolCalls: run.toolCalls,
+            transcript: run.transcript,
+            agentReport: run.agentReport,
+          }),
+        { debug: DEBUG },
+      );
 
       if (STOP_ON_PASS && last.passed) {
         return {

--- a/apps/framework/lib/scorer.ts
+++ b/apps/framework/lib/scorer.ts
@@ -1,0 +1,25 @@
+/**
+ * Invoke a scorer with `console.error` suppressed.
+ *
+ * Scorers routinely trigger supabase-js operations that are *expected* to fail
+ * (e.g. a cross-user write blocked by RLS). supabase-js logs those failures via
+ * `console.error` even though the scorer handles them as values, producing noise
+ * that buries real output. We silence `console.error` for the duration of the
+ * scorer call so this is handled framework-wide rather than re-implemented in
+ * each eval.
+ *
+ * Pass `debug: true` to keep error logs visible when troubleshooting a scorer.
+ */
+export async function runScorer<T>(
+  fn: () => Promise<T>,
+  options: { debug?: boolean } = {},
+): Promise<T> {
+  if (options.debug) return fn();
+  const original = console.error;
+  console.error = () => undefined;
+  try {
+    return await fn();
+  } finally {
+    console.error = original;
+  }
+}

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -6,6 +6,7 @@ import { bootPlatformBackend } from "../harness/platform-backend.js";
 import { viteBuild, vitestRun } from "../harness/project-runner.js";
 import type { ToolScorer, TranscriptPart } from "../harness/types.js";
 import type { PlatformBackend } from "../harness/platform-backend.js";
+import { runScorer } from "../lib/scorer.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..", "..");
@@ -19,7 +20,10 @@ const FRONTEND_EVAL = "evals/design-frontend-001-todos-app";
 
 async function loadScorer(relDir: string): Promise<ToolScorer> {
   const mod = await import(pathToFileURL(join(ROOT, relDir, "EVAL.ts")).href);
-  return mod.default as ToolScorer;
+  const scorer = mod.default as ToolScorer;
+  // Route scorers through the same silencing wrapper the runner uses, so smoke
+  // runs stay quiet on expected-fail supabase-js calls.
+  return (ctx) => runScorer(() => scorer(ctx));
 }
 
 function scorerCtx(

--- a/evals/design-rls-002-own-todos-client/EVAL.ts
+++ b/evals/design-rls-002-own-todos-client/EVAL.ts
@@ -89,12 +89,10 @@ INSERT INTO todos (user_id, body, done) VALUES
         ownInsert.user_id === userAId,
     });
 
-    const { data: spoofInsert, error: spoofInsertError } = await silenceExpectedError(() =>
-      clientB
-        .from("todos")
-        .insert({ user_id: userAId, body: "b spoofed as a" })
-        .select("id")
-    );
+    const { data: spoofInsert, error: spoofInsertError } = await clientB
+      .from("todos")
+      .insert({ user_id: userAId, body: "b spoofed as a" })
+      .select("id");
     checks.push({
       name: "user B cannot insert todo for user A",
       passed: Boolean(spoofInsertError) || !spoofInsert || spoofInsert.length === 0,
@@ -161,12 +159,3 @@ INSERT INTO todos (user_id, body, done) VALUES
 
 export default scorer;
 
-async function silenceExpectedError<T>(fn: () => PromiseLike<T>): Promise<T> {
-  const original = console.error;
-  console.error = () => undefined;
-  try {
-    return await fn();
-  } finally {
-    console.error = original;
-  }
-}

--- a/evals/resolve-dataapi-001-empty-results/EVAL.ts
+++ b/evals/resolve-dataapi-001-empty-results/EVAL.ts
@@ -177,16 +177,14 @@ async function checkUserBCannotInsertAsUserA(
   ctx: ToolEvalContext,
   users: TestUsers,
 ): Promise<CheckResult> {
-  await silenceExpectedError(() =>
-    users.clientB
-      .from("bookmarks")
-      .insert({
-        user_id: users.userAId,
-        title: "planted by user B",
-        url: "https://example.com/planted",
-      })
-      .select("id"),
-  );
+  await users.clientB
+    .from("bookmarks")
+    .insert({
+      user_id: users.userAId,
+      title: "planted by user B",
+      url: "https://example.com/planted",
+    })
+    .select("id");
   const { rows } = await ctx.query(
     `SELECT count(*)::int AS count FROM bookmarks WHERE title = 'planted by user B';`,
   );
@@ -222,14 +220,4 @@ async function checkRlsDiagnosisAndOwnerPolicies(
     passed: verdict.passed,
     judgeNotes: verdict.notes,
   };
-}
-
-async function silenceExpectedError<T>(fn: () => PromiseLike<T>): Promise<T> {
-  const original = console.error;
-  console.error = () => undefined;
-  try {
-    return await fn();
-  } finally {
-    console.error = original;
-  }
 }

--- a/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
+++ b/evals/resolve-security-001-rls-cross-user-leak/EVAL.ts
@@ -88,13 +88,11 @@ INSERT INTO notes (user_id, body, is_pinned) VALUES
         ownUpdate[0]?.user_id === userAId,
     });
 
-    await silenceExpectedError(() =>
-      clientB
-        .from("notes")
-        .update({ user_id: userAId, body: "stolen by reassignment" })
-        .eq("body", "b private note")
-        .select("id,user_id")
-    );
+    await clientB
+      .from("notes")
+      .update({ user_id: userAId, body: "stolen by reassignment" })
+      .eq("body", "b private note")
+      .select("id,user_id");
     const { rows: reassignedRows } = await q(`
 SELECT user_id, body
 FROM notes
@@ -129,12 +127,3 @@ ORDER BY body;
 
 export default scorer;
 
-async function silenceExpectedError<T>(fn: () => PromiseLike<T>): Promise<T> {
-  const original = console.error;
-  console.error = () => undefined;
-  try {
-    return await fn();
-  } finally {
-    console.error = original;
-  }
-}


### PR DESCRIPTION
Follow-up to a review note on #17:

> Side note, maybe in a follow up we should pull this out into some shared framework logic, either as a shared function or something built into the framework so it silences scorer logs by default with option to enable for debugging.

Scorers routinely trigger supabase-js operations that are *expected* to fail (e.g. a cross-user write blocked by RLS), and `supabase-js` logs those failures via `console.error` even though the scorer handles them as values. 
Until now each eval worked around this with its own copy-pasted `silenceExpectedError` helper wrapped around the risky call.

Implements `runScorer` with a `--debug` option, passed as command line argument, that silences `console.error` for the duration of the scorer at a framework level. If `debug=true`, the supabase-js error is thrown.

**Notes**

- Scope is `console.error` only (the exact channel supabase-js uses), matching the old helper. Scorers report results via `CheckResult`/`notes`, not the console, so nothing meaningful is hidden — and `--debug` brings it all back.
- Relies on scorers running sequentially (they do, in both the runner loops and the smoke steps), since `console.error` is swapped globally.