### PR TITLE
feat(ci): run each eval in an isolated matrix job

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -90,7 +90,6 @@ jobs:
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
-          sparse-checkout: evals
 
       - name: Discover evals
         id: discover
@@ -117,6 +116,11 @@ jobs:
               matching+=("$id")
             fi
           done
+
+          if [ "${#matching[@]}" -eq 0 ]; then
+            echo "No evals found for suites: $suite_json" >&2
+            exit 1
+          fi
 
           evals_json=$(printf '%s\n' "${matching[@]}" | jq -Rcs 'split("\n") | map(select(length > 0))')
           echo "evals=$evals_json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       experiments: ${{ steps.inputs.outputs.experiments }}
       eval: ${{ steps.inputs.outputs.eval }}
+      evals: ${{ steps.discover.outputs.evals }}
       suite: ${{ steps.inputs.outputs.suite }}
       runs: ${{ steps.inputs.outputs.runs }}
       timeout_sec: ${{ steps.inputs.outputs.timeout_sec }}
@@ -85,6 +86,41 @@ jobs:
             echo "timeout_sec=$timeout_sec"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+          sparse-checkout: evals
+
+      - name: Discover evals
+        id: discover
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          eval_id="${{ steps.inputs.outputs.eval }}"
+          if [ -n "$eval_id" ]; then
+            echo "evals=$(jq -n --arg id "$eval_id" '[$id]')" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          suite_json='${{ steps.inputs.outputs.suite }}'
+          matching=()
+          for dir in evals/*/; do
+            [ -d "$dir" ] || continue
+            id=$(basename "$dir")
+            prompt="$dir/PROMPT.md"
+            [ -f "$prompt" ] || continue
+            suite_val=$(grep -m1 '^suite:' "$prompt" | sed 's/^suite:[[:space:]]*//')
+            [ -n "$suite_val" ] || continue
+            if jq -e --arg s "$suite_val" 'index($s) != null' <<< "$suite_json" > /dev/null 2>&1; then
+              matching+=("$id")
+            fi
+          done
+
+          evals_json=$(printf '%s\n' "${matching[@]}" | jq -Rcs 'split("\n") | map(select(length > 0))')
+          echo "evals=$evals_json" >> "$GITHUB_OUTPUT"
+
   run-evals:
     needs: prepare
     runs-on: ubuntu-latest
@@ -92,6 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         experiment: ${{ fromJSON(needs.prepare.outputs.experiments) }}
+        eval_id: ${{ fromJSON(needs.prepare.outputs.evals) }}
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -129,30 +166,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          args=(
-            "--experiment"
-            "${{ matrix.experiment }}"
-            "--runs"
-            "${{ needs.prepare.outputs.runs }}"
-            "--timeout-sec"
-            "${{ needs.prepare.outputs.timeout_sec }}"
-            "--force"
-          )
-
-          while IFS= read -r suite; do
-            args+=("--suite" "$suite")
-          done < <(jq -r '.[]' <<< '${{ needs.prepare.outputs.suite }}')
-
-          if [ -n "${{ needs.prepare.outputs.eval }}" ]; then
-            args+=("--eval" "${{ needs.prepare.outputs.eval }}")
-          fi
-
-          pnpm eval -- "${args[@]}"
+          pnpm eval -- \
+            --experiment "${{ matrix.experiment }}" \
+            --eval "${{ matrix.eval_id }}" \
+            --runs "${{ needs.prepare.outputs.runs }}" \
+            --timeout-sec "${{ needs.prepare.outputs.timeout_sec }}" \
+            --force
 
       - name: Upload raw results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: raw-results-${{ matrix.experiment }}
+          name: raw-results-${{ matrix.experiment }}-${{ matrix.eval_id }}
           path: results/${{ matrix.experiment }}/
           retention-days: 3
 
@@ -191,11 +215,10 @@ jobs:
           mkdir -p results
           export_args=()
           while IFS= read -r experiment; do
