### PR TITLE
feat(benchmark): add RLS tenant isolation eval

### DIFF
--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -39,7 +39,7 @@
       {
         "name": "REST API returns no todos to anonymous requests",
         "passed": true,
-        "notes": "error 42501: permission denied for table todos"
+        "notes": "0 rows"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
@@ -67,7 +67,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -83,11 +83,11 @@
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": false
+        "passed": true
       }
     ],
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
@@ -125,7 +125,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed766-5754-73dc-b4c8-313dfff345d3/receipt-alpha.pdf, 019ed766-5754-73dc-b4c8-313dfff345d3/receipt-beta.pdf"
+        "notes": "saw: 019ed773-943e-7699-a6a0-5b3c007563d1/receipt-alpha.pdf, 019ed773-943e-7699-a6a0-5b3c007563d1/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -146,7 +146,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configures a private user-files bucket, keeps RLS enabled, adds authenticated owner-scoped SELECT and INSERT policies on storage.objects using the first path segment as auth.uid(), and provides supabase-js createSignedUrl code with an expiry for temporary sharing."
+        "judgeNotes": "Configured a private user-files bucket, kept/enabled RLS on storage.objects, added authenticated owner-scoped SELECT and INSERT policies using the user id path prefix, and provided supabase-js createSignedUrl code with an expiry."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -167,30 +167,30 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/database/tenant_isolation.test.sql"
+        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
       },
       {
         "name": "positive isolation tests pass (notes table)",
         "passed": true,
-        "notes": "4 passed, 2 failed"
+        "notes": "4 passed, 0 failed"
       },
       {
         "name": "negative isolation tests catch the bug in posts table",
-        "passed": true,
-        "notes": "4 passed, 2 failed"
+        "passed": false,
+        "notes": "all tests passed — negative case not covered or policy was not tested"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified that the posts table has broken tenant isolation for authenticated members reading cross-org posts, tied this to the pgTAP failures, and did not blame notes or dismiss the tests."
+        "judgeNotes": "The agent correctly identified the broken tenant isolation policy on `posts`, specifically cross-org reads by authenticated members, and treated the pgTAP tests/results as authoritative. It did not blame `notes` or dismiss the failures."
       }
     ],
