### PR TITLE
feat: add Realtime publication debugging eval (AI-819)

### DIFF
--- a/evals/investigate-realtime-001-subscribed-no-events/EVAL.ts
+++ b/evals/investigate-realtime-001-subscribed-no-events/EVAL.ts
@@ -13,7 +13,8 @@ const scorer: ToolScorer = async (ctx) => {
       await checkOrdersInPublication(ctx),
       await checkCourierFeedStillPublished(ctx),
       await checkPublicationStillPublishesInserts(ctx),
-      await checkOrdersRlsIntact(ctx),
+      await checkOrdersRlsEnabled(ctx),
+      await checkStaffCanReadOrders(ctx),
       await checkPublicationDiagnosis(ctx),
     ];
 
@@ -84,38 +85,58 @@ async function checkPublicationStillPublishesInserts(
   };
 }
 
-async function checkOrdersRlsIntact(ctx: ToolEvalContext): Promise<CheckResult> {
-  // Guard against debugging by weakening security: RLS stays enabled and
-  // staff can still read orders through it.
-  const { rows: rls } = await ctx.query(
+async function checkOrdersRlsEnabled(ctx: ToolEvalContext): Promise<CheckResult> {
+  // Guard against debugging by weakening security: RLS must stay enabled.
+  const { rows } = await ctx.query(
     `SELECT relrowsecurity FROM pg_class WHERE relname = 'orders';`,
   );
-  if (rls[0]?.relrowsecurity !== true) {
-    return { name: "RLS still enabled on orders", passed: false };
-  }
+
+  return {
+    name: "RLS still enabled on orders",
+    passed: rows[0]?.relrowsecurity === true,
+  };
+}
+
+async function checkStaffCanReadOrders(ctx: ToolEvalContext): Promise<CheckResult> {
+  // The "staff can read orders" policy must survive the fix: an authenticated
+  // user should still see every order through PostgREST.
+  const name = "staff can still read orders through RLS";
 
   try {
-    const { rows } = await ctx.query(stripIndent`
-      BEGIN;
-      SET LOCAL ROLE authenticated;
-      SET LOCAL request.jwt.claim.role = 'authenticated';
-      SELECT count(*)::int AS count FROM orders;
-      COMMIT;
-    `);
+    const client = ctx.getClient();
+    const { error: signUpError } = await client.auth.signUp({
+      email: "dispatch-staff@example.com",
+      password: "secret123",
+    });
+    if (signUpError) {
+      return { name, passed: false, notes: signUpError.message };
+    }
+
+    const { rows: privileged } = await ctx.query(
+      `SELECT count(*)::int AS count FROM orders;`,
+    );
+
+    if (privileged.length === 0 || privileged[0].count === undefined) {
+      return { name, passed: false, notes: "failed to count orders with privileged SQL" };
+    }
+
+    const expected = privileged[0].count;
+
+    const { count: authenticatedCount, error: readError } = await client
+      .from("orders")
+      .select("*", { count: "exact", head: true });
+    if (readError) {
+      return { name, passed: false, notes: readError.message };
+    }
 
     return {
-      name: "RLS still enabled on orders",
-      passed: rows[0]?.count === 2,
-      notes: `authenticated sees ${rows[0]?.count} orders`,
+      name,
+      passed: authenticatedCount === expected,
+      notes: `authenticated sees ${authenticatedCount} of ${expected} orders`,
     };
   } catch (error) {
-    try {
-      await ctx.query("ROLLBACK;");
-    } catch {
-      // Clear aborted scorer transactions.
-    }
     const msg = error instanceof Error ? error.message : String(error);
-    return { name: "RLS still enabled on orders", passed: false, notes: msg };
+    return { name, passed: false, notes: msg };
   }
 }
 

--- a/evals/investigate-realtime-001-subscribed-no-events/EVAL.ts
+++ b/evals/investigate-realtime-001-subscribed-no-events/EVAL.ts
@@ -1,0 +1,144 @@
+import {
+  judge,
+  serializeTranscript,
+  type CheckResult,
+  type ToolEvalContext,
+  type ToolScorer,
+} from "@supabase-evals/core";
+import { stripIndent } from "common-tags";
+
+const scorer: ToolScorer = async (ctx) => {
+  try {
+    const checks: CheckResult[] = [
+      await checkOrdersInPublication(ctx),
+      await checkCourierFeedStillPublished(ctx),
+      await checkPublicationStillPublishesInserts(ctx),
+      await checkOrdersRlsIntact(ctx),
+      await checkPublicationDiagnosis(ctx),
+    ];
+
+    return {
+      passed: checks.every((check) => check.passed),
+      checks,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      passed: false,
+      checks: [
+        {
+          name: "scorer evaluated realtime publication fix",
+          passed: false,
+          notes: msg,
+        },
+      ],
+    };
+  }
+};
+
+export default scorer;
+
+async function checkOrdersInPublication(ctx: ToolEvalContext): Promise<CheckResult> {
+  // Realtime Postgres Changes only delivers events for tables in this publication.
+  const { rows } = await ctx.query(stripIndent`
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'orders';
+  `);
+
+  return {
+    name: "orders table added to supabase_realtime publication",
+    passed: rows.length > 0,
+  };
+}
+
+async function checkCourierFeedStillPublished(ctx: ToolEvalContext): Promise<CheckResult> {
+  // The working courier feed must survive the fix (e.g. a publication
+  // recreated with only orders would silently break it).
+  const { rows } = await ctx.query(stripIndent`
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'courier_locations';
+  `);
+
+  return {
+    name: "courier_locations still in supabase_realtime publication",
+    passed: rows.length > 0,
+  };
+}
+
+async function checkPublicationStillPublishesInserts(
+  ctx: ToolEvalContext,
+): Promise<CheckResult> {
+  const { rows } = await ctx.query(
+    `SELECT pubinsert FROM pg_publication WHERE pubname = 'supabase_realtime';`,
+  );
+
+  return {
+    name: "publication still publishes INSERT events",
+    passed: rows[0]?.pubinsert === true,
+  };
+}
+
+async function checkOrdersRlsIntact(ctx: ToolEvalContext): Promise<CheckResult> {
+  // Guard against debugging by weakening security: RLS stays enabled and
+  // staff can still read orders through it.
+  const { rows: rls } = await ctx.query(
+    `SELECT relrowsecurity FROM pg_class WHERE relname = 'orders';`,
+  );
+  if (rls[0]?.relrowsecurity !== true) {
+    return { name: "RLS still enabled on orders", passed: false };
+  }
+
+  try {
+    const { rows } = await ctx.query(stripIndent`
+      BEGIN;
+      SET LOCAL ROLE authenticated;
+      SET LOCAL request.jwt.claim.role = 'authenticated';
+      SELECT count(*)::int AS count FROM orders;
+      COMMIT;
+    `);
+
+    return {
+      name: "RLS still enabled on orders",
+      passed: rows[0]?.count === 2,
+      notes: `authenticated sees ${rows[0]?.count} orders`,
+    };
+  } catch (error) {
+    try {
+      await ctx.query("ROLLBACK;");
+    } catch {
+      // Clear aborted scorer transactions.
+    }
+    const msg = error instanceof Error ? error.message : String(error);
+    return { name: "RLS still enabled on orders", passed: false, notes: msg };
+  }
+}
+
+async function checkPublicationDiagnosis(ctx: ToolEvalContext): Promise<CheckResult> {
+  const verdict = await judge({
+    input: serializeTranscript(ctx.transcript, {
+      includeToolCallInputs: true,
+    }),
+    rubric: stripIndent`
+      Pass if the assistant diagnoses the silent Realtime subscription as the orders table missing from the supabase_realtime publication and fixes exactly that.
+
+      A passing answer should:
+      - Identify that the channel reaches SUBSCRIBED but Postgres Changes never delivers INSERT events for orders because orders is not in the supabase_realtime publication.
+      - Add the orders table to the existing publication, e.g. ALTER PUBLICATION supabase_realtime ADD TABLE orders (or the dashboard equivalent).
+      - Leave the rest of the project working: the courier_locations feed, the existing policies, and RLS on orders.
+
+      Fail if the assistant blames RLS, grants, the client subscription code, or networking as the root cause, recreates the publication FOR ALL TABLES or drops tables that were already in it, disables RLS or weakens policies as part of the fix, recommends read replicas, or only suggests client-side changes without fixing the publication.
+    `,
+  });
+
+  return {
+    name: "diagnosed missing publication membership",
+    passed: verdict.passed,
+    judgeNotes: verdict.notes,
+  };
+}

--- a/evals/investigate-realtime-001-subscribed-no-events/PROMPT.md
+++ b/evals/investigate-realtime-001-subscribed-no-events/PROMPT.md
@@ -9,7 +9,7 @@ topic:
 motivation: AI-819, REAL-577
 ---
 
-# New Orders Never Appear Live
+# Debug Realtime publication
 
 Our dispatch dashboard shows incoming orders as they happen. The courier
 location feed on the same page updates live without problems, but new orders

--- a/evals/investigate-realtime-001-subscribed-no-events/PROMPT.md
+++ b/evals/investigate-realtime-001-subscribed-no-events/PROMPT.md
@@ -1,0 +1,23 @@
+---
+stage: investigate
+suite: benchmark
+product:
+  - realtime
+  - database
+topic:
+  - sdk
+motivation: AI-819, REAL-577
+---
+
+# New Orders Never Appear Live
+
+Our dispatch dashboard shows incoming orders as they happen. The courier
+location feed on the same page updates live without problems, but new orders
+only show up after a page refresh.
+
+The dashboard uses supabase-js to subscribe to INSERT events on the `orders`
+table through postgres_changes, the same way it subscribes to courier
+locations. The channel's status callback logs SUBSCRIBED and there are no
+errors in the browser console.
+
+Figure out why no order events ever arrive and fix it.

--- a/evals/investigate-realtime-001-subscribed-no-events/seed/project.sql
+++ b/evals/investigate-realtime-001-subscribed-no-events/seed/project.sql
@@ -1,0 +1,59 @@
+CREATE TABLE orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_name text NOT NULL,
+  status text NOT NULL DEFAULT 'new',
+  total numeric(10,2) NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE courier_locations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  courier_id uuid NOT NULL,
+  lat double precision NOT NULL,
+  lng double precision NOT NULL,
+  recorded_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE courier_locations ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT ON orders TO authenticated;
+GRANT SELECT, INSERT ON courier_locations TO authenticated;
+
+CREATE POLICY "staff can read orders"
+ON orders
+FOR SELECT
+TO authenticated
+USING (true);
+
+CREATE POLICY "staff can create orders"
+ON orders
+FOR INSERT
+TO authenticated
+WITH CHECK (true);
+
+CREATE POLICY "staff can read courier locations"
+ON courier_locations
+FOR SELECT
+TO authenticated
+USING (true);
+
+CREATE POLICY "couriers can report locations"
+ON courier_locations
+FOR INSERT
+TO authenticated
+WITH CHECK (true);
+
+-- Bug: the dashboard subscribes to postgres_changes on orders and reaches
+-- SUBSCRIBED, but orders was never added to the supabase_realtime
+-- publication, so no INSERT events are ever delivered. The courier feed
+-- works because its table is in the publication.
+CREATE PUBLICATION supabase_realtime FOR TABLE courier_locations;
+
+INSERT INTO orders (customer_name, status, total) VALUES
+  ('Ada Fields', 'delivered', 24.50),
+  ('Tom Okafor', 'preparing', 18.00);
+
+INSERT INTO courier_locations (courier_id, lat, lng) VALUES
+  ('11111111-1111-1111-1111-111111111111', 52.370216, 4.895168),
+  ('11111111-1111-1111-1111-111111111111', 52.371500, 4.897000);


### PR DESCRIPTION
See "Debug Realtime publication" scenario from [Supa-bench (condensed)](https://app.notion.com/p/supabase/Supa-bench-condensed-3675004b775f8066824ce11e9fd06304?source=copy_link#37c5004b775f804ebab9e23b92f6848b).

**Additions**
- Benchmark eval `investigate-realtime-001-subscribed-no-events` for debugging a Realtime subscription that reaches SUBSCRIBED but never receives INSERT events, tracing the cause to the table missing from the `supabase_realtime` publication and fixing it with a targeted `ALTER PUBLICATION ... ADD TABLE`.
- Seed with a working dispatch app: a courier locations feed whose table is in the publication (live updates work) and an `orders` table that was never added (the bug). The symptom — SUBSCRIBED with no events — is only observable client-side, so the prompt reports it the way a user would; the diagnosis and fix are entirely database-side, where the agent can work through the Management API.

Once a runtime with a real Realtime service exists, this eval can be upgraded to verify end-to-end delivery (subscribe, insert, assert the event arrives after the fix).

**To run the eval**
```bash
pnpm eval -- --eval investigate-realtime-001-subscribed-no-events --experiment claude-sonnet-4.6 --force --runs 1
```

**What the eval checks**
- The `orders` table was added to the `supabase_realtime` publication.
- `courier_locations` is still in the publication (the working feed survived the fix).
- The publication still publishes INSERT events.
- RLS remains enabled on `orders` and staff can still read orders through it.
- Agent diagnosed the silent subscription as missing publication membership (not RLS, client code, or networking) and fixed exactly that, without recreating the publication `FOR ALL TABLES` or recommending read replicas.

**References**
- https://linear.app/supabase/issue/REAL-577/avoid-retrying-to-reconnect-pg-changes-for-unrecoverable-errors

Closes AI-819