### PR TITLE
chore: update supabase lite to `v0.4.1-next.2`

### DIFF
--- a/packages/platform-lite/test/database.test.ts
+++ b/packages/platform-lite/test/database.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { createClient } from '@supabase/supabase-js'
+import { createPlatform } from '../src/app.js'
 import { createTestApp, request } from './helpers.js'
 
 describe('database', () => {
@@ -103,5 +105,57 @@ describe('database', () => {
     )
     expect(list).toHaveLength(1)
     expect(list[0].name).toBe('create_items')
+  })
+
+  it('routes supabase-js rpc calls to PostgREST', async () => {
+    const ref = 'rpc-proj'
+    const platform = await createPlatform({
+      projects: [
+        {
+          ref,
+          sql: `
+            CREATE OR REPLACE FUNCTION public.echo_input(value text)
+            RETURNS text
+            LANGUAGE sql
+            STABLE
+            AS $$
+              SELECT value || '-rpc'
+            $$;
+
+            GRANT USAGE ON SCHEMA public TO anon;
+            GRANT EXECUTE ON FUNCTION public.echo_input(text) TO anon;
+          `,
+        },
+      ],
+    })
+
+    try {
+      const instance = platform.getProject(ref)
+      if (!instance) throw new Error(`project missing: ${ref}`)
+
+      const { data: keys } = await request<Array<{ name: string; api_key: string }>>(
+        platform.app,
+        'GET',
+        `/v1/projects/${ref}/api-keys`
+      )
+      const anon = keys.find((key) => key.name === 'anon')
+      if (!anon) throw new Error(`anon key missing: ${ref}`)
+
+      const supabase = createClient('http://supabase-evals.local', anon.api_key, {
+        global: {
+          fetch: (input, init) => {
+            const req = new Request(input, init)
+            return instance.app.fetch(req)
+          },
+        },
+      })
+
+      const { data, error } = await supabase.rpc('echo_input', { value: 'lite' })
+
+      expect(error).toBeNull()
+      expect(data).toEqual([{ echo_input: 'lite-rpc' }])
+    } finally {
+      await platform.dispose()
+    }
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 0.4.5
       version: 0.4.5
     '@supabase/lite':
-      specifier: ^0.4.0
-      version: 0.4.0
+      specifier: 0.4.1-next.2
+      version: 0.4.1-next.2
     '@supabase/supabase-js':
       specifier: ^2.105.1
       version: 2.108.1
@@ -92,7 +92,7 @@ importers:
         version: link:../../packages/platform-lite
       '@supabase/lite':
         specifier: 'catalog:'
-        version: 0.4.0(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+        version: 0.4.1-next.2(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.108.1
@@ -259,7 +259,7 @@ importers:
         version: 1.19.14(hono@4.12.25)
       '@supabase/lite':
         specifier: 'catalog:'
-        version: 0.4.0(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+        version: 0.4.1-next.2(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.108.1
@@ -1928,8 +1928,8 @@ packages:
     resolution: {integrity: sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/lite@0.4.0':
-    resolution: {integrity: sha512-3g3cKauoXgWZnxGL75KTAeNKtVlfUvG8owRnxgi+YvSknaO4tG27OwCtsZOn4/SHBEidrlgmxJDlGgNJgy5j4w==}
+  '@supabase/lite@0.4.1-next.2':
+    resolution: {integrity: sha512-9Lf113tw9I/wHeVm0Fk4ex1ZY58LLpZWmO2lxOLvbT7d/yilm0kNP8/JTdlfmuKhjjWntft9mFlWzcEr5FonUQ==}
     hasBin: true
     peerDependencies:
       '@supabase/supabase-js': '>=2.90.0'
@@ -6006,7 +6006,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/lite@0.4.0(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+  '@supabase/lite@0.4.1-next.2(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
       '@electric-sql/pglite': 0.4.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ catalog:
   '@ai-sdk/mcp': ^1.0.39
   '@ai-sdk/openai': ^3.0.66
   '@electric-sql/pglite': 0.4.5
-  '@supabase/lite': ^0.4.0
+  '@supabase/lite': 0.4.1-next.2
   '@supabase/supabase-js': ^2.105.1
   '@types/node': ^22.0.0
   '@vitejs/plugin-react': ^5.2.0


### PR DESCRIPTION
- Bumps `@supabase/lite` to [`0.4.1-next.2`](https://www.npmjs.com/package/@supabase/lite/v/0.4.1-next.2) to support scenarios with DB functions
- Adds a test of running `supabase.rpc()` against lite

Related: https://github.com/supabase-community/lite/pull/243