-    "prompt": "Can you write some database tests to verify the tenant isolation is working? Cover both the happy path and the negative case, run them, and share what you find.",
+    "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-mini/build-tests-001-rls-tenant-isolation.json"
@@ -215,12 +215,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Prometheus uses basic_auth.password with an expanded SUPABASE_SECRET_API_KEY instead of password_file, and docker-compose does not mount a password_file via volume or Compose secret. Secret API key is wired through environment/config expansion. App scrape is preserved and endpoint/scheme are otherwise correct."
+        "judgeNotes": "Fails: Supabase scrape is not added to observability/prometheus.yml, and the Compose-generated scrape uses basic_auth.password with an env Secret API key instead of basic_auth.password_file. docker-compose.yml does not mount the password_file via a volume or Compose secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes Secret API key creation and Prometheus target verification, but it does not instruct placing the matching secret file and does not clearly restart/reload the Compose stack. It uses env vars instead, so the required secret setup is mismatched."
+        "judgeNotes": "README mentions needing a Supabase Secret API key and .env, but does not give concrete steps to create the key, place the matching secret file/value, restart or reload the Compose stack after changes, or verify the integration via Prometheus targets/PromQL/Grafana. Verification is insufficient."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -277,7 +277,7 @@
       },
       {
         "name": "publication still publishes INSERT events",
-        "passed": false
+        "passed": true
       },
       {
         "name": "RLS still enabled on orders",
@@ -291,7 +291,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The assistant did not fix the issue by adding the existing orders table to the supabase_realtime publication. It claimed there was no orders table and made no corrective change. This does not satisfy the rubric."
+        "judgeNotes": "The assistant did not identify/fix the specific issue as orders missing from the existing supabase_realtime publication. It created a publication for the public schema instead, claimed there was no public.orders table, and did not use ALTER PUBLICATION supabase_realtime ADD TABLE orders or preserve the existing publication membership exactly."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -310,22 +310,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant named image-transform as the affected function and described intermittent 503s throughout the morning of 2026-04-28, including the recurring pattern around :00 and :30. It did not focus on old billing-webhook errors and provided concrete next steps."
+        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described recurring HTTP 503 gateway responses throughout the morning of 2026-04-28, including the intermittent pattern and noting other issues were isolated."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The response does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function. It instead frames the likely cause as Edge Function runtime/platform startup or imported package initialization and recommends function/package debugging, which conflicts with the required gateway-layer attribution."
+        "passed": true,
+        "judgeNotes": "The assistant attributes the recurring 503s to gateway/routing/platform instability in front of image-transform rather than function code, and grounds this in observations including gateway 503s, nearby successful function executions, function health when reached, unchanged version reference, and distinction from an isolated avatar-upload 500."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps: checking Edge Function boot/runtime errors around the 503 timestamps, verifying the imported package loads correctly in Edge Functions, adding retry/fallback behavior, and opening a Supabase support ticket with timestamps and function name if platform-side failures are confirmed."
+        "judgeNotes": "The assistant recommended concrete next steps: inspect deployment/infra around timestamps, open a Supabase support ticket with 503 timestamps and function id, and consider bypassing transformations as mitigation."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -376,7 +376,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed deny-all RLS on bookmarks, kept RLS enabled, and added authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed deny-all RLS with no policies and added authenticated SELECT and INSERT owner-scoped policies using auth.uid() = user_id / WITH CHECK, without disabling RLS."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -396,11 +396,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -413,7 +413,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -608,7 +608,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed767-0729-7119-83ea-f17a33cc2a97/receipt-alpha.pdf, 019ed767-0729-7119-83ea-f17a33cc2a97/receipt-beta.pdf"
+        "notes": "saw: 019ed774-6dc2-773b-a9b2-34cfa84d5d83/receipt-alpha.pdf, 019ed774-6dc2-773b-a9b2-34cfa84d5d83/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -629,7 +629,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, owner-scoped storage.objects INSERT and SELECT policies using the user-id path prefix, did not disable RLS, and provided supabase-js createSignedUrl code with an expiry for temporary sharing. Service role usage was server-side only, not client-side."
+        "judgeNotes": "Meets requirements: private user-files bucket, RLS enabled, owner-scoped SELECT and INSERT WITH CHECK policies on storage.objects for the bucket, and supabase-js createSignedUrl with expiry. No public bucket, permissive public policies, getPublicUrl, or client service role usage."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -650,30 +650,30 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": false,
-        "notes": "no .sql files found under supabase/tests/"
+        "passed": true,
+        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
       },
       {
         "name": "positive isolation tests pass (notes table)",
-        "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+        "passed": true,
+        "notes": "2 passed, 2 failed"
       },
       {
         "name": "negative isolation tests catch the bug in posts table",
-        "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+        "passed": true,
+        "notes": "2 passed, 2 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the table with broken tenant isolation, specifically that an authenticated member (`u1`) can read posts from an organization they are not a member of. It attributes the finding to the negative test failure and does not blame `notes` or dismiss the test results."
+        "judgeNotes": "The agent correctly identifies `posts` as the table with broken tenant isolation, explains that authenticated users can see posts across organizations, and ties this directly to the failing pgTAP tests while treating the test results as authoritative."
       }
     ],
