### PR TITLE
feat(sandbox): install agent skills into the local-stack sandbox (AI-845)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ Skills come from [`supabase/agent-skills`](https://github.com/supabase/agent-ski
 
 To use a skill in an experiment, reference its directory name in the experiment's `skills` array.
 
-How a skill reaches the agent depends on the runtime:
+Both runtimes load skills lazily ([progressive disclosure](https://ai-sdk.dev/cookbook/guides/agent-skills)): only each skill's name+description is in the system prompt, and the agent pulls a skill's full instructions on demand. They differ only in how the body is fetched, because the tools-mode agent has no filesystem:
 
-- **Local-stack (sandbox) mode:** skills are installed into the workspace with [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) (baked into the sandbox image, sourced from the local `skills/` directory — never the network) under `.claude/skills/`. Only each skill's name+description is in the system prompt; when a task matches, the agent reads `.claude/skills/<name>/SKILL.md` (and any files it references) with its file tools — progressive disclosure, [the AI SDK agent-skills pattern](https://ai-sdk.dev/cookbook/guides/agent-skills).
-- **Tools mode:** the agent has no filesystem, so each skill's full `SKILL.md` is injected into the system prompt.
+- **Local-stack (sandbox) mode:** skills are installed into the workspace with [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) (baked into the sandbox image, sourced from the local `skills/` directory — never the network) under `.claude/skills/`. When a task matches, the agent reads `.claude/skills/<name>/SKILL.md` (and any files it references) with its file tools.
+- **Tools mode:** no filesystem, so a `load_skill` tool returns a skill's full instructions when the agent calls it with the skill's name.
 
 ## Framework Checks
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ Skills come from [`supabase/agent-skills`](https://github.com/supabase/agent-ski
 
 To use a skill in an experiment, reference its directory name in the experiment's `skills` array.
 
+How a skill reaches the agent depends on the runtime:
+
+- **Local-stack (sandbox) mode:** skills are installed into the workspace with [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) (baked into the sandbox image, sourced from the local `skills/` directory — never the network) under `.claude/skills/`. Only each skill's name+description is in the system prompt; when a task matches, the agent reads `.claude/skills/<name>/SKILL.md` (and any files it references) with its file tools — progressive disclosure, [the AI SDK agent-skills pattern](https://ai-sdk.dev/cookbook/guides/agent-skills).
+- **Tools mode:** the agent has no filesystem, so each skill's full `SKILL.md` is injected into the system prompt.
+
 ## Framework Checks
 
 ```bash

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -12,7 +12,12 @@ import {
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { jsonSchema, tool, type ToolSet } from "ai";
 import { parseEvalMarkdown } from "@supabase-evals/core/eval-markdown";
+import {
+  frontmatterDescription,
+  stripFrontmatter,
+} from "@supabase-evals/sandbox";
 import {
   normalizeExperimentName,
   readRepeatedFlag,
@@ -136,31 +141,100 @@ function discoverEvals(): EvalManifest[] {
   return out;
 }
 
+type ToolsSkill = { name: string; description: string; body: string };
+
 /**
- * Tools-mode skill loading: the agent has no filesystem, so each skill's full
- * SKILL.md is injected into the system prompt. (Local-stack mode installs the
- * skills into the sandbox instead — see resolveSkillSources.)
+ * Tools-mode skills, read from the host `skills/` dir. Unlike local-stack
+ * (where skills are installed into the sandbox and the agent reads SKILL.md
+ * with its file tools), a tools-mode agent has no filesystem — so only each
+ * skill's name+description is advertised in the prompt and a `load_skill` tool
+ * returns the full body on demand. Same lazy/progressive-disclosure property,
+ * different load mechanism. Missing skills are skipped with a warning.
  */
-function loadSkills(skillNames: string[]): string {
-  const blocks: string[] = [];
+function loadToolsSkills(skillNames: string[]): ToolsSkill[] {
+  const skills: ToolsSkill[] = [];
   for (const name of skillNames) {
     const p = join(ROOT, "skills", name, "SKILL.md");
-    if (existsSync(p))
-      blocks.push(`# Skill: ${name}\n\n${readFileSync(p, "utf8")}`);
-    else
-      blocks.push(
-        `# Skill: ${name}\n\n(not found — ensure submodule is initialised: \`git submodule update --init\`)`,
+    if (!existsSync(p)) {
+      console.warn(
+        `SKILL ${name} not found at skills/${name} — ensure the submodule is initialised (\`git submodule update --init\`); skipping`,
       );
+      continue;
+    }
+    const md = readFileSync(p, "utf8");
+    skills.push({
+      name,
+      description: frontmatterDescription(md),
+      body: stripFrontmatter(md),
+    });
   }
-  return blocks.join("\n\n---\n\n");
+  return skills;
+}
+
+/**
+ * Discovery listing for the tools-mode system prompt: only names+descriptions,
+ * so the agent knows when a skill is relevant without its full text in context.
+ * Empty when there are no skills.
+ */
+function buildToolsSkillsPrompt(skills: readonly ToolsSkill[]): string {
+  if (skills.length === 0) return "";
+  return [
+    "## Available skills",
+    "",
+    "The following agent skills are available. Only their names and descriptions are shown — " +
+      "the full instructions are not loaded yet. When a task matches a skill, call the `load_skill` " +
+      "tool with its name to load its full instructions.",
+    "",
+    ...skills.map((s) => `- ${s.name}: ${s.description}`),
+  ].join("\n");
+}
+
+/**
+ * The agent-invoked `load_skill` tool: given a skill name it returns that
+ * skill's full instructions. This is how tools-mode evals load a skill lazily
+ * (the local-stack equivalent is the agent reading SKILL.md with files_read).
+ * Empty toolset when there are no skills.
+ */
+function buildLoadSkillTool(skills: readonly ToolsSkill[]): ToolSet {
+  if (skills.length === 0) return {};
+  const byName = new Map(skills.map((s) => [s.name, s]));
+  return {
+    load_skill: tool({
+      description:
+        "Load an agent skill's full instructions by name. Available skills are listed in the system prompt.",
+      inputSchema: jsonSchema({
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description:
+              "The skill name to load (as listed under Available skills).",
+            enum: skills.map((s) => s.name),
+          },
+        },
+        required: ["name"],
+      }),
+      execute: async (input) => {
+        const name = String((input as { name?: unknown })?.name ?? "");
+        const entry = byName.get(name);
+        if (!entry) {
+          throw new Error(
+            `unknown skill "${name}"; available: ${skills.map((s) => s.name).join(", ")}`,
+          );
+        }
+        return { instructions: entry.body };
+      },
+    }),
+  };
 }
 
 /**
  * Local-stack skill sources: resolve each skill name to its host directory so
- * the sandbox can install it with Vercel's `skills` CLI and the agent can
- * discover it via the load_skill tool. The `skills/` entries are symlinks into
- * the agent-skills submodule; realpath them so `docker cp` copies real files,
- * not dangling links. Missing skills are skipped with a warning.
+ * the sandbox can install it with Vercel's `skills` CLI; the agent then
+ * discovers each skill by reading its SKILL.md with its file tools. The
+ * `skills/` entries are symlinks into the agent-skills submodule; realpath them
+ * so `docker cp` copies real files, not dangling links. Missing skills are
+ * skipped with a warning.
  */
 function resolveSkillSources(
   skillNames: string[],
@@ -255,6 +329,9 @@ async function runOne(
     readFileSync(ev.promptPath, "utf8"),
     ev.promptPath,
   ).body;
+  // Tools-mode skills are advertised in the prompt and loaded via the
+  // load_skill tool; local-stack installs them into the sandbox instead.
+  const toolsSkills = ev.mode === "tools" ? loadToolsSkills(exp.skills) : [];
   const scorer = (await import(pathToFileURL(ev.evalPath).href)).default as
     | ToolScorer
     | LocalStackScorer;
@@ -374,16 +451,18 @@ async function runOne(
     const session = await exp.runtime.startSession(readSessionSeedArgs(ev));
 
     try {
-      // Tools mode has no filesystem: inject each skill's full text into the
-      // system prompt (local-stack installs them into the sandbox instead).
+      // Tools mode has no filesystem: advertise only each skill's
+      // name+description and let the agent pull a skill's full body on demand
+      // via the load_skill tool (lazy, like local-stack's files_read).
       const systemPrompt = buildSystemPrompt(
         "tools",
         session.promptAddendum,
-        loadSkills(exp.skills),
+        buildToolsSkillsPrompt(toolsSkills),
       );
       const run = await exp.agent.run({
         systemPrompt,
         userPrompt: prompt,
+        tools: buildLoadSkillTool(toolsSkills),
         mcpServers: session.mcpServers,
         timeoutSec: TIMEOUT_SEC,
       });

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -135,6 +136,11 @@ function discoverEvals(): EvalManifest[] {
   return out;
 }
 
+/**
+ * Tools-mode skill loading: the agent has no filesystem, so each skill's full
+ * SKILL.md is injected into the system prompt. (Local-stack mode installs the
+ * skills into the sandbox instead — see resolveSkillSources.)
+ */
 function loadSkills(skillNames: string[]): string {
   const blocks: string[] = [];
   for (const name of skillNames) {
@@ -147,6 +153,30 @@ function loadSkills(skillNames: string[]): string {
       );
   }
   return blocks.join("\n\n---\n\n");
+}
+
+/**
+ * Local-stack skill sources: resolve each skill name to its host directory so
+ * the sandbox can install it with Vercel's `skills` CLI and the agent can
+ * discover it via the load_skill tool. The `skills/` entries are symlinks into
+ * the agent-skills submodule; realpath them so `docker cp` copies real files,
+ * not dangling links. Missing skills are skipped with a warning.
+ */
+function resolveSkillSources(
+  skillNames: string[],
+): Array<{ name: string; dir: string }> {
+  const sources: Array<{ name: string; dir: string }> = [];
+  for (const name of skillNames) {
+    const dir = join(ROOT, "skills", name);
+    if (!existsSync(dir)) {
+      console.warn(
+        `SKILL ${name} not found at skills/${name} — ensure the submodule is initialised (\`git submodule update --init\`); skipping`,
+      );
+      continue;
+    }
+    sources.push({ name, dir: realpathSync(dir) });
+  }
+  return sources;
 }
 
 function resultPath(modelName: string, ev: Pick<EvalManifest, "id" | "mode">) {
@@ -201,8 +231,8 @@ function basePromptFor(mode: EvalMode): string {
 
 function buildSystemPrompt(
   mode: EvalMode,
-  skillContext: string,
   addendum?: string,
+  skillContext?: string,
 ): string {
   const blocks = [basePromptFor(mode), addendum, skillContext].filter(Boolean);
   return blocks.join("\n\n");
@@ -221,7 +251,6 @@ async function runOne(
     stoppedReason: string;
   }
 > {
-  const skillContext = loadSkills(exp.skills);
   const prompt = parseEvalMarkdown(
     readFileSync(ev.promptPath, "utf8"),
     ev.promptPath,
@@ -271,12 +300,15 @@ async function runOne(
               invokeFunction: hostedBackend.invokeFunction,
             }
           : undefined,
+        // Skills are installed into the sandbox and discovered by the agent
+        // (the session folds the discovery listing into its promptAddendum),
+        // so no skill text is injected into the prompt here.
+        skills: resolveSkillSources(exp.skills),
       });
       try {
         const run = await exp.agent.run({
           systemPrompt: buildSystemPrompt(
             "local-stack",
-            skillContext,
             session.promptAddendum,
           ),
           userPrompt: prompt,
@@ -342,10 +374,12 @@ async function runOne(
     const session = await exp.runtime.startSession(readSessionSeedArgs(ev));
 
     try {
+      // Tools mode has no filesystem: inject each skill's full text into the
+      // system prompt (local-stack installs them into the sandbox instead).
       const systemPrompt = buildSystemPrompt(
         "tools",
-        skillContext,
         session.promptAddendum,
+        loadSkills(exp.skills),
       );
       const run = await exp.agent.run({
         systemPrompt,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,6 +289,12 @@ export type AgentHarness = {
   run(args: AgentRunArgs): Promise<AgentRunResult>;
 };
 
+/**
+ * An agent skill to install into the sandbox: its name and the host directory
+ * holding its SKILL.md (and any bundled reference files).
+ */
+export type SkillSource = { name: string; dir: string };
+
 export type LocalStackSessionArgs = {
   /**
    * Host directory (the eval's `local/`) whose contents seed the sandbox
@@ -314,6 +320,14 @@ export type LocalStackSessionArgs = {
    * sandbox and exposes the hosted handle to the scorer.
    */
   hosted?: HostedLink;
+  /**
+   * Agent skills to install into the sandbox (one host source dir per skill).
+   * Installed with Vercel's `skills` CLI and discovered by the agent reading
+   * each skill's SKILL.md with its file tools — not preloaded into the system
+   * prompt. Tools-mode evals (no filesystem) inject skills into the prompt
+   * instead, so they ignore this.
+   */
+  skills?: readonly SkillSource[];
 };
 
 /** A mocked hosted project (platform-lite) the sandbox CLI is linked to. */

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -13,3 +13,9 @@ RUN ARCH="$(dpkg --print-architecture)" \
   && curl -fsSL "https://github.com/supabase/cli/releases/download/v${CLI_VERSION}/supabase_${CLI_VERSION}_linux_${ARCH}.deb" -o /tmp/supabase.deb \
   && dpkg -i /tmp/supabase.deb \
   && rm /tmp/supabase.deb
+
+# Vercel's agent-skills CLI, used to install agent skills from local sources
+# into each session's workspace. Baked in (pinned) so installs are offline and
+# instant rather than an npx download per session.
+ARG SKILLS_CLI_VERSION
+RUN npm install -g "skills@${SKILLS_CLI_VERSION}"

--- a/packages/sandbox/src/docker-sandbox.ts
+++ b/packages/sandbox/src/docker-sandbox.ts
@@ -220,8 +220,8 @@ export class DockerSandbox {
    * Copy between the host and the container with `docker cp`. Either endpoint
    * may carry the `container:` prefix (`<id>:<path>`); direction is implied by
    * which side does. Binary-safe and streamed straight through the engine — no
-   * buffering into memory. The shared primitive behind copyHostDir, copyToHost,
-   * and writeFiles.
+   * buffering into memory. The shared primitive behind copyToContainer,
+   * copyToHost, and writeFiles.
    */
   private async dockerCopy(source: string, dest: string): Promise<void> {
     const result = await dockerCli(["cp", source, dest]);
@@ -230,28 +230,30 @@ export class DockerSandbox {
     }
   }
 
-  /** `container:<workdir>` reference for docker cp. */
-  private get containerWorkdir(): string {
-    return `${this.containerId}:${this.workdir}`;
+  /** `container:<path>` reference for docker cp. */
+  private containerRef(path: string): string {
+    return `${this.containerId}:${path}`;
   }
 
   /**
-   * Copy a host directory's contents into the workspace root, then drop
-   * VCS/dependency noise and hand ownership to the sandbox user. Use this to
-   * seed a workspace; use writeFiles for the in-memory single-file case (the
-   * file tools).
+   * Copy a host directory's contents to a path inside the container, drop
+   * VCS/dependency noise, and hand ownership to the sandbox user. Seeds the
+   * workspace (`containerPath` = workdir) and stages auxiliary files such as
+   * agent-skill sources alike; use writeFiles for the in-memory single-file
+   * case (the file tools).
    */
-  async copyHostDir(hostDir: string): Promise<void> {
+  async copyToContainer(hostDir: string, containerPath: string): Promise<void> {
     this.assertRunning();
-    await this.dockerCopy(`${hostDir}/.`, `${this.containerWorkdir}/`);
-    // Drop VCS/dependency noise that shouldn't seed the workspace; a cheap
-    // no-op when none of these are present in the source directory.
+    await this.runShellAsRoot(`mkdir -p ${shellQuote(containerPath)}`);
+    await this.dockerCopy(`${hostDir}/.`, `${this.containerRef(containerPath)}/`);
+    // Drop VCS/dependency noise that shouldn't be copied into the sandbox; a
+    // cheap no-op when none of these are present in the source directory.
     await this.runShellAsRoot(
-      `find ${this.workdir} -depth \\( -name .git -o -name node_modules -o -name .DS_Store \\) -exec rm -rf {} + 2>/dev/null || true`,
+      `find ${shellQuote(containerPath)} -depth \\( -name .git -o -name node_modules -o -name .DS_Store \\) -exec rm -rf {} + 2>/dev/null || true`,
     );
     // docker cp preserves host ownership; hand the files to the sandbox user.
     const chown = await this.runShellAsRoot(
-      `chown -R ${SANDBOX_UID}:${SANDBOX_GID} ${this.workdir}`,
+      `chown -R ${SANDBOX_UID}:${SANDBOX_GID} ${shellQuote(containerPath)}`,
     );
     if (!chown.ok) {
       throw new Error(`failed to chown copied files: ${chown.stderr}`);
@@ -259,15 +261,15 @@ export class DockerSandbox {
   }
 
   /**
-   * Copy the workspace contents out of the container into a host directory
-   * (the `docker cp` reverse of copyHostDir). Lets host-side tooling — e.g.
-   * vite/vitest from the repo root — score the agent's produced files without
-   * that tooling having to exist inside the sandbox.
+   * Copy a container path's contents out to a host directory (the `docker cp`
+   * reverse of copyToContainer). Lets host-side tooling — e.g. vite/vitest from
+   * the repo root — score the agent's produced files without that tooling
+   * having to exist inside the sandbox.
    */
-  async copyToHost(hostDir: string): Promise<void> {
+  async copyToHost(containerPath: string, hostDir: string): Promise<void> {
     this.assertRunning();
     mkdirSync(hostDir, { recursive: true });
-    await this.dockerCopy(`${this.containerWorkdir}/.`, `${hostDir}/`);
+    await this.dockerCopy(`${this.containerRef(containerPath)}/.`, `${hostDir}/`);
   }
 
   /** Write files into the workspace. Paths are relative to the workspace root. */
@@ -285,7 +287,7 @@ export class DockerSandbox {
         mkdirSync(dirname(target), { recursive: true });
         writeFileSync(target, content);
       }
-      await this.dockerCopy(`${staging}/.`, `${this.containerWorkdir}/`);
+      await this.dockerCopy(`${staging}/.`, `${this.containerRef(this.workdir)}/`);
     } finally {
       rmSync(staging, { recursive: true, force: true });
     }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -18,5 +18,13 @@ export {
   localStackRuntime,
 } from "./local-stack-runtime.js";
 export type { LocalStackRuntimeOptions } from "./local-stack-runtime.js";
+export {
+  SKILLS_CLI_VERSION,
+  SKILLS_INSTALL_DIR,
+  buildSkillsPrompt,
+  frontmatterDescription,
+  installSkills,
+} from "./skills.js";
+export type { SkillEntry } from "./skills.js";
 export { ALL_SUPABASE_SERVICES } from "./types.js";
 export type { SandboxCommandResult, SupabaseService } from "./types.js";

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -24,6 +24,7 @@ export {
   buildSkillsPrompt,
   frontmatterDescription,
   installSkills,
+  stripFrontmatter,
 } from "./skills.js";
 export type { SkillEntry } from "./skills.js";
 export { ALL_SUPABASE_SERVICES } from "./types.js";

--- a/packages/sandbox/src/local-stack-runtime.ts
+++ b/packages/sandbox/src/local-stack-runtime.ts
@@ -14,6 +14,7 @@ import {
   setupSupabaseSandbox,
   teardownSupabaseProject,
 } from "./supabase.js";
+import { buildSkillsPrompt, installSkills, type SkillEntry } from "./skills.js";
 
 /** Local-stack Postgres as published by `supabase start` (DNAT'd in-sandbox). */
 const LOCAL_DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
@@ -72,7 +73,13 @@ export function localStackRuntime(
 ): LocalStackRuntime {
   return {
     id: "local-stack",
-    async startSession({ localDir, includeServices, projectRunning, hosted }) {
+    async startSession({
+      localDir,
+      includeServices,
+      projectRunning,
+      hosted,
+      skills,
+    }) {
       const image = await ensureSupabaseSandboxImage(options.cliVersion);
       const sandbox = await DockerSandbox.create({
         image,
@@ -84,6 +91,7 @@ export function localStackRuntime(
         capAdd: ["NET_ADMIN"],
         sysctls: { "net.ipv4.conf.all.route_localnet": "1" },
       });
+      let skillEntries: SkillEntry[] = [];
       try {
         await setupSupabaseSandbox(sandbox, {
           includeServices,
@@ -93,6 +101,10 @@ export function localStackRuntime(
             ? { port: hosted.port, ref: hosted.ref, accessToken: hosted.accessToken }
             : undefined,
         });
+        // Install requested skills into the sandbox after the workspace is
+        // seeded, so the agent can discover them (it reads each SKILL.md on
+        // demand via its file tools).
+        skillEntries = await installSkills(sandbox, skills ?? []);
       } catch (err) {
         await sandbox.stop();
         throw err;
@@ -100,16 +112,21 @@ export function localStackRuntime(
 
       const mcpServers = await resolveMcpServers(options, hosted);
 
+      const baseAddendum =
+        "The Supabase CLI (`supabase`), docker, psql, git, and curl are installed in the workspace. " +
+        "Use the bash tool to run commands (the working directory is always the workspace root) " +
+        "and the files tools to inspect and modify files. " +
+        "Services started with `supabase start` are reachable on their default 127.0.0.1 ports.";
+
       return {
         tools: buildLocalStackTools(sandbox),
         mcpServers,
-        promptAddendum:
-          "The Supabase CLI (`supabase`), docker, psql, git, and curl are installed in the workspace. " +
-          "Use the bash tool to run commands (the working directory is always the workspace root) " +
-          "and the files tools to inspect and modify files. " +
-          "Services started with `supabase start` are reachable on their default 127.0.0.1 ports.",
+        promptAddendum: [baseAddendum, buildSkillsPrompt(skillEntries)]
+          .filter(Boolean)
+          .join("\n\n"),
         scoringContext: buildLocalStackScoringContext(sandbox, hosted),
-        exportWorkspace: (hostDir: string) => sandbox.copyToHost(hostDir),
+        exportWorkspace: (hostDir: string) =>
+          sandbox.copyToHost(sandbox.workdir, hostDir),
         close: async () => {
           await teardownSupabaseProject(sandbox);
           await sandbox.stop();

--- a/packages/sandbox/src/skills.ts
+++ b/packages/sandbox/src/skills.ts
@@ -52,6 +52,15 @@ export interface SkillEntry {
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 /**
+ * Drop the YAML frontmatter, returning just the skill's instruction body. Used
+ * by tools-mode evals, where a `load_skill` tool returns this body on demand
+ * (the agent has no filesystem to read SKILL.md itself).
+ */
+export function stripFrontmatter(markdown: string): string {
+  return markdown.replace(FRONTMATTER_RE, "").trim();
+}
+
+/**
  * Read the `description` field from a SKILL.md's frontmatter (the one-line
  * "when to use this skill" text shown in the discovery listing). Returns "" if
  * there is no frontmatter or no description. Assumes the conventional

--- a/packages/sandbox/src/skills.ts
+++ b/packages/sandbox/src/skills.ts
@@ -1,0 +1,150 @@
+/**
+ * Agent skills inside the local-stack sandbox.
+ *
+ * Skills are reusable instruction sets (a SKILL.md plus bundled reference
+ * files) that the agent discovers and loads on demand — the AI SDK
+ * "agent skills" pattern (https://ai-sdk.dev/cookbook/guides/agent-skills).
+ * Rather than preloading every skill's full text into the system prompt, the
+ * sandbox advertises only each skill's name+description and tells the agent to
+ * read a skill's SKILL.md (with the existing file tools) when a task matches —
+ * progressive disclosure. This only works where the agent has a filesystem —
+ * the sandbox. Tools-mode evals (no filesystem) inject skills into the system
+ * prompt instead.
+ *
+ * Skills are installed with Vercel's `skills` CLI (baked into the sandbox
+ * image), sourcing from local directories — never the network. Each requested
+ * skill is staged outside the workspace, then `skills add` copies it into the
+ * workspace's `.claude/skills/` (claude-code project scope), where the agent's
+ * file tools can reach the SKILL.md and the files it references.
+ */
+
+import type { SkillSource } from "@supabase-evals/core";
+import type { DockerSandbox } from "./docker-sandbox.js";
+
+/** Version of Vercel's `skills` CLI baked into the sandbox image (pinned). */
+export const SKILLS_CLI_VERSION = "1.5.11";
+
+/**
+ * Where installed project-scoped skills are read from, relative to the
+ * workspace root (the CLI's cwd during install). We install for all agents
+ * (see installSkills), and `.claude/skills` is claude-code's project scope —
+ * the discovery listing points the agent here.
+ */
+export const SKILLS_INSTALL_DIR = ".claude/skills";
+
+/** Staging path (outside the workspace) host skill sources are copied to before install. */
+const SKILLS_STAGING_DIR = "/tmp/skills-src";
+
+/** A skill discovered in the sandbox: enough to advertise it for progressive disclosure. */
+export interface SkillEntry {
+  name: string;
+  description: string;
+  /** Workspace-relative directory of the installed skill. */
+  dir: string;
+}
+
+/**
+ * Leading YAML frontmatter block (`---` … `---`) at the start of a SKILL.md.
+ * We only need the one-line `description` and to strip this block — not full
+ * YAML — so a regex (as in the AI SDK agent-skills reference) avoids a YAML
+ * dependency. The skill's name is the install directory, so we don't read it.
+ */
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Read the `description` field from a SKILL.md's frontmatter (the one-line
+ * "when to use this skill" text shown in the discovery listing). Returns "" if
+ * there is no frontmatter or no description. Assumes the conventional
+ * single-line description; surrounding quotes are stripped.
+ */
+export function frontmatterDescription(markdown: string): string {
+  const block = FRONTMATTER_RE.exec(markdown)?.[1];
+  if (!block) return "";
+  const line = block.match(/^description:[ \t]*(.*)$/m)?.[1]?.trim();
+  if (!line) return "";
+  return line.replace(/^(['"])(.*)\1$/, "$2");
+}
+
+/**
+ * Render the discovery prompt: only names+descriptions enter the system
+ * prompt, keeping context lean. When a task matches, the agent reads that
+ * skill's SKILL.md with the existing file tools (progressive disclosure).
+ * Empty when no skills are installed.
+ */
+export function buildSkillsPrompt(skills: readonly SkillEntry[]): string {
+  if (skills.length === 0) return "";
+  return [
+    "## Available skills",
+    "",
+    `The following agent skills are installed in this workspace under \`${SKILLS_INSTALL_DIR}/\`. ` +
+      "Only their names and descriptions are shown — the full instructions are not loaded yet. " +
+      `When a task matches a skill, read \`${SKILLS_INSTALL_DIR}/<name>/SKILL.md\` with the \`files_read\` tool ` +
+      "for its full instructions, then read any files it references in that directory with `files_read` or `bash`.",
+    "",
+    ...skills.map((s) => `- ${s.name}: ${s.description}`),
+  ].join("\n");
+}
+
+/**
+ * Install agent skills into the sandbox with Vercel's `skills` CLI, sourcing
+ * from local directories (never the network). Each skill is staged under
+ * `<staging>/skills/<name>` (the collection layout the CLI expects), then
+ * `skills add` copies it into the workspace's `.claude/skills/`. Returns the
+ * discovered registry (name+description+dir) used for progressive disclosure.
+ * A no-op that returns `[]` when no skills are requested.
+ */
+export async function installSkills(
+  sandbox: DockerSandbox,
+  sources: readonly SkillSource[],
+): Promise<SkillEntry[]> {
+  if (sources.length === 0) return [];
+
+  // Stage every requested skill under <staging>/skills/<name>, mirroring the
+  // collection layout `skills add <dir>` expects from a local source.
+  await sandbox.runShellAsRoot(
+    `rm -rf ${SKILLS_STAGING_DIR} && mkdir -p ${SKILLS_STAGING_DIR}/skills`,
+  );
+  for (const source of sources) {
+    await sandbox.copyToContainer(
+      source.dir,
+      `${SKILLS_STAGING_DIR}/skills/${source.name}`,
+    );
+  }
+
+  // `skills add <dir>` installs to the cwd's project scope, and runShell's cwd
+  // is the workspace, so skills land in <workspace>/<agent dirs>/. --copy (not
+  // symlink) keeps the workspace self-contained once staging is gone; --skill
+  // '*' installs all staged skills; --yes is non-interactive.
+  //
+  // TODO: install only for the agent the experiment uses (--agent claude-code,
+  // codex, gemini-cli, …) once that is threaded through. We only run models via
+  // the AI SDK today, so for now we install for all agents and read claude-code's
+  // .claude/skills scope (SKILLS_INSTALL_DIR).
+  const install = await sandbox.runShell(
+    `skills add ${SKILLS_STAGING_DIR} --skill '*' --copy --yes`,
+  );
+  if (!install.ok) {
+    throw new Error(
+      `failed to install skills with the skills CLI: ${install.stderr || install.stdout}`,
+    );
+  }
+
+  // Confirm what landed and read each skill's description for the discovery
+  // listing. The name is the install directory; only the description is read.
+  const entries: SkillEntry[] = [];
+  for (const source of sources) {
+    const dir = `${SKILLS_INSTALL_DIR}/${source.name}`;
+    const skillPath = `${dir}/SKILL.md`;
+    if (!(await sandbox.fileExists(skillPath))) {
+      throw new Error(
+        `skills CLI did not install "${source.name}" (no ${skillPath} in the sandbox)`,
+      );
+    }
+    entries.push({
+      name: source.name,
+      description: frontmatterDescription(await sandbox.readFile(skillPath)),
+      dir,
+    });
+  }
+  return entries;
+}

--- a/packages/sandbox/src/supabase.ts
+++ b/packages/sandbox/src/supabase.ts
@@ -24,6 +24,7 @@ import {
   dockerCli,
   type DockerSandbox,
 } from "./docker-sandbox.js";
+import { SKILLS_CLI_VERSION } from "./skills.js";
 import { ALL_SUPABASE_SERVICES, type SupabaseService } from "./types.js";
 
 export const SUPABASE_CLI_VERSION = "2.67.1";
@@ -46,12 +47,23 @@ const SUPABASE_PORTS = [54321, 54322, 54323, 54324, 54327, 54329];
 export async function ensureSupabaseSandboxImage(
   cliVersion: string = SUPABASE_CLI_VERSION,
 ): Promise<string> {
-  const tag = `${SANDBOX_IMAGE_REPOSITORY}:${cliVersion}`;
+  // The skills CLI version is part of the tag so bumping it rebuilds rather
+  // than reusing a stale cached image.
+  const tag = `${SANDBOX_IMAGE_REPOSITORY}:${cliVersion}-skills-${SKILLS_CLI_VERSION}`;
   const existing = await dockerCli(["image", "inspect", tag]);
   if (existing.ok) return tag;
 
   const build = await dockerCli(
-    ["build", "--build-arg", `CLI_VERSION=${cliVersion}`, "--tag", tag, "-"],
+    [
+      "build",
+      "--build-arg",
+      `CLI_VERSION=${cliVersion}`,
+      "--build-arg",
+      `SKILLS_CLI_VERSION=${SKILLS_CLI_VERSION}`,
+      "--tag",
+      tag,
+      "-",
+    ],
     { input: readFileSync(SANDBOX_DOCKERFILE_PATH, "utf8") },
   );
   if (!build.ok) {
@@ -132,7 +144,7 @@ export async function setupSupabaseSandbox(
   }
 
   if (options.localDir) {
-    await sandbox.copyHostDir(options.localDir);
+    await sandbox.copyToContainer(options.localDir, sandbox.workdir);
   }
 
   if (options.projectRunning ?? true) {

--- a/packages/sandbox/test/docker.test.ts
+++ b/packages/sandbox/test/docker.test.ts
@@ -18,6 +18,7 @@ import {
   SUPABASE_CLI_VERSION,
   teardownSupabaseProject,
 } from "../src/supabase.js";
+import { installSkills, SKILLS_INSTALL_DIR } from "../src/skills.js";
 
 const TEST_TIMEOUT_MS = 600_000;
 
@@ -56,14 +57,14 @@ describe.runIf(process.env.SANDBOX_DOCKER_TESTS)("local-stack sandbox (docker)",
         await sandbox.writeFiles({ "nested/dir/hello.txt": "roundtrip" });
         expect(await sandbox.readFile("nested/dir/hello.txt")).toBe("roundtrip");
 
-        // copyHostDir seeds straight from disk: binary content survives intact
-        // and the ignore list (.git here) is dropped.
+        // copyToContainer seeds straight from disk: binary content survives
+        // intact and the ignore list (.git here) is dropped.
         const seed = mkdtempSync(join(tmpdir(), "copyhostdir-test-"));
         try {
           writeFileSync(join(seed, "bin.dat"), Buffer.from([0x00, 0xff, 0x00, 0xfe]));
           mkdirSync(join(seed, ".git"));
           writeFileSync(join(seed, ".git", "HEAD"), "ref");
-          await sandbox.copyHostDir(seed);
+          await sandbox.copyToContainer(seed, sandbox.workdir);
           // Dump the bytes as hex (od, from coreutils) to confirm the copy is byte-exact.
           const hex = await sandbox.runShell("od -An -v -tx1 bin.dat | tr -d ' \\n'");
           expect(hex.stdout.trim()).toBe("00ff00fe");
@@ -98,6 +99,59 @@ describe.runIf(process.env.SANDBOX_DOCKER_TESTS)("local-stack sandbox (docker)",
         expect(error).not.toBeNull();
       } finally {
         await teardownSupabaseProject(sandbox);
+        await sandbox.stop();
+      }
+    },
+  );
+
+  it(
+    "installs a local skill into the workspace with the skills CLI",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const image = await ensureSupabaseSandboxImage();
+      const sandbox = await DockerSandbox.create({ image });
+      // A minimal on-disk skill fixture (name+description frontmatter plus a
+      // bundled reference file) installed from a local dir — never the network.
+      const src = mkdtempSync(join(tmpdir(), "skill-src-"));
+      try {
+        mkdirSync(join(src, "references"), { recursive: true });
+        writeFileSync(
+          join(src, "SKILL.md"),
+          [
+            "---",
+            "name: demo-skill",
+            "description: A demo skill used in tests.",
+            "---",
+            "",
+            "# Demo",
+            "See references/extra.md.",
+          ].join("\n"),
+        );
+        writeFileSync(join(src, "references", "extra.md"), "extra content");
+
+        const entries = await installSkills(sandbox, [
+          { name: "demo-skill", dir: src },
+        ]);
+
+        expect(entries).toEqual([
+          {
+            name: "demo-skill",
+            description: "A demo skill used in tests.",
+            dir: `${SKILLS_INSTALL_DIR}/demo-skill`,
+          },
+        ]);
+        // The full skill tree (including bundled references) is reachable in
+        // the workspace via the agent's file tools.
+        expect(
+          await sandbox.fileExists(`${SKILLS_INSTALL_DIR}/demo-skill/SKILL.md`),
+        ).toBe(true);
+        expect(
+          await sandbox.readFile(
+            `${SKILLS_INSTALL_DIR}/demo-skill/references/extra.md`,
+          ),
+        ).toBe("extra content");
+      } finally {
+        rmSync(src, { recursive: true, force: true });
         await sandbox.stop();
       }
     },

--- a/packages/sandbox/test/unit.test.ts
+++ b/packages/sandbox/test/unit.test.ts
@@ -12,6 +12,12 @@ import {
   buildSupabaseStartCommand,
   computeExcludedServices,
 } from "../src/supabase.js";
+import {
+  SKILLS_CLI_VERSION,
+  SKILLS_INSTALL_DIR,
+  buildSkillsPrompt,
+  frontmatterDescription,
+} from "../src/skills.js";
 import { ALL_SUPABASE_SERVICES } from "../src/types.js";
 
 describe("sandbox Dockerfile", () => {
@@ -23,6 +29,65 @@ describe("sandbox Dockerfile", () => {
       "https://github.com/supabase/cli/releases/download/v${CLI_VERSION}/supabase_${CLI_VERSION}_linux_${ARCH}.deb",
     );
     expect(dockerfile).toContain("dpkg -i /tmp/supabase.deb");
+  });
+
+  it("bakes in Vercel's skills CLI pinned via build arg", () => {
+    const dockerfile = readFileSync(SANDBOX_DOCKERFILE_PATH, "utf8");
+    expect(dockerfile).toContain("ARG SKILLS_CLI_VERSION");
+    expect(dockerfile).toContain('npm install -g "skills@${SKILLS_CLI_VERSION}"');
+  });
+});
+
+describe("frontmatterDescription", () => {
+  it("reads a quoted description containing colons", () => {
+    const md = [
+      "---",
+      "name: supabase",
+      'description: "Use when doing X. Triggers: a, b, c."',
+      "metadata:",
+      "  author: supabase",
+      "---",
+      "",
+      "# Body",
+    ].join("\n");
+    expect(frontmatterDescription(md)).toBe("Use when doing X. Triggers: a, b, c.");
+  });
+
+  it("reads an unquoted single-line description", () => {
+    expect(
+      frontmatterDescription("---\nname: pg\ndescription: Postgres tips.\n---\nbody"),
+    ).toBe("Postgres tips.");
+  });
+
+  it("returns empty without frontmatter or without a description", () => {
+    expect(frontmatterDescription("# Just a body")).toBe("");
+    expect(frontmatterDescription("---\nname: solo\n---\nbody")).toBe("");
+  });
+});
+
+describe("buildSkillsPrompt", () => {
+  it("is empty when no skills are installed", () => {
+    expect(buildSkillsPrompt([])).toBe("");
+  });
+
+  it("lists name+description and points at the install dir for files_read", () => {
+    const prompt = buildSkillsPrompt([
+      { name: "supabase", description: "Use for Supabase tasks.", dir: "x" },
+      { name: "pg", description: "Postgres tips.", dir: "y" },
+    ]);
+    expect(prompt).toContain(SKILLS_INSTALL_DIR);
+    expect(prompt).toContain("files_read");
+    expect(prompt).toContain("SKILL.md");
+    expect(prompt).toContain("- supabase: Use for Supabase tasks.");
+    expect(prompt).toContain("- pg: Postgres tips.");
+    // Discovery only — the full body must not be inlined here.
+    expect(prompt).not.toContain("# Body");
+  });
+});
+
+describe("SKILLS_CLI_VERSION", () => {
+  it("is a pinned semver string", () => {
+    expect(SKILLS_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });
 


### PR DESCRIPTION
Install the experiment's agent skills into the local-stack sandbox with Vercel's `skills` package and expose them via progressive discovery (name+description in the prompt; the agent reads `.claude/skills/<name>/SKILL.md` on demand), while tools mode keeps injecting full skill text into the prompt.

Closes AI-845