-            artifact_dir="downloaded-results/raw-results-$experiment"
-            if [ -d "$artifact_dir" ]; then
-              mkdir -p "results/$experiment"
-              cp -R "$artifact_dir"/. "results/$experiment"/
-            fi
+            mkdir -p "results/$experiment"
+            for artifact_dir in "downloaded-results/raw-results-${experiment}-"*/; do
+              [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. "results/$experiment"/
+            done
             export_args+=("--experiment" "$experiment")
           done < <(jq -r '.[]' <<< '${{ needs.prepare.outputs.experiments }}')
 

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -110,8 +110,8 @@ jobs:
             id=$(basename "$dir")
             prompt="$dir/PROMPT.md"
             [ -f "$prompt" ] || continue
-            suite_val=$(grep -m1 '^suite:' "$prompt" | sed 's/^suite:[[:space:]]*//')
-            [ -n "$suite_val" ] || continue
+            suite_val=$(sed -n 's/^suite:[[:space:]]*//p' "$prompt" | head -n 1)
+            suite_val="${suite_val:-regression}"
             if jq -e --arg s "$suite_val" 'index($s) != null' <<< "$suite_json" > /dev/null 2>&1; then
               matching+=("$id")
             fi

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Upload raw results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: raw-results-${{ matrix.experiment }}-${{ matrix.eval_id }}
+          name: raw-results-${{ matrix.experiment }}__${{ matrix.eval_id }}
           path: results/${{ matrix.experiment }}/
           retention-days: 3
 
@@ -216,7 +216,7 @@ jobs:
           export_args=()
           while IFS= read -r experiment; do
             mkdir -p "results/$experiment"
-            for artifact_dir in "downloaded-results/raw-results-${experiment}-"*/; do
+            for artifact_dir in "downloaded-results/raw-results-${experiment}__"*/; do
               [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. "results/$experiment"/
             done
             export_args+=("--experiment" "$experiment")

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -58,7 +58,7 @@ const EVAL_FILTERS = readRepeatedFlag(rawArgs, "eval");
 const SUITE_FILTERS = readSuiteFilters(rawArgs);
 const RUNS = Number(readFlag("runs") ?? 4);
 const TIMEOUT_SEC = Number(readFlag("timeout-sec") ?? 720);
-const CONCURRENCY = Number(readFlag("concurrency") ?? 4);
+const CONCURRENCY = Number(readFlag("concurrency") ?? 1);
 const STOP_ON_PASS = !args.has("--run-all-attempts");
 const DEBUG = args.has("--debug");
 

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -73,7 +73,8 @@
       },
       {
         "name": "schema file updated to include description column",
-        "passed": true
+        "passed": false,
+        "notes": "description not found in any schema file"
       },
       {
         "name": "a new migration was generated for the change",
@@ -104,7 +105,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -116,7 +117,7 @@
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user A cannot force-read user B note",
@@ -162,7 +163,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ee1a1-bced-745d-aaef-83b3d7092d41/receipt-alpha.pdf, 019ee1a1-bced-745d-aaef-83b3d7092d41/receipt-beta.pdf"
+        "notes": "saw: 019ee1d4-0a15-77f2-811d-9f918c6f36b2/receipt-alpha.pdf, 019ee1d4-0a15-77f2-811d-9f918c6f36b2/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -183,13 +184,54 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, enabled RLS, added authenticated owner-scoped SELECT and INSERT policies using the first path segment equals auth.uid(), and provided supabase-js createSignedUrl code with an expiry. The service role key was only recommended server-side, not client-side."
+        "judgeNotes": "Meets all requirements: private user-files bucket, RLS enabled, authenticated owner-scoped SELECT and INSERT policies using first path segment = auth.uid(), and supabase-js createSignedUrl with expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-mini/build-storage-001-private-bucket-access.json"
+  },
+  {
+    "experiment": "openai-gpt-5.4-mini",
+    "eval": "build-tests-001-rls-tenant-isolation",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "tests",
+      "rls"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "pgTAP test file(s) written under supabase/tests/",
+        "passed": true,
+        "notes": "1 file(s): supabase/tests/database/001_tenant_isolation.test.sql"
+      },
+      {
+        "name": "positive isolation tests pass (notes table)",
+        "passed": true,
+        "notes": "4 passed, 0 failed"
+      },
+      {
+        "name": "negative isolation tests catch the bug in posts table",
+        "passed": false,
+        "notes": "all tests passed — negative case not covered or policy was not tested"
+      },
+      {
+        "name": "agent correctly identifies the posts isolation bug from test results",
+        "passed": true,
+        "judgeNotes": "The agent correctly identified the broken tenant isolation policy on `posts`, attributed the pgTAP failures to that policy flaw, and did not blame `notes` or dismiss the test results."
+      }
+    ],
+    "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
+    "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "openai-gpt-5.4-mini/build-tests-001-rls-tenant-isolation.json"
   },
   {
     "experiment": "openai-gpt-5.4-mini",
@@ -237,12 +279,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Prometheus basic_auth uses an inline environment variable password instead of password_file, and docker-compose.yml does not mount the password file via a volume or Compose secret."
+        "judgeNotes": "Fails because Prometheus uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount or wire a password_file via a volume or Compose secret. The app job is preserved and the HTTPS metrics endpoint/target are otherwise present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes creating a Supabase Secret API key and concrete verification via `up{job=\"supabase\"}`, but it does not clearly require placing the matching secret file for the Compose stack or restarting/reloading the Compose stack to make the integration live."
+        "judgeNotes": "README includes creating a Supabase Secret API key, restarting the Compose stack, and verifying via Prometheus targets, but it does not require placing the matching secret file. The Compose setup uses environment variables instead, so it fails the required secret-file setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -276,7 +318,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "judgeNotes": "Reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -350,8 +392,8 @@
       },
       {
         "name": "diagnosed missing publication membership",
-        "passed": true,
-        "judgeNotes": "Identified the root cause as orders missing from supabase_realtime and added public.orders to that publication. No RLS/policy weakening or client-side-only fix was proposed, though creating the table/setting replica identity were extra unnecessary steps."
+        "passed": false,
+        "judgeNotes": "The assistant correctly identified the missing supabase_realtime publication membership and added orders. However, it did more than exactly that: it created the orders table and created the supabase_realtime publication, which risks altering existing setup and could break the courier_locations feed. The rubric requires adding orders to the existing publication while leaving the rest intact."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -370,22 +412,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as affected and described repeated 503s throughout the morning with a recurring pattern, while not misattributing to billing-webhook."
+        "judgeNotes": "Identified image-transform as affected and described intermittent recurring 503 gateway failures throughout the morning, with many successes and sporadic failures roughly every 30 minutes. This covers the required pattern rather than misattributing to older billing-webhook issues."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The assistant does not attribute the recurring image-transform 503s to the gateway/platform layer. It instead says it looks like a transient dependency/health issue inside the image-processing function path and recommends inspecting/fixing function code, adding logging/retries. Although it notes unchanged deployment/version and distinguishes avatar-upload's 500, the primary attribution is to the function path rather than gateway/platform."
+        "passed": true,
+        "judgeNotes": "The assistant attributes the intermittent image-transform 503s to the gateway/platform/runtime layer rather than deterministic function code, and grounds this in valid observations: 503s appear on the gateway surface while Edge Function logs show only successful invocations/no function-level crash evidence, and it distinguishes avatar-upload's one-off 500 from the gateway 503s."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete actionable next steps, including inspecting Edge Function code/dependencies, adding targeted error logging, implementing retries/backoff, graceful failover, and checking external provider status."
+        "judgeNotes": "The assistant recommended concrete next steps including checking Supabase/Edge Function incident history, inspecting gateway health/function metrics around 503 timestamps, adding retries, and investigating related upload validation/storage permissions."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -407,12 +449,36 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
-        "name": "created auth sessions",
-        "passed": false,
-        "notes": "Internal server error"
+        "name": "RLS still enabled on bookmarks",
+        "passed": true
+      },
+      {
+        "name": "user A reads own bookmarks",
+        "passed": true
+      },
+      {
+        "name": "user B cannot read user A bookmarks",
+        "passed": true
+      },
+      {
+        "name": "anon reads no bookmarks",
+        "passed": true
+      },
+      {
+        "name": "user A can save a new bookmark",
+        "passed": true
+      },
+      {
+        "name": "user B cannot insert a bookmark as user A",
+        "passed": true
+      },
+      {
+        "name": "diagnosed RLS and added owner-scoped policies",
+        "passed": true,
+        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and created authenticated-only SELECT and INSERT owner-scoped policies enforcing auth.uid() = user_id."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -432,11 +498,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -592,8 +658,7 @@
       },
       {
         "name": "schema file updated to include description column",
-        "passed": false,
-        "notes": "description not found in any schema file"
+        "passed": true
       },
       {
         "name": "a new migration was generated for the change",
@@ -682,7 +747,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ee1a1-ce3f-7093-aacb-fd6441b6473f/receipt-alpha.pdf, 019ee1a1-ce3f-7093-aacb-fd6441b6473f/receipt-beta.pdf"
+        "notes": "saw: 019ee1d4-2821-77a0-9cf3-332beb4b9272/receipt-alpha.pdf, 019ee1d4-2821-77a0-9cf3-332beb4b9272/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -703,7 +768,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped INSERT and SELECT policies on storage.objects based on the first path segment matching auth.uid(), and provided supabase-js code using createSignedUrl with an expiry for temporary sharing."
+        "judgeNotes": "Meets requirements: private user-files bucket, RLS enabled, authenticated owner-scoped SELECT and INSERT policies on storage.objects, and supabase-js createSignedUrl code with expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -728,23 +793,23 @@
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": false,
-        "notes": "no .sql files found under supabase/tests/"
+        "passed": true,
+        "notes": "2 file(s): supabase/tests/tenant_rls.sql, supabase/tests/tenant_rls_assertions.sql"
       },
       {
         "name": "positive isolation tests pass (notes table)",
         "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+        "notes": "no test summary found; exit 1; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download comple"
       },
       {
         "name": "negative isolation tests catch the bug in posts table",
         "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+        "notes": "no test summary found; exit 1; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download comple"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as having a broken tenant isolation policy allowing cross-organization reads by authenticated members, attributed this to test failures, and did not blame `notes` or dismiss the test results. It also noted memberships leakage, but that does not undermine the required conclusion."
+        "judgeNotes": "The agent correctly identifies `posts` as the table with the tenant isolation flaw, explains that authenticated members can read posts from other orgs due to missing org_id constraint, and attributes the observed test failure (u1 sees 2 posts instead of 1) to that policy. It treats the test results as authoritative and does not blame notes or dismiss failures."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -770,7 +835,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "relation \"documents\" does not exist"
+        "notes": "operator does not exist: uuid = integer"
       }
     ],
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -798,12 +863,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with an environment variable instead of required password_file, and docker-compose.yml does not mount that password_file via a volume or Compose secret. Secret wiring is therefore missing/mismatched despite preserving the app job and using the correct HTTPS metrics path."
+        "judgeNotes": "Fails: the Supabase scrape job is commented out, uses basic_auth password/env var instead of password_file, and docker-compose.yml does not mount the password_file via volume or Compose secret. Existing app scrape is preserved and endpoint is otherwise correct, but required secret wiring is missing."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README does not instruct creating/placing a matching secret file; it tells users to put the Secret API key directly in docker-compose environment. Verification is also not concrete via Prometheus targets/PromQL/Grafana."
+        "judgeNotes": "README includes endpoint/auth and basic verification via Prometheus targets/Grafana, but it does not provide required steps to create a Secret API key, place the matching secret file, or restart/reload the Compose stack with that secret setup. It uses vague env var injection instead of the required secret file workflow."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -912,7 +977,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": false,
-        "judgeNotes": "The answer did not clearly diagnose the specific root cause as `orders` missing from the existing `supabase_realtime` publication. It also added unrelated `REPLICA IDENTITY FULL` changes and suggested RLS as a possible remaining blocker, rather than fixing exactly the publication membership issue."
+        "judgeNotes": "The assistant did not identify and fix the specific issue (orders missing from the supabase_realtime publication). It reported no orders table/no publications and requested more info, with no ALTER PUBLICATION fix applied."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -936,17 +1001,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant identified image-transform as the affected function and described recurring intermittent HTTP 503 responses throughout the morning of 2026-04-28, with timestamps covering most of the gateway failures."
+        "judgeNotes": "The assistant identified image-transform as the affected function and described recurring intermittent 503s throughout the morning of 2026-04-28, with multiple examples across the 07:00Z-12:00Z window and successes in between."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The response does not attribute the recurring 503s to the gateway/platform layer as the primary cause. It suggests cold starts, runtime crashes, dependency/startup issues, and recommends redeploying/hardening the function, which the rubric explicitly treats as failing. It also lacks the key grounding observation that the 503s appear only in gateway/HTTP logs without corresponding invocation/runtime rows."
+        "judgeNotes": "The response does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function. It instead frames the issue as the image-transform Edge Function/runtime/dependency being unable to serve requests and recommends investigating/redeploying the function, which the rubric explicitly treats as failing."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: redeploying the Edge Function, adding retries, instrumenting/hardening the function, and inspecting runtime/error logs around the failing timestamps."
+        "judgeNotes": "The assistant recommended specific actionable next steps, including checking Edge Function execution/runtime health around the 503s, adding observability, redeploying with updated runtime/dependency settings, and adding retries/fallbacks."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -997,7 +1062,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all Data API results, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "The assistant correctly diagnosed deny-all RLS due to no policies, kept RLS enabled, and created authenticated-only owner-scoped SELECT and INSERT policies using user_id = auth.uid()."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -1017,15 +1082,15 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": false
+        "passed": true
       },
       {
         "name": "created index covering user_id and created_at",


### PR DESCRIPTION
Runs eval refresh as an `experiment × eval_id` matrix so each eval gets a fresh runner and no longer shares ports or memory with sibling evals. This avoids errors like those seen on [this run](https://github.com/supabase/evals/actions/runs/27844049342/job/82411546018).

Sample run from this PR with the full suite succeeding in 5 min: https://github.com/supabase/evals/actions/runs/27849626280

For local testing, eval concurrency now defaults to `1` and higher concurrency is opt-in with `--concurrency`

Ref AI-829