-    "prompt": "Can you write some database tests to verify the tenant isolation is working? Cover both the happy path and the negative case, run them, and share what you find.",
+    "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-nano/build-tests-001-rls-tenant-isolation.json"
@@ -698,12 +698,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape is only a commented template, not deployable. It uses inline password instead of basic_auth.password_file, and docker-compose.yml does not mount/provide any password_file via volume or Compose secret. App scrape is preserved, but required secret wiring is missing."
+        "judgeNotes": "Supabase scrape is commented out/not deployable, uses password instead of password_file, relies on env var interpolation, and docker-compose.yml does not mount the password_file via a volume or Compose secret. The app scrape is preserved, but required secret wiring is missing."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README explains endpoint/auth, creating a Secret API key, restarting Prometheus, and basic verification. However it does not require placing the matching secret file or configure Compose/Prometheus to consume one; instead it implies editing the secret into prometheus.yml. This fails the required secret-file setup."
+        "judgeNotes": "README mentions creating a Supabase Secret API key and restarting Prometheus via Compose, but it does not require placing a matching secret file or wiring Docker Compose secrets/env accordingly. The compose file also does not pass the referenced environment variables to Prometheus. Verification is present but somewhat vague; the missing/mismatched secret setup is sufficient to fail."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -774,7 +774,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The assistant did not identify or fix the missing orders table in the supabase_realtime publication. It instead concluded the orders table did not exist / project mismatch and mentioned RLS as a possible blocker, with no ALTER PUBLICATION fix."
+        "judgeNotes": "The assistant blamed the client subscription schema as the root cause and only suggested client-side changes. It did not identify or fix the missing orders table in the supabase_realtime publication."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -798,17 +798,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified `image-transform` as the affected Edge Function and described the recurring HTTP 503 pattern throughout the morning of 2026-04-28, listing all 8 failures from 07:00Z through 12:00Z."
+        "judgeNotes": "Identified image-transform as the affected function and described a recurring intermittent HTTP 503 pattern across the morning of 2026-04-28, covering representative failures from ~07:00Z through 12:00Z. Also noted an avatar-upload 500, but did not make it the main issue."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The assistant attributes the 503s to the image-transform Edge Function/runtime/dependency and recommends inspecting/redeploying/rolling back the function. It does not identify the gateway/platform layer as the source, nor ground that attribution in missing invocation/runtime rows or unchanged deployment_id."
+        "judgeNotes": "The assistant partially notes that the api/gateway returned 503 and that edge-function logs lack corresponding stack traces, but ultimately attributes the cause to the image-transform Edge Function being intermittently unavailable and recommends pulling function logs/checking function code, concurrency, deployments, and integration. It does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function, so it fails the rubric."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps, including inspecting Edge Function error details for the 503 timestamps, adding retries, redeploying/rolling back the image-transform function, and checking dependency/downstream service health."
+        "judgeNotes": "The assistant recommended concrete next steps, including focused Edge Function log investigation around failing timestamps, checking runtime/concurrency/deployment changes, validating routing/integration, and adding retries."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -859,7 +859,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed missing RLS policies on an RLS-enabled bookmarks table and added authenticated SELECT and INSERT policies scoped to user_id = auth.uid(), keeping RLS enabled."
+        "judgeNotes": "Diagnosed deny-all RLS with no policies and added authenticated owner-scoped SELECT and INSERT policies using user_id = auth.uid(), while keeping RLS enabled. Extra UPDATE/DELETE owner policies do not violate the rubric."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -879,11 +879,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -39,7 +39,7 @@
       {
         "name": "REST API returns no todos to anonymous requests",
         "passed": true,
-        "notes": "0 rows"
+        "notes": "error 42501: permission denied for table todos"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
@@ -125,7 +125,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed2a6-503e-77ab-9fae-ec77937aac1d/receipt-alpha.pdf, 019ed2a6-503e-77ab-9fae-ec77937aac1d/receipt-beta.pdf"
+        "notes": "saw: 019ed766-5754-73dc-b4c8-313dfff345d3/receipt-alpha.pdf, 019ed766-5754-73dc-b4c8-313dfff345d3/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -146,13 +146,54 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped SELECT and INSERT policies using the user-id path prefix, and provided supabase-js createSignedUrl code with an expiry for temporary sharing."
+        "judgeNotes": "Configures a private user-files bucket, keeps RLS enabled, adds authenticated owner-scoped SELECT and INSERT policies on storage.objects using the first path segment as auth.uid(), and provides supabase-js createSignedUrl code with an expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-mini/build-storage-001-private-bucket-access.json"
+  },
+  {
+    "experiment": "openai-gpt-5.4-mini",
+    "eval": "build-tests-001-rls-tenant-isolation",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "tests",
+      "rls"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "pgTAP test file(s) written under supabase/tests/",
+        "passed": true,
+        "notes": "1 file(s): supabase/tests/database/tenant_isolation.test.sql"
+      },
+      {
+        "name": "positive isolation tests pass (notes table)",
+        "passed": true,
+        "notes": "4 passed, 2 failed"
+      },
+      {
+        "name": "negative isolation tests catch the bug in posts table",
+        "passed": true,
+        "notes": "4 passed, 2 failed"
+      },
+      {
+        "name": "agent correctly identifies the posts isolation bug from test results",
+        "passed": true,
+        "judgeNotes": "The agent correctly identified that the posts table has broken tenant isolation for authenticated members reading cross-org posts, tied this to the pgTAP failures, and did not blame notes or dismiss the tests."
+      }
+    ],
+    "prompt": "Can you write some database tests to verify the tenant isolation is working? Cover both the happy path and the negative case, run them, and share what you find.",
+    "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "openai-gpt-5.4-mini/build-tests-001-rls-tenant-isolation.json"
   },
   {
     "experiment": "openai-gpt-5.4-mini",
@@ -174,12 +215,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with an environment variable instead of password_file, and docker-compose.yml does not mount/provide that password_file via a volume or Compose secret. App job is preserved and endpoint/path/scheme are otherwise correct."
+        "judgeNotes": "Fails: Prometheus uses basic_auth.password with an expanded SUPABASE_SECRET_API_KEY instead of password_file, and docker-compose does not mount a password_file via volume or Compose secret. Secret API key is wired through environment/config expansion. App scrape is preserved and endpoint/scheme are otherwise correct."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README explains endpoint/auth and creating a Secret API key, and includes basic verification by confirming the supabase target is UP. However it does not instruct placing a matching secret file, and deployment/restart steps are vague/not tied to reloading the Compose stack. It also relies on environment substitution without showing a concrete Compose-compatible setup."
+        "judgeNotes": "README includes Secret API key creation and Prometheus target verification, but it does not instruct placing the matching secret file and does not clearly restart/reload the Compose stack. It uses env vars instead, so the required secret setup is mismatched."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -236,7 +277,7 @@
       },
       {
         "name": "publication still publishes INSERT events",
-        "passed": true
+        "passed": false
       },
       {
         "name": "RLS still enabled on orders",
@@ -250,7 +291,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "Failed: the assistant diagnosed the publication as missing and attempted to create `supabase_realtime FOR ALL TABLES`, rather than identifying that only `orders` was missing from the existing publication and adding exactly that table. This risks altering the existing realtime setup instead of preserving courier_locations and other publication membership."
+        "judgeNotes": "The assistant did not fix the issue by adding the existing orders table to the supabase_realtime publication. It claimed there was no orders table and made no corrective change. This does not satisfy the rubric."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -274,17 +315,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described intermittent/recurring 503s throughout the morning, aligning with the required pattern. It also avoided focusing on the old billing-webhook issue."
+        "judgeNotes": "The assistant named image-transform as the affected function and described intermittent 503s throughout the morning of 2026-04-28, including the recurring pattern around :00 and :30. It did not focus on old billing-webhook errors and provided concrete next steps."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The assistant attributes the issue to the Edge Function path/upstream dependency and recommends inspecting function code/logs, rather than clearly identifying the gateway/platform layer in front of the function. It does not ground a platform-layer attribution in observations such as gateway-only 503s with no invocation/runtime rows, unchanged deployment_id, or distinction from function-level errors."
+        "judgeNotes": "The response does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function. It instead frames the likely cause as Edge Function runtime/platform startup or imported package initialization and recommends function/package debugging, which conflicts with the required gateway-layer attribution."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps, including checking Edge Function logs for a defined time window, inspecting dependencies, adding retry/backoff, and considering routing/fallback changes."
+        "judgeNotes": "The assistant recommended specific actionable next steps: checking Edge Function boot/runtime errors around the 503 timestamps, verifying the imported package loads correctly in Edge Functions, adding retry/fallback behavior, and opening a Supabase support ticket with timestamps and function name if platform-side failures are confirmed."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -335,7 +376,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all on bookmarks and added authenticated SELECT/INSERT owner-scoped policies with WITH CHECK while keeping RLS enabled."
+        "judgeNotes": "Diagnosed deny-all RLS on bookmarks, kept RLS enabled, and added authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -355,11 +396,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -372,7 +413,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on idx_events_user_id_created_at_desc  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -481,7 +522,7 @@
       {
         "name": "REST API returns no todos to anonymous requests",
         "passed": true,
-        "notes": "error 42501: permission denied for table todos"
+        "notes": "0 rows"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
@@ -567,7 +608,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ed2ab-2871-7376-befc-44c0f9548804/receipt-alpha.pdf, 019ed2ab-2871-7376-befc-44c0f9548804/receipt-beta.pdf"
+        "notes": "saw: 019ed767-0729-7119-83ea-f17a33cc2a97/receipt-alpha.pdf, 019ed767-0729-7119-83ea-f17a33cc2a97/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -588,13 +629,54 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "The answer creates the `user-files` bucket with `public = false`, defines authenticated-only INSERT and SELECT policies on `storage.objects` scoped to the bucket and owner/user folder, does not disable RLS, and uses `createSignedUrl` with an expiry for temporary sharing. It does not make the bucket public, use permissive policies, public roles, getPublicUrl, or service role client-side."
+        "judgeNotes": "Configured a private user-files bucket, owner-scoped storage.objects INSERT and SELECT policies using the user-id path prefix, did not disable RLS, and provided supabase-js createSignedUrl code with an expiry for temporary sharing. Service role usage was server-side only, not client-side."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-nano/build-storage-001-private-bucket-access.json"
+  },
+  {
+    "experiment": "openai-gpt-5.4-nano",
+    "eval": "build-tests-001-rls-tenant-isolation",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "tests",
+      "rls"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "pgTAP test file(s) written under supabase/tests/",
+        "passed": false,
+        "notes": "no .sql files found under supabase/tests/"
+      },
+      {
+        "name": "positive isolation tests pass (notes table)",
+        "passed": false,
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+      },
+      {
+        "name": "negative isolation tests catch the bug in posts table",
+        "passed": false,
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+      },
+      {
+        "name": "agent correctly identifies the posts isolation bug from test results",
+        "passed": true,
+        "judgeNotes": "The agent correctly identified `posts` as the table with broken tenant isolation, specifically that an authenticated member (`u1`) can read posts from an organization they are not a member of. It attributes the finding to the negative test failure and does not blame `notes` or dismiss the test results."
+      }
+    ],
+    "prompt": "Can you write some database tests to verify the tenant isolation is working? Cover both the happy path and the negative case, run them, and share what you find.",
+    "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "openai-gpt-5.4-nano/build-tests-001-rls-tenant-isolation.json"
   },
   {
     "experiment": "openai-gpt-5.4-nano",
@@ -616,12 +698,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape preserves the app job and uses HTTPS with the correct metrics path and project target placeholder, but it fails the rubric because it uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount the password file via a volume or Compose secret."
+        "judgeNotes": "Supabase scrape is only a commented template, not deployable. It uses inline password instead of basic_auth.password_file, and docker-compose.yml does not mount/provide any password_file via volume or Compose secret. App scrape is preserved, but required secret wiring is missing."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes creating a Secret API key, restart steps, and some Prometheus verification, but it does not instruct placing a matching secret file as required. Secret setup is environment-variable based and not wired concretely in Compose, so it fails the required secret-file setup."
+        "judgeNotes": "README explains endpoint/auth, creating a Secret API key, restarting Prometheus, and basic verification. However it does not require placing the matching secret file or configure Compose/Prometheus to consume one; instead it implies editing the secret into prometheus.yml. This fails the required secret-file setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -692,7 +774,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The assistant incorrectly identified RLS policies as the root cause and recommended changing SELECT policy. It did not diagnose or fix the missing orders table in the supabase_realtime publication, and did not add orders to the existing publication."
+        "judgeNotes": "The assistant did not identify or fix the missing orders table in the supabase_realtime publication. It instead concluded the orders table did not exist / project mismatch and mentioned RLS as a possible blocker, with no ALTER PUBLICATION fix."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -716,17 +798,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant identified image-transform as the affected function and described recurring intermittent HTTP 503 responses throughout the morning of 2026-04-28, including examples spanning 07:00 onward and noting the pattern continued until late morning. It did not incorrectly center the old billing-webhook issue."
+        "judgeNotes": "The assistant correctly identified `image-transform` as the affected Edge Function and described the recurring HTTP 503 pattern throughout the morning of 2026-04-28, listing all 8 failures from 07:00Z through 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The assistant partially attributes the 503s to the gateway/API log surface and notes successful edge-function logs, but then describes it as a transient Edge runtime/upstream issue and recommends redeploying the function, which the rubric explicitly says should fail. The grounding is also weak: it says detailed failure traces are needed rather than clearly concluding no invocation/runtime rows correspond to the 503s."
+        "judgeNotes": "The assistant attributes the 503s to the image-transform Edge Function/runtime/dependency and recommends inspecting/redeploying/rolling back the function. It does not identify the gateway/platform layer as the source, nor ground that attribution in missing invocation/runtime rows or unchanged deployment_id."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps: inspect Edge Function failure traces/request details, redeploy the function, add 503 retries, and check deployment/version changes and traffic correlation."
+        "judgeNotes": "The assistant recommended specific actionable next steps, including inspecting Edge Function error details for the 503 timestamps, adding retries, redeploying/rolling back the image-transform function, and checking dependency/downstream service health."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -777,7 +859,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all Data API results, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() while keeping RLS enabled. Extra update/delete owner-scoped policies do not violate the rubric."
+        "judgeNotes": "Diagnosed missing RLS policies on an RLS-enabled bookmarks table and added authenticated SELECT and INSERT policies scoped to user_id = auth.uid(), keeping RLS enabled."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -797,11 +879,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -814,7 +896,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",

--- a/evals/build-tests-001-rls-tenant-isolation/EVAL.ts
+++ b/evals/build-tests-001-rls-tenant-isolation/EVAL.ts
@@ -1,0 +1,96 @@
+import { judge, serializeTranscript, type CheckResult, type LocalStackEvalContext, type LocalStackScorer } from "@supabase-evals/core";
+import { stripIndent } from "common-tags";
+
+const scorer: LocalStackScorer = async (ctx) => {
+  try {
+    const checks: CheckResult[] = [
+      await checkTestFilesExist(ctx),
+      ...(await checkTestResults(ctx)),
+      await checkAgentDiagnosis(ctx),
+    ];
+    return { passed: checks.every((c) => c.passed), checks };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      passed: false,
+      checks: [{ name: "scorer evaluated pgTAP tests", passed: false, notes: msg }],
+    };
+  }
+};
+
+export default scorer;
+
+async function checkTestFilesExist(ctx: LocalStackEvalContext): Promise<CheckResult> {
+  const name = "pgTAP test file(s) written under supabase/tests/";
+  const result = await ctx.exec("find supabase/tests -name '*.sql' 2>/dev/null");
+  const files = result.stdout.trim().split("\n").filter(Boolean);
+  return {
+    name,
+    passed: files.length > 0,
+    notes: files.length > 0
+      ? `${files.length} file(s): ${files.join(", ")}`
+      : "no .sql files found under supabase/tests/",
+  };
+}
+
+async function checkAgentDiagnosis(ctx: LocalStackEvalContext): Promise<CheckResult> {
+  const verdict = await judge({
+    input: serializeTranscript(ctx.transcript, { includeToolCallInputs: true }),
+    rubric: stripIndent`
+      Pass if the agent correctly identifies that the \`posts\` table has a broken
+      tenant isolation policy — specifically that authenticated members can read
+      posts belonging to organizations they are not a member of — and attributes
+      this to the test failures. The agent does not need to supply the exact SQL
+      fix, but must identify \`posts\` (not \`notes\`) as the table with the policy
+      flaw, and treat the pgTAP results as the authoritative signal rather than
+      dismissing them or trusting the migration comments.
+
+      Fail if the agent claims both tables are correctly isolated, blames \`notes\`
+      instead of \`posts\`, attributes all failures to test bugs without suspecting
+      the policy, or reports the test results without drawing the correct conclusion
+      about which table is broken.
+    `,
+  });
+  return {
+    name: "agent correctly identifies the posts isolation bug from test results",
+    passed: verdict.passed,
+    judgeNotes: verdict.notes,
+  };
+}
+
+async function checkTestResults(
+  ctx: LocalStackEvalContext,
+): Promise<CheckResult[]> {
+  const result = await ctx.exec("supabase test db 2>&1", { timeoutMs: 120_000 });
+  const output = result.stdout + result.stderr;
+
+  // pg_prove summary line: "Files=1, Tests=4, 1 failed." or "Files=1, Tests=4, 0 failed."
+  const totalMatch = output.match(/Tests[=:]\s*(\d+)/i);
+  const failedMatch = output.match(/Failed:\s*(\d+)/i);
+  const totalTests = totalMatch ? parseInt(totalMatch[1], 10) : 0;
+  const failedTests = failedMatch ? parseInt(failedMatch[1], 10) : 0;
+  const passedTests = totalTests - failedTests;
+  const ranTests = totalTests > 0;
+
+  const summary = ranTests
+    ? `${passedTests} passed, ${failedTests} failed`
+    : `no test summary found; exit ${result.exitCode}; output: ${output.slice(0, 500)}`;
+
+  return [
+    {
+      name: "positive isolation tests pass (notes table)",
+      passed: ranTests && passedTests > 0,
+      notes: summary,
+    },
+    {
+      name: "negative isolation tests catch the bug in posts table",
+      // A non-zero exit with at least one failure means the agent wrote
+      // negative-case tests that caught the intentional policy flaw.
+      passed: ranTests && failedTests > 0,
+      notes:
+        ranTests && failedTests === 0
+          ? "all tests passed — negative case not covered or policy was not tested"
+          : summary,
+    },
+  ];
+}

