### PR TITLE
feat(eval): expose `search_docs` MCP to the local-stack runtime

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -255,6 +255,7 @@ async function runOne(
           ),
           userPrompt: prompt,
           tools: session.tools,
+          mcpServers: session.mcpServers,
           timeoutSec: TIMEOUT_SEC,
         });
 

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -125,7 +125,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed199-b3c1-765b-a6e3-831e9e013041/receipt-alpha.pdf, 019ed199-b3c1-765b-a6e3-831e9e013041/receipt-beta.pdf"
+        "notes": "saw: 019ed2a6-503e-77ab-9fae-ec77937aac1d/receipt-alpha.pdf, 019ed2a6-503e-77ab-9fae-ec77937aac1d/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -146,7 +146,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped SELECT and INSERT policies with matching path/owner checks, and provided supabase-js createSignedUrl code with an expiry."
+        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped SELECT and INSERT policies using the user-id path prefix, and provided supabase-js createSignedUrl code with an expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -174,12 +174,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with environment substitution instead of basic_auth.password_file, and docker-compose.yml does not mount/provide a password_file via a volume or Compose secret. The app scrape, HTTPS, metrics path, and project target are otherwise present."
+        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with an environment variable instead of password_file, and docker-compose.yml does not mount/provide that password_file via a volume or Compose secret. App job is preserved and endpoint/path/scheme are otherwise correct."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes creating a Secret API key, restarting the Compose stack, and verifying via Prometheus targets, but it does not require placing the matching secret file. It instead documents environment variables, which fails the rubric’s required secret-file setup."
+        "judgeNotes": "README explains endpoint/auth and creating a Secret API key, and includes basic verification by confirming the supabase target is UP. However it does not instruct placing a matching secret file, and deployment/restart steps are vague/not tied to reloading the Compose stack. It also relies on environment substitution without showing a concrete Compose-compatible setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -250,7 +250,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The assistant did add public.orders to supabase_realtime, but it misdiagnosed the issue as needing to create the publication rather than orders missing from the existing publication, and its final summary says it created supabase_realtime. It also did not clearly verify/preserve the existing courier_locations publication setup."
+        "judgeNotes": "Failed: the assistant diagnosed the publication as missing and attempted to create `supabase_realtime FOR ALL TABLES`, rather than identifying that only `orders` was missing from the existing publication and adding exactly that table. This risks altering the existing realtime setup instead of preserving courier_locations and other publication membership."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -274,17 +274,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Assistant identified image-transform as the main issue and described the recurring 503 pattern throughout the morning of 2026-04-28, listing most/all gateway failures from 07:00Z to 12:00Z."
+        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described intermittent/recurring 503s throughout the morning, aligning with the required pattern. It also avoided focusing on the old billing-webhook issue."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The assistant says the issue is likely not a permanent code bug, but attributes it to possible platform/runtime failures or upstream dependency inside transformImage and recommends inspecting/fixing function internals. It does not clearly attribute the 503s to the gateway/Edge Functions platform layer in front of the function, nor ground that layer attribution in observations like gateway-only logs with no invocation/runtime rows. Thus it fails the rubric."
+        "judgeNotes": "The assistant attributes the issue to the Edge Function path/upstream dependency and recommends inspecting function code/logs, rather than clearly identifying the gateway/platform layer in front of the function. It does not ground a platform-layer attribution in observations such as gateway-only 503s with no invocation/runtime rows, unchanged deployment_id, or distinction from function-level errors."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps, including checking Edge Function logs/metrics around exact 503 timestamps, inspecting upstream dependencies/timeouts, adding error/timeout logging, verifying external upstream failures, and adding bypass/retry mitigations."
+        "judgeNotes": "The assistant recommended specific actionable next steps, including checking Edge Function logs for a defined time window, inspecting dependencies, adding retry/backoff, and considering routing/fallback changes."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -335,7 +335,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all behavior and added authenticated SELECT and INSERT policies scoped to user_id = auth.uid(), without disabling RLS."
+        "judgeNotes": "Diagnosed RLS deny-all on bookmarks and added authenticated SELECT/INSERT owner-scoped policies with WITH CHECK while keeping RLS enabled."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -372,7 +372,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on idx_events_user_id_created_at_desc  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -481,7 +481,7 @@
       {
         "name": "REST API returns no todos to anonymous requests",
         "passed": true,
-        "notes": "0 rows"
+        "notes": "error 42501: permission denied for table todos"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
@@ -567,7 +567,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed199-b66c-7029-8b8f-be72e49d4858/receipt-alpha.pdf, 019ed199-b66c-7029-8b8f-be72e49d4858/receipt-beta.pdf"
+        "notes": "saw: 019ed2ab-2871-7376-befc-44c0f9548804/receipt-alpha.pdf, 019ed2ab-2871-7376-befc-44c0f9548804/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -588,7 +588,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "The answer creates a private user-files bucket, adds authenticated-only owner-scoped SELECT and INSERT policies on storage.objects with matching WITH CHECK for uploads, does not disable RLS or make the bucket public, and uses supabase-js createSignedUrl with an expiry for temporary sharing links."
+        "judgeNotes": "The answer creates the `user-files` bucket with `public = false`, defines authenticated-only INSERT and SELECT policies on `storage.objects` scoped to the bucket and owner/user folder, does not disable RLS, and uses `createSignedUrl` with an expiry for temporary sharing. It does not make the bucket public, use permissive policies, public roles, getPublicUrl, or service role client-side."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -616,12 +616,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape uses basic_auth.password instead of password_file, and docker-compose.yml does not mount/provide that password file via a volume or Compose secret. README also instructs placing the Secret API key directly in prometheus.yml. Existing app job is preserved and endpoint/scheme are correct, but secret wiring is not deployable per rubric."
+        "judgeNotes": "Supabase scrape preserves the app job and uses HTTPS with the correct metrics path and project target placeholder, but it fails the rubric because it uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount the password file via a volume or Compose secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README explains endpoint/auth and includes Prometheus target verification, but it does not require creating a Secret API key and placing it in a matching secret file. Instead it instructs users to edit prometheus.yml and put the secret directly in the config, which fails the required secret-file setup."
+        "judgeNotes": "README includes creating a Secret API key, restart steps, and some Prometheus verification, but it does not instruct placing a matching secret file as required. Secret setup is environment-variable based and not wired concretely in Compose, so it fails the required secret-file setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -692,7 +692,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The assistant did not fix the required cause. It claimed the project likely has no app tables / wrong project and asked for more information, rather than identifying and adding the orders table to the existing supabase_realtime publication. It also mentioned checking RLS/policies, which is not the required root cause/fix."
+        "judgeNotes": "The assistant incorrectly identified RLS policies as the root cause and recommended changing SELECT policy. It did not diagnose or fix the missing orders table in the supabase_realtime publication, and did not add orders to the existing publication."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -711,22 +711,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Assistant identified image-transform as the affected function and described recurring intermittent HTTP 503s throughout the morning of 2026-04-28, covering most of the gateway failures across roughly 07:00Z-12:00Z."
+        "judgeNotes": "The assistant identified image-transform as the affected function and described recurring intermittent HTTP 503 responses throughout the morning of 2026-04-28, including examples spanning 07:00 onward and noting the pattern continued until late morning. It did not incorrectly center the old billing-webhook issue."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": true,
-        "judgeNotes": "The assistant attributes the intermittent 503s to the function gateway/routing layer before the function runs, not the application code. This is grounded in the observation that HTTP/gateway logs show 503s while Edge Function execution logs only show successful 200 executions with no corresponding failed image-transform invocations. It also distinguishes this from code-thrown errors. Minor note: it suggests redeploying only to rule out deployment/version, but the main attribution and next step are gateway/platform incident/support, so it passes."
+        "passed": false,
+        "judgeNotes": "The assistant partially attributes the 503s to the gateway/API log surface and notes successful edge-function logs, but then describes it as a transient Edge runtime/upstream issue and recommends redeploying the function, which the rubric explicitly says should fail. The grounding is also weak: it says detailed failure traces are needed rather than clearly concluding no invocation/runtime rows correspond to the 503s."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including checking recent redeploy/config changes, redeploying the Edge Function, adding retries, inspecting the integration path, and opening/verifying a gateway incident for the timeframe."
+        "judgeNotes": "The assistant recommended specific actionable next steps: inspect Edge Function failure traces/request details, redeploy the function, add 503 retries, and check deployment/version changes and traffic correlation."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -777,7 +777,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all due to no policies and created authenticated owner-scoped SELECT and INSERT policies using user_id = auth.uid() / WITH CHECK, without disabling RLS. Extra UPDATE/DELETE policies do not violate the rubric."
+        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all Data API results, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() while keeping RLS enabled. Extra update/delete owner-scoped policies do not violate the rubric."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -797,11 +797,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -4,9 +4,8 @@
     "eval": "build-cli-001-bootstrap-app",
     "stage": "build",
     "product": [
-      "cli",
       "database",
-      "data api"
+      "data-api"
     ],
     "topic": [
       "migrations",
@@ -40,7 +39,7 @@
       {
         "name": "REST API returns no todos to anonymous requests",
         "passed": true,
-        "notes": "error 42501: permission denied for table todos"
+        "notes": "0 rows"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
@@ -58,16 +57,14 @@
     "eval": "build-functions-004-service-role-bypass",
     "stage": "build",
     "product": [
-      "functions",
+      "edge-functions",
       "auth",
-      "database",
-      "sdk"
+      "database"
     ],
     "topic": [
-      "edge-functions",
       "rls",
       "security",
-      "supabase-js"
+      "sdk"
     ],
     "suite": "benchmark",
     "passed": false,
@@ -128,7 +125,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed06e-6f72-716f-8153-2defae4da0a1/receipt-alpha.pdf, 019ed06e-6f72-716f-8153-2defae4da0a1/receipt-beta.pdf"
+        "notes": "saw: 019ed199-b3c1-765b-a6e3-831e9e013041/receipt-alpha.pdf, 019ed199-b3c1-765b-a6e3-831e9e013041/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -149,7 +146,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configures a private user-files bucket, owner-scoped authenticated INSERT and SELECT policies on storage.objects, does not disable RLS, and uses createSignedUrl with an expiry for temporary sharing."
+        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped SELECT and INSERT policies with matching path/owner checks, and provided supabase-js createSignedUrl code with an expiry."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -177,12 +174,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails because the Supabase target is a placeholder (YOUR_PROJECT_REF.supabase.co:443), not an actual deployable Supabase project target. HTTPS, metrics path, basic_auth password_file, app scrape preservation, and secret volume mount are otherwise present."
+        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with environment substitution instead of basic_auth.password_file, and docker-compose.yml does not mount/provide a password_file via a volume or Compose secret. The app scrape, HTTPS, metrics path, and project target are otherwise present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README covers the Supabase Secret API key and secret file path, and includes a concrete curl verification. However it does not provide a concrete restart/reload of the Compose stack after configuring the secret/ref; it only says “Restart Prometheus,” which does not satisfy the required Compose stack restart/reload step."
+        "judgeNotes": "README includes creating a Secret API key, restarting the Compose stack, and verifying via Prometheus targets, but it does not require placing the matching secret file. It instead documents environment variables, which fails the rubric’s required secret-file setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -253,7 +250,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The assistant identified the likely publication issue, but failed the required fix by dropping and recreating `supabase_realtime` as `FOR ALL TABLES`. The rubric explicitly requires adding only `orders` to the existing publication and preserving existing publication contents; recreating it for all tables is a fail condition."
+        "judgeNotes": "The assistant did add public.orders to supabase_realtime, but it misdiagnosed the issue as needing to create the publication rather than orders missing from the existing publication, and its final summary says it created supabase_realtime. It also did not clearly verify/preserve the existing courier_locations publication setup."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -266,12 +263,10 @@
     "eval": "investigate-reliability-003-edge-function-5xx-correlation",
     "stage": "investigate",
     "product": [
-      "functions"
+      "edge-functions"
     ],
     "topic": [
-      "reliability",
-      "observability",
-      "logs"
+      "observability"
     ],
     "suite": "benchmark",
     "passed": false,
@@ -279,17 +274,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Assistant identified image-transform as affected and described repeated/intermittent 503s through the morning with 200s in between, satisfying the recurring pattern requirement. It did not mention the exact count/time span, but covered the main issue sufficiently."
+        "judgeNotes": "Assistant identified image-transform as the main issue and described the recurring 503 pattern throughout the morning of 2026-04-28, listing most/all gateway failures from 07:00Z to 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The assistant attributes the 503s to intermittent Edge Function failures and likely package/upstream dependency/function code behavior, and recommends inspecting/fixing function implementation with retries. It does not identify the gateway/platform layer as the source, nor ground that attribution in observations like missing invocation/runtime rows or unchanged deployment_id."
+        "judgeNotes": "The assistant says the issue is likely not a permanent code bug, but attributes it to possible platform/runtime failures or upstream dependency inside transformImage and recommends inspecting/fixing function internals. It does not clearly attribute the 503s to the gateway/Edge Functions platform layer in front of the function, nor ground that layer attribution in observations like gateway-only logs with no invocation/runtime rows. Thus it fails the rubric."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: inspect the Edge Function/dependency implementation, add retries and better error handling, check external dependency health, and add a fallback path for transient 503/500 failures."
+        "judgeNotes": "The assistant recommended specific actionable next steps, including checking Edge Function logs/metrics around exact 503 timestamps, inspecting upstream dependencies/timeouts, adding error/timeout logging, verifying external upstream failures, and adding bypass/retry mitigations."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -302,7 +297,7 @@
     "eval": "resolve-dataapi-001-empty-results",
     "stage": "resolve",
     "product": [
-      "data api",
+      "data-api",
       "database",
       "auth"
     ],
@@ -340,7 +335,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed RLS deny-all due to no policies, added authenticated SELECT and INSERT owner-scoped policies using auth.uid(), and kept RLS enabled."
+        "judgeNotes": "Diagnosed RLS deny-all behavior and added authenticated SELECT and INSERT policies scoped to user_id = auth.uid(), without disabling RLS."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -451,9 +446,8 @@
     "eval": "build-cli-001-bootstrap-app",
     "stage": "build",
     "product": [
-      "cli",
       "database",
-      "data api"
+      "data-api"
     ],
     "topic": [
       "migrations",
@@ -474,7 +468,7 @@
       {
         "name": "todos table exists with at least 2 seeded rows",
         "passed": true,
-        "notes": "found 3 rows"
+        "notes": "found 2 rows"
       },
       {
         "name": "row level security is enabled on todos",
@@ -492,7 +486,7 @@
       {
         "name": "REST API returns the todos to authenticated requests",
         "passed": true,
-        "notes": "3 rows"
+        "notes": "2 rows"
       }
     ],
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
@@ -505,16 +499,14 @@
     "eval": "build-functions-004-service-role-bypass",
     "stage": "build",
     "product": [
-      "functions",
+      "edge-functions",
       "auth",
-      "database",
-      "sdk"
+      "database"
     ],
     "topic": [
-      "edge-functions",
       "rls",
       "security",
-      "supabase-js"
+      "sdk"
     ],
     "suite": "benchmark",
     "passed": true,
@@ -575,7 +567,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed070-290a-723e-ac04-7788bf4e3535/receipt-alpha.pdf, 019ed070-290a-723e-ac04-7788bf4e3535/receipt-beta.pdf"
+        "notes": "saw: 019ed199-b66c-7029-8b8f-be72e49d4858/receipt-alpha.pdf, 019ed199-b66c-7029-8b8f-be72e49d4858/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -596,7 +588,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configures a private user-files bucket, owner-scoped SELECT and INSERT storage.objects policies for authenticated users, does not disable RLS or make public, and uses createSignedUrl with an expiry for temporary sharing links."
+        "judgeNotes": "The answer creates a private user-files bucket, adds authenticated-only owner-scoped SELECT and INSERT policies on storage.objects with matching WITH CHECK for uploads, does not disable RLS or make the bucket public, and uses supabase-js createSignedUrl with an expiry for temporary sharing links."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -624,12 +616,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "prometheus.yml only preserves the existing app scrape and does not add a Supabase Metrics API scrape with HTTPS /customer/v1/privileged/metrics, Basic Auth password_file, or project target. docker-compose.yml also does not mount any password_file or secret."
+        "judgeNotes": "Supabase scrape uses basic_auth.password instead of password_file, and docker-compose.yml does not mount/provide that password file via a volume or Compose secret. README also instructs placing the Secret API key directly in prometheus.yml. Existing app job is preserved and endpoint/scheme are correct, but secret wiring is not deployable per rubric."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README.md does not include required steps to create a Secret API key, place the matching secret file, restart/reload the Compose stack, or verify the integration via Prometheus targets/PromQL/Grafana. It only documents starting the local stack and current app target."
+        "judgeNotes": "README explains endpoint/auth and includes Prometheus target verification, but it does not require creating a Secret API key and placing it in a matching secret file. Instead it instructs users to edit prometheus.yml and put the secret directly in the config, which fails the required secret-file setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -700,7 +692,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The answer does not diagnose the root cause exactly as orders missing from the supabase_realtime publication. It blames other causes (primary key/client filtering), recommends dropping and recreating the publication which could remove existing courier_locations, and does not preserve the existing publication state."
+        "judgeNotes": "The assistant did not fix the required cause. It claimed the project likely has no app tables / wrong project and asked for more information, rather than identifying and adding the orders table to the existing supabase_realtime publication. It also mentioned checking RLS/policies, which is not the required root cause/fix."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -713,30 +705,28 @@
     "eval": "investigate-reliability-003-edge-function-5xx-correlation",
     "stage": "investigate",
     "product": [
-      "functions"
+      "edge-functions"
     ],
     "topic": [
-      "reliability",
-      "observability",
-      "logs"
+      "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as the affected function and described recurring intermittent HTTP 503 responses throughout the morning of 2026-04-28, with examples spanning 07:00Z through 12:00Z and most of the gateway failures."
+        "judgeNotes": "Assistant identified image-transform as the affected function and described recurring intermittent HTTP 503s throughout the morning of 2026-04-28, covering most of the gateway failures across roughly 07:00Z-12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The response does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function. It frames the cause as gateway/runtime and even possible upstream dependency inside the function, then recommends inspecting code and redeploying the function, which the rubric explicitly treats as failing remediation."
+        "passed": true,
+        "judgeNotes": "The assistant attributes the intermittent 503s to the function gateway/routing layer before the function runs, not the application code. This is grounded in the observation that HTTP/gateway logs show 503s while Edge Function execution logs only show successful 200 executions with no corresponding failed image-transform invocations. It also distinguishes this from code-thrown errors. Minor note: it suggests redeploying only to rule out deployment/version, but the main attribution and next step are gateway/platform incident/support, so it passes."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete actionable next steps: inspect the Edge Function code for external calls/timeouts, redeploy the function, add client retries for 503s, and check for memory-heavy processing/runtime instability."
+        "judgeNotes": "The assistant recommended concrete next steps, including checking recent redeploy/config changes, redeploying the Edge Function, adding retries, inspecting the integration path, and opening/verifying a gateway incident for the timeframe."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -749,7 +739,7 @@
     "eval": "resolve-dataapi-001-empty-results",
     "stage": "resolve",
     "product": [
-      "data api",
+      "data-api",
       "database",
       "auth"
     ],
@@ -787,7 +777,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The answer correctly diagnosed RLS enabled with no policies causing deny-all Data API results, kept RLS enabled, and created owner-scoped SELECT and INSERT policies for the authenticated role using user_id = auth.uid(), with INSERT enforced via WITH CHECK. Extra UPDATE/DELETE owner policies do not violate the rubric."
+        "judgeNotes": "Diagnosed RLS deny-all due to no policies and created authenticated owner-scoped SELECT and INSERT policies using user_id = auth.uid() / WITH CHECK, without disabling RLS. Extra UPDATE/DELETE policies do not violate the rubric."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -807,11 +797,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -824,7 +814,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,11 +32,19 @@ import {
 } from "@supabase-evals/platform-lite";
 import type { CheckResult } from "./eval-metadata.js";
 
-const EXECUTOR_BIN = join(
-  dirname(fileURLToPath(import.meta.resolve("executor/package.json"))),
-  "bin",
-  "executor"
-);
+// Resolved lazily on first use, not at module load: `import.meta.resolve` is a
+// load-time side effect that throws under bundler SSR transforms (e.g. vitest),
+// which would break every importer of this module — including ones that never
+// invoke the executor (the sandbox runtime only imports `docsMcpServer`).
+let executorBinPath: string | undefined;
+function getExecutorBin(): string {
+  executorBinPath ??= join(
+    dirname(fileURLToPath(import.meta.resolve("executor/package.json"))),
+    "bin",
+    "executor"
+  );
+  return executorBinPath;
+}
 const execFileAsync = promisify(execFile);
 
 export type { SupabaseClient };
@@ -730,7 +738,7 @@ export function executorMcpServer(): McpServerDefinition {
       return {
         config: {
           command: process.execPath,
-          args: [EXECUTOR_BIN, "mcp", "--scope", scopeDir],
+          args: [getExecutorBin(), "mcp", "--scope", scopeDir],
           env: { EXECUTOR_DATA_DIR: dataDir },
         },
         cleanup: async () => {
@@ -761,7 +769,7 @@ async function addExecutorOpenApiSource(input: {
   const { stdout } = await execFileAsync(
     process.execPath,
     [
-      EXECUTOR_BIN,
+      getExecutorBin(),
       "call",
       "executor",
       "openapi",
@@ -781,7 +789,7 @@ async function addExecutorOpenApiSource(input: {
   await execFileAsync(
     process.execPath,
     [
-      EXECUTOR_BIN,
+      getExecutorBin(),
       "resume",
       "--execution-id",
       executionId,
@@ -807,7 +815,7 @@ async function cleanupExecutorResources(input: {
   try {
     await execFileAsync(
       process.execPath,
-      [EXECUTOR_BIN, "daemon", "stop", "--base-url", input.daemonUrl],
+      [getExecutorBin(), "daemon", "stop", "--base-url", input.daemonUrl],
       { env: executorEnv(input.dataDir) }
     );
   } catch (err) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,6 +289,12 @@ export type LocalStackSessionArgs = {
  */
 export type LocalStackSession = {
   tools: ToolSet;
+  /**
+   * MCP servers to expose to the agent alongside the sandbox tools (e.g. the
+   * docs server for `search_docs`). Spawned host-side; merged with `tools` by
+   * the agent harness.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
   promptAddendum?: string;
   scoringContext: LocalStackScoringContext;
   /**
@@ -663,6 +669,34 @@ export function supabaseMcpServer(
         },
       };
     },
+  };
+}
+
+/**
+ * A Supabase MCP server limited to the `docs` feature group — i.e. the
+ * `search_docs` tool, which queries the public Supabase docs GraphQL API
+ * (https://supabase.com/docs/api/graphql) and needs no project, api-url, or
+ * platform connection. Returns a ready-to-run config (no platform-lite
+ * context), so the local-stack runtime can give CLI/sandbox evals the one
+ * capability they otherwise lack: documentation search (the custom harness has
+ * no web tools).
+ */
+export function docsMcpServer(
+  options: { version?: string } = {},
+): McpServerConfig {
+  const version = options.version ?? MCP_SERVER_VERSION;
+  return {
+    command: "npx",
+    args: [
+      `@supabase/mcp-server-supabase@${version}`,
+      "--features",
+      "docs",
+      // The server refuses to boot without a token, but with only `docs`
+      // enabled it never authenticates against the management API, so a
+      // well-formed throwaway token is enough.
+      "--access-token",
+      `sbp_${"0".repeat(40)}`,
+    ],
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,7 +35,7 @@ import type { CheckResult } from "./eval-metadata.js";
 // Resolved lazily on first use, not at module load: `import.meta.resolve` is a
 // load-time side effect that throws under bundler SSR transforms (e.g. vitest),
 // which would break every importer of this module — including ones that never
-// invoke the executor (the sandbox runtime only imports `docsMcpServer`).
+// invoke the executor (the sandbox runtime only imports `supabaseMcpServer`).
 let executorBinPath: string | undefined;
 function getExecutorBin(): string {
   executorBinPath ??= join(
@@ -533,8 +533,10 @@ export type EvalSession = {
 };
 
 export type PlatformLiteMcpContext = {
-  apiUrl: string;
-  accessToken: string;
+  // Both optional: a docs-only Supabase MCP server is platform-independent, so
+  // it needs neither a project api-url nor a real token.
+  apiUrl?: string;
+  accessToken?: string;
 };
 
 export type McpServerConfig = {
@@ -556,7 +558,7 @@ type McpClientHandle = {
 export type McpServerDefinition = {
   name: string;
   promptAddendum?: string;
-  createConfig(context: PlatformLiteMcpContext): Promise<ResolvedMcpServer>;
+  createConfig(context?: PlatformLiteMcpContext): Promise<ResolvedMcpServer>;
 };
 
 export function platformLiteRuntime(options: {
@@ -661,50 +663,23 @@ export function supabaseMcpServer(
 
   return {
     name: "supabase-mcp",
-    async createConfig({ apiUrl, accessToken }) {
-      return {
-        config: {
-          command: "npx",
-          args: [
-            `@supabase/mcp-server-supabase@${version}`,
-            "--access-token",
-            accessToken,
-            "--api-url",
-            apiUrl,
-            "--features",
-            features.join(","),
-          ],
-        },
-      };
+    async createConfig({ apiUrl, accessToken } = {}) {
+      const args = [
+        `@supabase/mcp-server-supabase@${version}`,
+        // The server refuses to boot without a token; with only platform-
+        // independent features (docs) it never authenticates against the
+        // management API, so a well-formed throwaway is enough.
+        "--access-token",
+        accessToken ?? THROWAWAY_ACCESS_TOKEN,
+        "--features",
+        features.join(","),
+      ];
+      // Only point the server at a platform when one is given. `docs` is
+      // platform-independent (it queries the public docs GraphQL API), so a
+      // docs-only server runs standalone with no `--api-url`.
+      if (apiUrl) args.push("--api-url", apiUrl);
+      return { config: { command: "npx", args } };
     },
-  };
-}
-
-/**
- * A Supabase MCP server limited to the `docs` feature group — i.e. the
- * `search_docs` tool, which queries the public Supabase docs GraphQL API
- * (https://supabase.com/docs/api/graphql) and needs no project, api-url, or
- * platform connection. Returns a ready-to-run config (no platform-lite
- * context), so the local-stack runtime can give CLI/sandbox evals the one
- * capability they otherwise lack: documentation search (the custom harness has
- * no web tools).
- */
-export function docsMcpServer(
-  options: { version?: string } = {},
-): McpServerConfig {
-  const version = options.version ?? MCP_SERVER_VERSION;
-  return {
-    command: "npx",
-    args: [
-      `@supabase/mcp-server-supabase@${version}`,
-      "--features",
-      "docs",
-      // The server refuses to boot without a token, but with only `docs`
-      // enabled it never authenticates against the management API, so a
-      // well-formed throwaway token is enough.
-      "--access-token",
-      `sbp_${"0".repeat(40)}`,
-    ],
   };
 }
 
@@ -713,7 +688,15 @@ export function executorMcpServer(): McpServerDefinition {
     name: "executor-mcp",
     promptAddendum:
       "When execute returns a paused result containing an executionId, immediately call resume with that executionId and action=accept.",
-    async createConfig({ apiUrl, accessToken }) {
+    async createConfig({ apiUrl, accessToken } = {}) {
+      // Unlike the docs-only Supabase MCP, the executor proxies the platform's
+      // OpenAPI, so it genuinely needs both — fail fast rather than register a
+      // broken source.
+      if (!apiUrl || !accessToken) {
+        throw new Error(
+          "executor MCP requires a platform context (apiUrl + accessToken)",
+        );
+      }
       const scopeDir = mkdtempSync(join(tmpdir(), "eval-executor-scope-"));
       const dataDir = mkdtempSync(join(tmpdir(), "eval-executor-data-"));
       // Keep source registration isolated from any user daemon already listening on 4788.
@@ -862,6 +845,9 @@ async function getAvailablePort(): Promise<number> {
 
 export const ACCESS_TOKEN = "eval-token";
 export const MCP_SERVER_VERSION = "0.8.1";
+// Well-formed but inert PAT used when a Supabase MCP server is docs-only: the
+// server requires a token to boot but never authenticates without a platform.
+const THROWAWAY_ACCESS_TOKEN = `sbp_${"0".repeat(40)}`;
 
 export interface PlatformBackend {
   url: string;

--- a/packages/sandbox/src/local-stack-runtime.ts
+++ b/packages/sandbox/src/local-stack-runtime.ts
@@ -1,9 +1,11 @@
 import { posix } from "node:path";
 import { jsonSchema, tool, type ToolSet } from "ai";
 import { createClient } from "@supabase/supabase-js";
-import type {
-  LocalStackRuntime,
-  LocalStackScoringContext,
+import {
+  docsMcpServer,
+  type LocalStackRuntime,
+  type LocalStackScoringContext,
+  type McpServerConfig,
 } from "@supabase-evals/core";
 import { DockerSandbox } from "./docker-sandbox.js";
 import {
@@ -33,11 +35,20 @@ const MAX_TOOL_OUTPUT_CHARS = 16_000;
 export interface LocalStackRuntimeOptions {
   /** Supabase CLI version baked into the sandbox image (pinned default). */
   cliVersion?: string;
+  /**
+   * MCP servers exposed to the agent alongside the sandbox tools, keyed by
+   * name. Defaults to a docs-only Supabase MCP server so the agent can
+   * `search_docs` (the sandbox has no web tools). Pass `{}` to disable, or add
+   * more servers. These run host-side; they do not connect to the sandbox.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
 }
 
 export function localStackRuntime(
   options: LocalStackRuntimeOptions = {},
 ): LocalStackRuntime {
+  const mcpServers = options.mcpServers ?? { "supabase-docs": docsMcpServer() };
+  const hasMcpServers = Object.keys(mcpServers).length > 0;
   return {
     id: "local-stack",
     async startSession({ localDir, includeServices, projectRunning }) {
@@ -65,11 +76,15 @@ export function localStackRuntime(
 
       return {
         tools: buildLocalStackTools(sandbox),
+        mcpServers,
         promptAddendum:
           "The Supabase CLI (`supabase`), docker, psql, git, and curl are installed in the workspace. " +
           "Use the bash tool to run commands (the working directory is always the workspace root) " +
           "and the files tools to inspect and modify files. " +
-          "Services started with `supabase start` are reachable on their default 127.0.0.1 ports.",
+          "Services started with `supabase start` are reachable on their default 127.0.0.1 ports." +
+          (hasMcpServers
+            ? " Use the `search_docs` tool to look up Supabase documentation."
+            : ""),
         scoringContext: buildLocalStackScoringContext(sandbox),
         exportWorkspace: (hostDir: string) => sandbox.copyToHost(hostDir),
         close: async () => {

--- a/packages/sandbox/src/local-stack-runtime.ts
+++ b/packages/sandbox/src/local-stack-runtime.ts
@@ -48,7 +48,6 @@ export function localStackRuntime(
   options: LocalStackRuntimeOptions = {},
 ): LocalStackRuntime {
   const mcpServers = options.mcpServers ?? { "supabase-docs": docsMcpServer() };
-  const hasMcpServers = Object.keys(mcpServers).length > 0;
   return {
     id: "local-stack",
     async startSession({ localDir, includeServices, projectRunning }) {
@@ -81,10 +80,7 @@ export function localStackRuntime(
           "The Supabase CLI (`supabase`), docker, psql, git, and curl are installed in the workspace. " +
           "Use the bash tool to run commands (the working directory is always the workspace root) " +
           "and the files tools to inspect and modify files. " +
-          "Services started with `supabase start` are reachable on their default 127.0.0.1 ports." +
-          (hasMcpServers
-            ? " Use the `search_docs` tool to look up Supabase documentation."
-            : ""),
+          "Services started with `supabase start` are reachable on their default 127.0.0.1 ports.",
         scoringContext: buildLocalStackScoringContext(sandbox),
         exportWorkspace: (hostDir: string) => sandbox.copyToHost(hostDir),
         close: async () => {

--- a/packages/sandbox/src/local-stack-runtime.ts
+++ b/packages/sandbox/src/local-stack-runtime.ts
@@ -2,7 +2,7 @@ import { posix } from "node:path";
 import { jsonSchema, tool, type ToolSet } from "ai";
 import { createClient } from "@supabase/supabase-js";
 import {
-  docsMcpServer,
+  supabaseMcpServer,
   type LocalStackRuntime,
   type LocalStackScoringContext,
   type McpServerConfig,
@@ -47,10 +47,19 @@ export interface LocalStackRuntimeOptions {
 export function localStackRuntime(
   options: LocalStackRuntimeOptions = {},
 ): LocalStackRuntime {
-  const mcpServers = options.mcpServers ?? { "supabase-docs": docsMcpServer() };
   return {
     id: "local-stack",
     async startSession({ localDir, includeServices, projectRunning }) {
+      // Default to a docs-only Supabase MCP server (no platform context needed —
+      // `docs` is platform-independent), so the agent can `search_docs` even
+      // though the sandbox has no web tools.
+      const mcpServers =
+        options.mcpServers ??
+        {
+          "supabase-docs": (
+            await supabaseMcpServer({ features: ["docs"] }).createConfig()
+          ).config,
+        };
       const image = await ensureSupabaseSandboxImage(options.cliVersion);
       const sandbox = await DockerSandbox.create({
         image,


### PR DESCRIPTION
Gives local-stack (sandbox/CLI) evals access to the Supabase MCP `search_docs` tool. `localStackRuntime()` now starts a docs-only Supabase MCP server (`--features docs`) host-side and the runner merges it with the sandbox tools, so the agent can search docs even when the stack isn't running (e.g. the prometheus eval).

**Test:**
```
pnpm eval --experiment=openai-gpt-5.4-mini --eval=deploy-database-001-prometheus-metrics --force
```