--- a/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
+++ b/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
@@ -11,6 +11,4 @@ services: []
 motivation: AI-813, FDBKIN-9635, FDBKIN-8983
 ---
 
-We have a multi-tenant app where `notes` and `posts` both belong to orgs, and the `memberships` table controls who's in each org. Both tables are supposed to enforce org-level tenant isolation with RLS.
-
-Can you write pgTAP tests that verify the isolation is working on both tables? Cover both the happy path (a member reading their own org's data) and the negative case (a member trying to read another org's data). Run `supabase test db` when you're done and share what you find.
+Can you write some database tests to verify the tenant isolation is working? Cover both the happy path and the negative case, run them, and share what you find.

--- a/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
+++ b/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
@@ -8,7 +8,7 @@ topic:
   - tests
   - rls
 services: []
-motivation: AI-813
+motivation: AI-813, FDBKIN-9635, FDBKIN-8983
 ---
 
 We have a multi-tenant app where `notes` and `posts` both belong to orgs, and the `memberships` table controls who's in each org. Both tables are supposed to enforce org-level tenant isolation with RLS.

--- a/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
+++ b/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
@@ -11,4 +11,4 @@ services: []
 motivation: AI-813, FDBKIN-9635, FDBKIN-8983
 ---
 
-Can you write some database tests to verify the tenant isolation is working? Cover both the happy path and the negative case, run them, and share what you find.
+Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.

--- a/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
+++ b/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
@@ -1,0 +1,16 @@
+---
+stage: build
+suite: benchmark
+interface: cli
+product:
+  - database
+topic:
+  - tests
+  - rls
+services: []
+motivation: AI-813
+---
+
+We have a multi-tenant app where `notes` and `posts` both belong to orgs, and the `memberships` table controls who's in each org. Both tables are supposed to enforce org-level tenant isolation with RLS.
+
+Can you write pgTAP tests that verify the isolation is working on both tables? Cover both the happy path (a member reading their own org's data) and the negative case (a member trying to read another org's data). Run `supabase test db` when you're done and share what you find.

--- a/evals/build-tests-001-rls-tenant-isolation/README.md
+++ b/evals/build-tests-001-rls-tenant-isolation/README.md
@@ -1,0 +1,19 @@
+## Planted bug
+
+The `posts` SELECT policy in the migration is missing `AND m.org_id = posts.org_id`, so any
+authenticated member can read posts from organizations they don't belong to. The `notes` table
+has the correct policy.
+
+## Planted comment
+
+The migration header confidently asserts that both tables enforce org-level isolation:
+
+```sql
+-- RLS policies on notes and posts enforce org-level tenant isolation:
+-- members can only access rows that belong to their organization.
+```
+
+This is intentionally incorrect. An agent that reads the migration and trusts the comment
+would expect `supabase test db` to pass cleanly. The eval measures whether the agent treats
+the pgTAP results as the authoritative signal and correctly identifies `posts` as the broken
+table despite the misleading comment.

--- a/evals/build-tests-001-rls-tenant-isolation/local/supabase/config.toml
+++ b/evals/build-tests-001-rls-tenant-isolation/local/supabase/config.toml
@@ -1,0 +1,165 @@
+project_id = "sandbox-rls-tests"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[api.tls]
+enabled = false
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 17
+
+[db.pooler]
+enabled = false
+port = 54329
+pool_mode = "transaction"
+default_pool_size = 20
+max_client_conn = 100
+
+[db.migrations]
+enabled = true
+schema_paths = []
+
+[db.seed]
+enabled = false
+
+[realtime]
+enabled = true
+
+[studio]
+enabled = true
+port = 54323
+api_url = "http://127.0.0.1"
+openai_api_key = "env(OPENAI_API_KEY)"
+
+[inbucket]
+enabled = true
+port = 54324
+
+[storage]
+enabled = true
+file_size_limit = "50MiB"
+
+[storage.s3_protocol]
+enabled = true
+
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+[auth]
+enabled = true
+site_url = "http://127.0.0.1:3000"
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+refresh_token_reuse_interval = 10
+enable_signup = true
+enable_anonymous_sign_ins = false
+enable_manual_linking = false
+minimum_password_length = 6
+password_requirements = ""
+
+[auth.rate_limit]
+email_sent = 2
+sms_sent = 30
+anonymous_users = 30
+token_refresh = 150
+sign_in_sign_ups = 30
+token_verifications = 30
+web3 = 30
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = true
+enable_confirmations = false
+secure_password_change = false
+max_frequency = "1s"
+otp_length = 6
+otp_expiry = 3600
+
+[auth.sms]
+enable_signup = false
+enable_confirmations = false
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+[auth.mfa]
+max_enrolled_factors = 10
+
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+[auth.external.apple]
+enabled = false
+client_id = ""
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+redirect_uri = ""
+url = ""
+skip_nonce_check = false
+email_optional = false
+
+[auth.web3.solana]
+enabled = false
+
+[auth.third_party.firebase]
+enabled = false
+
+[auth.third_party.auth0]
+enabled = false
+
+[auth.third_party.aws_cognito]
+enabled = false
+
+[auth.third_party.clerk]
+enabled = false
+
+[auth.oauth_server]
+enabled = false
+authorization_url_path = "/oauth/consent"
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+policy = "per_worker"
+inspector_port = 8083
+deno_version = 2
+
+[analytics]
+enabled = true
+port = 54327
+backend = "postgres"
+
+[experimental]
+orioledb_version = ""
+s3_host = "env(S3_HOST)"
+s3_region = "env(S3_REGION)"
+s3_access_key = "env(S3_ACCESS_KEY)"
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/evals/build-tests-001-rls-tenant-isolation/local/supabase/migrations/20240101000000_init.sql
+++ b/evals/build-tests-001-rls-tenant-isolation/local/supabase/migrations/20240101000000_init.sql
@@ -1,0 +1,55 @@
+-- Adds memberships, notes, and posts tables.
+-- RLS policies on notes and posts enforce org-level tenant isolation:
+-- members can only access rows that belong to their organization.
+
+-- Shared membership table: user <-> org association
+CREATE TABLE memberships (
+  user_id uuid NOT NULL,
+  org_id uuid NOT NULL,
+  PRIMARY KEY (user_id, org_id)
+);
+
+GRANT SELECT ON memberships TO authenticated;
+
+-- notes: org-level tenant isolation
+CREATE TABLE notes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL,
+  author_id uuid NOT NULL,
+  body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE notes ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE, DELETE ON notes TO authenticated;
+
+CREATE POLICY "members can read org notes"
+ON notes FOR SELECT TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM memberships m
+    WHERE m.user_id = auth.uid()
+      AND m.org_id = notes.org_id
+  )
+);
+
+-- posts: org-level tenant isolation
+CREATE TABLE posts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL,
+  author_id uuid NOT NULL,
+  body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE, DELETE ON posts TO authenticated;
+
+CREATE POLICY "members can read posts"
+ON posts FOR SELECT TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM memberships m
+    WHERE m.user_id = auth.uid()
+  )
+);


### PR DESCRIPTION
Adds a benchmark `build-tests-001-rls-tenant-isolation` eval testing whether an agent can write database tests that catch an RLS policy bug.

**What the scenario is**

Seeds a multi-tenant app schema with `memberships`, `notes`, and `posts` tables, where both tables are supposed to enforce org-level RLS isolation. The `notes` policy is correct. The `posts` policy has a planted bug (missing `AND m.org_id = posts.org_id`), so any authenticated member can read posts from orgs they don't belong to. A misleading migration comment asserts both policies are correct. The eval measures whether the agent treats test output as the authoritative signal rather than trusting the comment.

**What the eval checks**
- pgTAP test file(s) written under `supabase/tests/`
- Positive isolation tests pass (notes table has the correct policy)
- Negative isolation tests catch the bug in the posts table
- Agent correctly identifies `posts` as the broken table from test results


**Results**

In this particular run, mini did the right thing but nano failed to interpret the prompt as needing to write pgTAP tests (likely due to not checking docs).

<img width="2814" height="484" alt="CleanShot 2026-06-17 at 17 14 31@2x" src="https://github.com/user-attachments/assets/461a7776-1564-403a-82db-44072b8b0ca4" />



**References**
- https://supabase.com/docs/guides/local-development/testing/overview
- https://supabase.com/docs/guides/database/extensions/pgtap

Closes AI-813