### PR TITLE
feat(benchmark): self-host Supabase with Docker eval

### DIFF
--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -1250,7 +1250,8 @@
       },
       {
         "name": "schema file updated to include description column",
-        "passed": true
+        "passed": false,
+        "notes": "description not found in any schema file"
       },
       {
         "name": "a new migration was generated for the change",
@@ -1500,44 +1501,6 @@
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-mini/deploy-functions-001-edge-function-secrets.json"
-  },
-  {
-    "experiment": "openai-gpt-5.4-mini",
-    "eval": "deploy-self-hosting-001-docker-compose",
-    "stage": "deploy",
-    "product": [
-      "database",
-      "auth",
-      "storage"
-    ],
-    "topic": [
-      "self-hosting"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": true
-      },
-      {
-        "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
-        "passed": true
-      },
-      {
-        "name": "secrets rotated off the shipped defaults",
-        "passed": true
-      },
-      {
-        "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": true
-      }
-    ],
-    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
-    "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "openai-gpt-5.4-mini/deploy-self-hosting-001-docker-compose.json"
   },
   {
     "experiment": "openai-gpt-5.4-mini",
@@ -1968,7 +1931,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "bucket user-files exists",
@@ -2068,7 +2031,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "relation \"documents\" does not exist"
+        "notes": "operator does not exist: uuid = integer"
       }
     ],
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -2146,47 +2109,6 @@
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-nano/deploy-functions-001-edge-function-secrets.json"
-  },
-  {
-    "experiment": "openai-gpt-5.4-nano",
-    "eval": "deploy-self-hosting-001-docker-compose",
-    "stage": "deploy",
-    "product": [
-      "database",
-      "auth",
-      "storage"
-    ],
-    "topic": [
-      "self-hosting"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": false,
-        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
-      },
-      {
-        "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
-        "passed": true
-      },
-      {
-        "name": "secrets rotated off the shipped defaults",
-        "passed": false,
-        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
-      },
-      {
-        "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": false,
-        "notes": "JWT_SECRET missing"
-      }
-    ],
-    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
-    "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "openai-gpt-5.4-nano/deploy-self-hosting-001-docker-compose.json"
   },
   {
     "experiment": "openai-gpt-5.4-nano",
@@ -2381,15 +2303,15 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": false
+        "passed": true
       },
       {
         "name": "created index covering user_id and created_at",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -105,7 +105,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -117,7 +117,7 @@
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user A cannot force-read user B note",
@@ -163,7 +163,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ee1d4-0a15-77f2-811d-9f918c6f36b2/receipt-alpha.pdf, 019ee1d4-0a15-77f2-811d-9f918c6f36b2/receipt-beta.pdf"
+        "notes": "saw: 019ef255-e197-713b-986e-55f0275800bd/receipt-alpha.pdf, 019ef255-e197-713b-986e-55f0275800bd/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -184,7 +184,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets all requirements: private user-files bucket, RLS enabled, authenticated owner-scoped SELECT and INSERT policies using first path segment = auth.uid(), and supabase-js createSignedUrl with expiry for temporary sharing."
+        "judgeNotes": "The answer creates a private user-files bucket, enables/keeps RLS on storage.objects, adds authenticated owner-scoped INSERT and SELECT policies using bucket_id, owner_id, and the user-id path prefix, and provides supabase-js createSignedUrl code with a 15-minute expiry. No public bucket, public URL, anon policy, permissive policy, or client service-role usage."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -205,27 +205,22 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/database/001_tenant_isolation.test.sql"
+        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
       },
       {
-        "name": "positive isolation tests pass (notes table)",
+        "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "4 passed, 0 failed"
-      },
-      {
-        "name": "negative isolation tests catch the bug in posts table",
-        "passed": false,
-        "notes": "all tests passed — negative case not covered or policy was not tested"
+        "notes": "6 passed, 0 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified the broken tenant isolation policy on `posts`, attributed the pgTAP failures to that policy flaw, and did not blame `notes` or dismiss the test results."
+        "judgeNotes": "The agent correctly identified `posts` as the table with broken tenant isolation, specifically that its SELECT policy allowed users with any membership to read posts outside their org. It grounded this in the pgTAP failure and did not blame `notes` or dismiss the tests."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -279,12 +274,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails because Prometheus uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount or wire a password_file via a volume or Compose secret. The app job is preserved and the HTTPS metrics endpoint/target are otherwise present."
+        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, and preserves the app job, but it uses basic_auth.password from an environment variable instead of basic_auth.password_file. docker-compose.yml also does not mount the password file via a volume or Compose secret. This fails the required secret wiring."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes creating a Supabase Secret API key, restarting the Compose stack, and verifying via Prometheus targets, but it does not require placing the matching secret file. The Compose setup uses environment variables instead, so it fails the required secret-file setup."
+        "judgeNotes": "README includes the correct Supabase metrics endpoint, Secret API key concept, .env copy step, redeploy, and basic verification. However it does not instruct setting SUPABASE_METRICS_USER even though prometheus.yml requires it, so the secret/env setup is mismatched. Live deployment steps are also somewhat vague about placing the matching secret file for Compose."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -332,6 +327,48 @@
   },
   {
     "experiment": "openai-gpt-5.4-mini",
+    "eval": "deploy-self-hosting-001-docker-compose",
+    "stage": "deploy",
+    "product": [
+      "database",
+      "auth",
+      "storage"
+    ],
+    "topic": [
+      "self-hosting"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
+        "passed": true
+      },
+      {
+        "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
+        "passed": true
+      },
+      {
+        "name": "secrets rotated off the shipped defaults",
+        "passed": true
+      },
+      {
+        "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
+        "passed": true
+      },
+      {
+        "name": "no CRLF line endings in the stack (breaks Kong entrypoint)",
+        "passed": true
+      }
+    ],
+    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here — I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets sorted out so I'm not\nshipping any of the insecure defaults. Put it in a `supabase-docker/` folder at\nthe repo root so I can scp the whole thing across in one go.",
+    "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "openai-gpt-5.4-mini/deploy-self-hosting-001-docker-compose.json"
+  },
+  {
+    "experiment": "openai-gpt-5.4-mini",
     "eval": "investigate-auth-001-deleted-user-access",
     "stage": "investigate",
     "product": [
@@ -345,9 +382,34 @@
     "passed": false,
     "checks": [
       {
-        "name": "scorer evaluated deleted user access",
+        "name": "victim session active before delete-account",
+        "passed": true
+      },
+      {
+        "name": "delete_account flow ran for the victim",
+        "passed": true
+      },
+      {
+        "name": "delete-account revokes the user's sessions",
+        "passed": true,
+        "notes": "sessions left: 0"
+      },
+      {
+        "name": "deleted user's refresh token is rejected",
+        "passed": true
+      },
+      {
+        "name": "deleted user cannot sign back in",
+        "passed": true
+      },
+      {
+        "name": "other users keep their sessions and access",
+        "passed": true
+      },
+      {
+        "name": "diagnosed and explained session revocation",
         "passed": false,
-        "notes": "relation \"profiles\" does not exist"
+        "judgeNotes": "The answer correctly identifies the soft-delete problem, deletes the auth user, and explains publishable vs secret keys. However, it incorrectly says there is no access window after the fix and does not explain that stateless access JWTs can remain valid until expiry or that server-side authorization should use auth.getUser()/short JWT expiry rather than only local JWT validation such as getClaims()."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -367,7 +429,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "orders table added to supabase_realtime publication",
@@ -375,7 +437,7 @@
       },
       {
         "name": "courier_locations still in supabase_realtime publication",
-        "passed": false
+        "passed": true
       },
       {
         "name": "publication still publishes INSERT events",
@@ -383,17 +445,17 @@
       },
       {
         "name": "RLS still enabled on orders",
-        "passed": false
+        "passed": true
       },
       {
         "name": "staff can still read orders through RLS",
-        "passed": false,
-        "notes": ""
+        "passed": true,
+        "notes": "authenticated sees 2 of 2 orders"
       },
       {
         "name": "diagnosed missing publication membership",
-        "passed": false,
-        "judgeNotes": "The assistant correctly identified the missing supabase_realtime publication membership and added orders. However, it did more than exactly that: it created the orders table and created the supabase_realtime publication, which risks altering existing setup and could break the courier_locations feed. The rubric requires adding orders to the existing publication while leaving the rest intact."
+        "passed": true,
+        "judgeNotes": "The assistant correctly diagnosed that orders was missing from the supabase_realtime publication and fixed it with ALTER PUBLICATION ... ADD TABLE public.orders, without changing RLS/policies or disrupting courier_locations."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -412,22 +474,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as affected and described intermittent recurring 503 gateway failures throughout the morning, with many successes and sporadic failures roughly every 30 minutes. This covers the required pattern rather than misattributing to older billing-webhook issues."
+        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described the recurring HTTP 503 gateway failures across the morning of 2026-04-28, listing most/all of the 8 failures from 07:00Z to 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": true,
-        "judgeNotes": "The assistant attributes the intermittent image-transform 503s to the gateway/platform/runtime layer rather than deterministic function code, and grounds this in valid observations: 503s appear on the gateway surface while Edge Function logs show only successful invocations/no function-level crash evidence, and it distinguishes avatar-upload's one-off 500 from the gateway 503s."
+        "passed": false,
+        "judgeNotes": "The answer does identify gateway 503s with no matching function logs, but it muddies the attribution by suggesting runtime/dependency/package crashes and recommends redeploying/hardening the function as remediation, which the rubric explicitly treats as failing."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps including checking Supabase/Edge Function incident history, inspecting gateway health/function metrics around 503 timestamps, adding retries, and investigating related upload validation/storage permissions."
+        "judgeNotes": "The assistant recommended concrete next steps: checking deployment/version 42, redeploying the Edge Function, adding error logging, routing around the function, and inspecting platform/runtime logs at exact 503 timestamps."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -478,7 +540,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and created authenticated-only SELECT and INSERT owner-scoped policies enforcing auth.uid() = user_id."
+        "judgeNotes": "The assistant correctly identified RLS enabled with no policies as the cause of empty Data API results, added authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid(), and did not disable RLS."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -498,11 +560,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -515,7 +577,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -658,7 +720,8 @@
       },
       {
         "name": "schema file updated to include description column",
-        "passed": true
+        "passed": false,
+        "notes": "description not found in any schema file"
       },
       {
         "name": "a new migration was generated for the change",
@@ -747,7 +810,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ee1d4-2821-77a0-9cf3-332beb4b9272/receipt-alpha.pdf, 019ee1d4-2821-77a0-9cf3-332beb4b9272/receipt-beta.pdf"
+        "notes": "saw: 019ef255-d0b8-721f-91ac-eeb04427443d/receipt-alpha.pdf, 019ef255-d0b8-721f-91ac-eeb04427443d/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -768,7 +831,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets requirements: private user-files bucket, RLS enabled, authenticated owner-scoped SELECT and INSERT policies on storage.objects, and supabase-js createSignedUrl code with expiry for temporary sharing."
+        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped SELECT and INSERT policies (plus update/delete), and provided supabase-js createSignedUrl code with expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -793,23 +856,18 @@
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": true,
-        "notes": "2 file(s): supabase/tests/tenant_rls.sql, supabase/tests/tenant_rls_assertions.sql"
+        "passed": false,
+        "notes": "no .sql files found under supabase/tests/"
       },
       {
-        "name": "positive isolation tests pass (notes table)",
+        "name": "pgTAP isolation tests ran and pass",
         "passed": false,
-        "notes": "no test summary found; exit 1; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download comple"
-      },
-      {
-        "name": "negative isolation tests catch the bug in posts table",
-        "passed": false,
-        "notes": "no test summary found; exit 1; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download comple"
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Pull complete\na2"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as the table with the tenant isolation flaw, explains that authenticated members can read posts from other orgs due to missing org_id constraint, and attributes the observed test failure (u1 sees 2 posts instead of 1) to that policy. It treats the test results as authoritative and does not blame notes or dismiss failures."
+        "judgeNotes": "The agent correctly identified `posts` as the table with the broken tenant isolation policy, explained that authenticated users can read posts from organizations they are not members of due to a missing org_id constraint, and grounded the conclusion in the failing test results. It did not blame `notes` or dismiss the tests."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -835,7 +893,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "operator does not exist: uuid = integer"
+        "notes": "relation \"documents\" does not exist"
       }
     ],
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -863,12 +921,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: the Supabase scrape job is commented out, uses basic_auth password/env var instead of password_file, and docker-compose.yml does not mount the password_file via volume or Compose secret. Existing app scrape is preserved and endpoint is otherwise correct, but required secret wiring is missing."
+        "judgeNotes": "Fails: Supabase scrape uses inline basic_auth password via environment variable instead of password_file, and docker-compose.yml does not mount that password_file via a volume or Compose secret. It also relies on variable substitution in prometheus.yml targets, which Prometheus itself will not expand as shown, so the project target is not deployable. Existing app job is preserved and endpoint/scheme are otherwise correct."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes endpoint/auth and basic verification via Prometheus targets/Grafana, but it does not provide required steps to create a Secret API key, place the matching secret file, or restart/reload the Compose stack with that secret setup. It uses vague env var injection instead of the required secret file workflow."
+        "judgeNotes": "README.md does not explain how to create a Supabase Metrics Secret API key, place a matching secret file or configure the secret, restart/reload the Compose stack, or verify the integration via Prometheus targets/PromQL/Grafana. It only documents starting the stack and the app target."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -902,7 +960,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -913,6 +971,51 @@
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-nano/deploy-functions-001-edge-function-secrets.json"
+  },
+  {
+    "experiment": "openai-gpt-5.4-nano",
+    "eval": "deploy-self-hosting-001-docker-compose",
+    "stage": "deploy",
+    "product": [
+      "database",
+      "auth",
+      "storage"
+    ],
+    "topic": [
+      "self-hosting"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
+        "passed": false,
+        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
+      },
+      {
+        "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
+        "passed": true
+      },
+      {
+        "name": "secrets rotated off the shipped defaults",
+        "passed": false,
+        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
+      },
+      {
+        "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
+        "passed": false,
+        "notes": "JWT_SECRET missing"
+      },
+      {
+        "name": "no CRLF line endings in the stack (breaks Kong entrypoint)",
+        "passed": true
+      }
+    ],
+    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here — I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets sorted out so I'm not\nshipping any of the insecure defaults. Put it in a `supabase-docker/` folder at\nthe repo root so I can scp the whole thing across in one go.",
+    "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "openai-gpt-5.4-nano/deploy-self-hosting-001-docker-compose.json"
   },
   {
     "experiment": "openai-gpt-5.4-nano",
@@ -929,9 +1032,34 @@
     "passed": false,
     "checks": [
       {
-        "name": "scorer evaluated deleted user access",
+        "name": "victim session active before delete-account",
+        "passed": true
+      },
+      {
+        "name": "delete_account flow ran for the victim",
+        "passed": true
+      },
+      {
+        "name": "delete-account revokes the user's sessions",
+        "passed": true,
+        "notes": "sessions left: 0"
+      },
+      {
+        "name": "deleted user's refresh token is rejected",
+        "passed": true
+      },
+      {
+        "name": "deleted user cannot sign back in",
+        "passed": true
+      },
+      {
+        "name": "other users keep their sessions and access",
+        "passed": true
+      },
+      {
+        "name": "diagnosed and explained session revocation",
         "passed": false,
-        "notes": "relation \"profiles\" does not exist"
+        "judgeNotes": "The answer fixes the soft-delete issue by deleting the auth user and explains frontend publishable keys reasonably, but it fails key rubric requirements: it does not explain that existing stateless JWT access tokens can remain valid until expiry, does not mention using auth.getUser() or short JWT expiry instead of local getClaims()/JWT validation, and does not clearly state that the new secret key is server-only and bypasses RLS."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -951,33 +1079,33 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "orders table added to supabase_realtime publication",
-        "passed": false
+        "passed": true
       },
       {
         "name": "courier_locations still in supabase_realtime publication",
-        "passed": false
+        "passed": true
       },
       {
         "name": "publication still publishes INSERT events",
-        "passed": false
+        "passed": true
       },
       {
         "name": "RLS still enabled on orders",
-        "passed": false
+        "passed": true
       },
       {
         "name": "staff can still read orders through RLS",
-        "passed": false,
-        "notes": "relation \"orders\" does not exist"
+        "passed": true,
+        "notes": "authenticated sees 2 of 2 orders"
       },
       {
         "name": "diagnosed missing publication membership",
-        "passed": false,
-        "judgeNotes": "The assistant did not identify and fix the specific issue (orders missing from the supabase_realtime publication). It reported no orders table/no publications and requested more info, with no ALTER PUBLICATION fix applied."
+        "passed": true,
+        "judgeNotes": "The answer correctly identifies the root cause as orders missing from the supabase_realtime publication despite the channel being SUBSCRIBED, applies exactly ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, and does not weaken RLS/policies or disrupt courier_locations."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -1001,17 +1129,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant identified image-transform as the affected function and described recurring intermittent 503s throughout the morning of 2026-04-28, with multiple examples across the 07:00Z-12:00Z window and successes in between."
+        "judgeNotes": "Assistant identified image-transform as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, covering the expected gateway failures from 07:00Z-12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The response does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function. It instead frames the issue as the image-transform Edge Function/runtime/dependency being unable to serve requests and recommends investigating/redeploying the function, which the rubric explicitly treats as failing."
+        "judgeNotes": "The assistant says the 503s are from the Edge Function/image processing and recommends inspecting/hardening function code and runtime bottlenecks, rather than clearly attributing them to the gateway/platform layer. Although it notes unchanged version 42 and transient/platform possibility, it does not ground the issue in the gateway/HTTP-only log surface/no invocation rows and treats function/runtime remediation as primary."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps, including checking Edge Function execution/runtime health around the 503s, adding observability, redeploying with updated runtime/dependency settings, and adding retries/fallbacks."
+        "judgeNotes": "The assistant recommended concrete next steps, including confirming the upload pipeline, adding retries with backoff, inspecting the Edge Function code, and checking for load/rate-limiting or resource bottlenecks."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -1033,7 +1161,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "RLS still enabled on bookmarks",
@@ -1061,8 +1189,8 @@
       },
       {
         "name": "diagnosed RLS and added owner-scoped policies",
-        "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed deny-all RLS due to no policies, kept RLS enabled, and created authenticated-only owner-scoped SELECT and INSERT policies using user_id = auth.uid()."
+        "passed": false,
+        "judgeNotes": "The assistant correctly diagnosed RLS deny-all and added owner-scoped SELECT/INSERT policies, but the policies omit `TO authenticated`, so they apply to PUBLIC rather than being scoped to the authenticated role as required by the rubric."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -1082,7 +1210,7 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
@@ -1090,7 +1218,7 @@
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": true
+        "passed": false
       },
       {
         "name": "created index covering user_id and created_at",
@@ -1099,7 +1227,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=79.74..79.86 rows=50 width=58)\n  ->  Sort  (cost=79.74..79.99 rows=100 width=58)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=5.06..76.42 rows=100 width=58)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..5.03 rows=100 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -73,8 +73,7 @@
       },
       {
         "name": "schema file updated to include description column",
-        "passed": false,
-        "notes": "description not found in any schema file"
+        "passed": true
       },
       {
         "name": "a new migration was generated for the change",
@@ -105,7 +104,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -121,11 +120,11 @@
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": false
       }
     ],
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
@@ -163,7 +162,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ef25e-033d-73d7-8e5d-71b978da361c/receipt-alpha.pdf, 019ef25e-033d-73d7-8e5d-71b978da361c/receipt-beta.pdf"
+        "notes": "saw: 019ef26b-3b16-70f6-b1e0-dd2055f16675/receipt-alpha.pdf, 019ef26b-3b16-70f6-b1e0-dd2055f16675/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -184,7 +183,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled on storage.objects, added authenticated owner-scoped SELECT and INSERT policies using the user-id path prefix, and provided supabase-js createSignedUrl code with an expiry for temporary sharing."
+        "judgeNotes": "Configured a private user-files bucket, enabled RLS on storage.objects, added authenticated owner-scoped SELECT and INSERT policies using the first path segment against auth.uid(), and provided createSignedUrl code with an expiry."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -215,12 +214,12 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "2 passed, 1 failed"
+        "notes": "4 passed, 0 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the table with the broken tenant isolation policy, explained that authenticated members can read posts from other orgs due to missing `m.org_id = posts.org_id`, and grounded the conclusion in pgTAP test results showing `notes` passed and `posts` failed."
+        "judgeNotes": "The agent correctly identified `posts` as the table with the tenant isolation flaw, specifically missing the `org_id` check allowing authenticated members to read posts outside their org, and grounded this in pgTAP results showing `posts` failures before the fix."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -274,12 +273,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, project target, and preserves the app job, but it uses basic_auth.password with an environment variable instead of basic_auth.password_file. docker-compose.yml also does not mount the password file via a volume or Compose secret, so the required secret wiring is missing."
+        "judgeNotes": "Fails: Supabase scrape uses basic_auth password with environment/template substitution instead of password_file, and docker-compose does not mount the password_file via a volume or Compose secret. It also injects the Secret API key into rendered prometheus.yml."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": true,
-        "judgeNotes": "README describes creating a Supabase Secret API key, putting values in the observability .env file, starting/redeploying the Compose stack, and verifying via Prometheus target health plus a concrete curl check."
+        "passed": false,
+        "judgeNotes": "README includes correct endpoint/auth and concrete Prometheus target verification, but it does not explain creating a Supabase Secret API key, does not require placing a matching secret file, and only vaguely says to restart Prometheus/Grafana rather than restart/reload the Compose stack."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -313,7 +312,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -356,13 +355,9 @@
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
         "passed": true
-      },
-      {
-        "name": "no CRLF line endings in the stack (breaks Kong entrypoint)",
-        "passed": true
       }
     ],
-    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here — I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets sorted out so I'm not\nshipping any of the insecure defaults. Put it in a `supabase-docker/` folder at\nthe repo root so I can scp the whole thing across in one go.",
+    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-mini/deploy-self-hosting-001-docker-compose.json"
@@ -409,7 +404,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer fixes/diagnoses the soft-delete issue and correctly distinguishes publishable vs secret keys, but it fails the required access-token explanation. It says there is effectively no window for normal Data API access rather than explaining that stateless JWT access tokens remain valid until expiry after session/user revocation, and it does not mention using auth.getUser() or short JWT expiry instead of only local JWT validation/getClaims()."
+        "judgeNotes": "The answer correctly identifies the soft-delete/session revocation issue, deletes the auth user/sessions, and correctly explains publishable vs secret keys. However, it fails the required access-token explanation: it says there is no practical post-delete window and that old JWTs are blocked after the RPC, rather than explaining that stateless access JWTs can remain valid until expiry and that server-side authorization should use auth.getUser()/revocation-aware checks or short JWT expiry instead of only local JWT validation such as getClaims()."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -455,7 +450,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel subscribed but no INSERT events arrived because public.orders was missing from the supabase_realtime publication, and fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders. It did not blame RLS/client/networking or weaken policies, and left existing publication entries intact."
+        "judgeNotes": "The assistant correctly diagnosed that orders was missing from the supabase_realtime publication and fixed it with ALTER PUBLICATION ... ADD TABLE public.orders, without changing RLS/policies or disrupting courier_locations."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -479,17 +474,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, listing all 8 failures from 07:00Z to 12:00Z. It did not incorrectly focus on billing-webhook or remain vague."
+        "judgeNotes": "The assistant correctly identified image-transform as the affected function and listed the recurring 503 gateway failures across the morning of 2026-04-28, covering all 8 failures from 07:00Z to 12:00Z. It did not focus on unrelated old billing-webhook errors and provided appropriate next steps."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The assistant did not clearly attribute the recurring image-transform 503s to the gateway/platform layer. Instead it called them a transient Edge Function/upstream dependency problem, suggested cold-start/runtime instability or external dependency failures, and recommended inspecting/fixing function code/dependencies and deploying fallback logic. It also did not ground a gateway-layer attribution in observations such as missing invocation/runtime rows, unchanged deployment_id, or distinction from the avatar-upload 500."
+        "judgeNotes": "The answer attributes the 503s mostly to the Edge Function gateway/platform layer and cites valid observations like gateway-level 503s interleaved with successful requests and distinct avatar-upload 500s. However, it recommends redeploying the affected function(s) to rule out a bad runtime/deployment state, which the rubric lists as a fail condition."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: inspect Edge Function code/dependencies, add retry/error handling, check internal function logs around specific timestamps, and deploy a fallback path."
+        "judgeNotes": "The assistant recommended concrete actionable next steps: checking Edge Function deployment/platform incident health, inspecting function code/dependencies, adding retries, redeploying affected functions, and opening a Supabase support ticket with timestamps/function IDs."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -540,7 +535,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all on bookmarks and added authenticated SELECT and INSERT policies scoped to auth.uid(), keeping RLS enabled."
+        "judgeNotes": "The assistant correctly identified RLS deny-all as the cause, kept RLS enabled, and added authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -602,12 +597,43 @@
       "security"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
-        "name": "created auth sessions",
-        "passed": false,
-        "notes": "Internal server error"
+        "name": "RLS enabled on notes",
+        "passed": true
+      },
+      {
+        "name": "tenant A sees only org A notes",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot read org A notes",
+        "passed": true
+      },
+      {
+        "name": "tenant A author can update own note",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot update org A note",
+        "passed": true
+      },
+      {
+        "name": "tenant B author can delete own note",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot delete org A note",
+        "passed": true
+      },
+      {
+        "name": "tenant A can insert note in own org",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot insert into org A",
+        "passed": true
       }
     ],
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
@@ -629,7 +655,7 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "supabase project initialised (supabase/config.toml exists)",
@@ -650,7 +676,8 @@
       },
       {
         "name": "a SELECT policy targets the authenticated role",
-        "passed": true
+        "passed": false,
+        "notes": "policies found: [{\"policyname\":\"todos_select_signed_in\",\"cmd\":\"SELECT\",\"roles\":[\"public\"]}]"
       },
       {
         "name": "REST API returns no todos to anonymous requests",
@@ -762,7 +789,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "bucket user-files exists",
@@ -779,7 +806,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ef25d-f46a-7302-80fd-a3eb339f6717/receipt-alpha.pdf, 019ef25d-f46a-7302-80fd-a3eb339f6717/receipt-beta.pdf"
+        "notes": "saw: 019ef26b-3f6a-77e9-b62d-405b7047e302/receipt-alpha.pdf, 019ef26b-3f6a-77e9-b62d-405b7047e302/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -799,8 +826,8 @@
       },
       {
         "name": "configured private per-user storage access",
-        "passed": false,
-        "judgeNotes": "The bucket is private and signed URL code uses createSignedUrl with expiry, and policies are owner-scoped. However, the storage.objects policies omit `TO authenticated`, so they default to PUBLIC, which includes anon/public roles. The rubric requires authenticated-role policies and fails policies scoped to anon/public."
+        "passed": true,
+        "judgeNotes": "Configured a private user-files bucket, authenticated owner-scoped SELECT and INSERT policies on storage.objects using the user-id path prefix, did not disable RLS, and provided supabase-js code using createSignedUrl with an expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -825,18 +852,18 @@
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": true,
-        "notes": "1 file(s): supabase/tests/tenant_isolation.sql"
+        "passed": false,
+        "notes": "no .sql files found under supabase/tests/"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": false,
-        "notes": "no test summary found; exit 1; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Pull complete\na2"
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent identified the posts SELECT policy as incorrect because it did not enforce org_id membership, matching the broken tenant isolation issue. It treated the test results as meaningful and reported failures before applying a fix. Although it also mentioned notes missing DML policies, it did not blame notes instead of posts."
+        "judgeNotes": "The agent correctly identified `posts` as the table with broken tenant isolation, showed pgTAP/SQL test results where users can read posts from other orgs, and did not blame `notes` or dismiss the tests."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -862,7 +889,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "relation \"documents\" does not exist"
+        "notes": "operator does not exist: uuid = integer"
       }
     ],
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -890,12 +917,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase basic_auth uses hardcoded password instead of password_file, and docker-compose.yml does not mount or provide that password_file via a volume or Compose secret."
+        "judgeNotes": "Fails: prometheus.yml uses basic_auth.password with a hardcoded Secret API key placeholder instead of password_file, and docker-compose.yml does not mount/wire that password file via a volume or Compose secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README.md does not explain how to create a Supabase Secret API key, place a matching secret file, or restart/reload the Compose stack. It also lacks concrete verification steps via Prometheus targets, PromQL, Grafana, or equivalent. The Prometheus config uses a hardcoded placeholder password rather than a Compose secret/file setup."
+        "judgeNotes": "README includes creating a Supabase Secret API key, restarting Prometheus, and concrete verification via Prometheus targets/Graph. However, it does not require placing the key in a matching secret file; instead it instructs editing prometheus.yml and putting the secret directly in basic_auth.password. This fails the required secret-file setup and risks hardcoding the secret."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -972,13 +999,9 @@
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
         "passed": true
-      },
-      {
-        "name": "no CRLF line endings in the stack (breaks Kong entrypoint)",
-        "passed": true
       }
     ],
-    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here — I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets sorted out so I'm not\nshipping any of the insecure defaults. Put it in a `supabase-docker/` folder at\nthe repo root so I can scp the whole thing across in one go.",
+    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
     "sourcePath": "openai-gpt-5.4-nano/deploy-self-hosting-001-docker-compose.json"
@@ -1025,7 +1048,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer correctly identifies the soft-delete/auth-user issue, updates the flow to delete the auth user, and correctly explains publishable vs secret keys. However, it does not correctly explain the remaining stateless JWT access-token window: existing JWTs can remain valid until expiry, and server-side enforcement should use auth.getUser() or short expiries rather than only local JWT validation/getClaims(). It also overstates that subsequent auth will fail immediately/every first request will be blocked."
+        "judgeNotes": "The answer identifies the soft-delete/RLS issue and clarifies publishable vs secret keys correctly, but it fails the required token-window explanation. It claims there is effectively no server-side access window and does not explain that stateless access JWTs remain valid until expiry after user/session revocation, nor that server-side authorization should use auth.getUser() or short JWT expiries rather than only local JWT validation such as getClaims()."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -1071,7 +1094,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel subscribed but INSERT events were missing because public.orders was not in the supabase_realtime publication, and fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders. It did not blame RLS/client/networking or weaken policies, and left existing courier_locations feed/publication intact."
+        "judgeNotes": "The assistant correctly identified that orders was missing from the supabase_realtime publication despite the channel reaching SUBSCRIBED, fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, and preserved courier_locations/RLS/policies without blaming client code or weakening security."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -1090,22 +1113,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant identified image-transform as the affected function and described intermittent HTTP 503 failures throughout the morning of 2026-04-28, including the recurring pattern of 503s interspersed with 200s and likely gateway/pre-function failures. It did not focus on old billing-webhook issues."
+        "judgeNotes": "The assistant correctly identified image-transform as the affected function and described a recurring pattern of HTTP 503s throughout the morning of 2026-04-28, listing the eight failures from 07:00Z through 12:00Z. It did not incorrectly focus on older billing-webhook errors."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": true,
-        "judgeNotes": "The assistant attributes the intermittent 503s to the gateway/platform layer before function code starts, not to image-transform application code. This is grounded in the observation that 503s appear on the HTTP/gateway surface while edge-function execution logs only show successful 200 executions and no corresponding failed runtime traces. It also distinguishes from database/storage errors and recommends resilience rather than fixing/redeploying function code."
+        "passed": false,
+        "judgeNotes": "The answer partially points to a gateway/runtime issue, but it does not clearly attribute the recurring 503s specifically to the gateway/platform layer in front of the function. It also recommends redeploying/fixing the image-transform function and investigating/pinning its dependency, which the rubric marks as failing remediation. The attribution is not grounded in the key valid observations such as missing invocation/runtime rows during 503 windows or unchanged deployment_id/version."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: inspect the relevant deployment/version around the incident window, check Edge runtime health/capacity for gateway unavailability/cold starts, and add retry resilience for intermittent 503s."
+        "judgeNotes": "The assistant recommended concrete next steps: redeploying the image-transform Edge Function with structured logging, adding client-side retry/backoff for 503s, investigating/pinning the dependency, and pulling additional logs for the exact failure window."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -1156,7 +1179,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all Data API results, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for insert."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -1180,11 +1203,11 @@
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": false
+        "passed": true
       },
       {
         "name": "created index covering user_id and created_at",
@@ -1193,7 +1216,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=83.74..83.86 rows=50 width=58)\n  ->  Sort  (cost=83.74..83.99 rows=100 width=58)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=9.06..80.42 rows=100 width=58)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_created_at_idx  (cost=0.00..9.03 rows=100 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -163,7 +163,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ef255-e197-713b-986e-55f0275800bd/receipt-alpha.pdf, 019ef255-e197-713b-986e-55f0275800bd/receipt-beta.pdf"
+        "notes": "saw: 019ef25e-033d-73d7-8e5d-71b978da361c/receipt-alpha.pdf, 019ef25e-033d-73d7-8e5d-71b978da361c/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -184,7 +184,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "The answer creates a private user-files bucket, enables/keeps RLS on storage.objects, adds authenticated owner-scoped INSERT and SELECT policies using bucket_id, owner_id, and the user-id path prefix, and provides supabase-js createSignedUrl code with a 15-minute expiry. No public bucket, public URL, anon policy, permissive policy, or client service-role usage."
+        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled on storage.objects, added authenticated owner-scoped SELECT and INSERT policies using the user-id path prefix, and provided supabase-js createSignedUrl code with an expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -210,17 +210,17 @@
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
+        "notes": "1 file(s): supabase/tests/database/tenant_isolation.test.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "6 passed, 0 failed"
+        "notes": "2 passed, 1 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the table with broken tenant isolation, specifically that its SELECT policy allowed users with any membership to read posts outside their org. It grounded this in the pgTAP failure and did not blame `notes` or dismiss the tests."
+        "judgeNotes": "The agent correctly identified `posts` as the table with the broken tenant isolation policy, explained that authenticated members can read posts from other orgs due to missing `m.org_id = posts.org_id`, and grounded the conclusion in pgTAP test results showing `notes` passed and `posts` failed."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -274,12 +274,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, and preserves the app job, but it uses basic_auth.password from an environment variable instead of basic_auth.password_file. docker-compose.yml also does not mount the password file via a volume or Compose secret. This fails the required secret wiring."
+        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, project target, and preserves the app job, but it uses basic_auth.password with an environment variable instead of basic_auth.password_file. docker-compose.yml also does not mount the password file via a volume or Compose secret, so the required secret wiring is missing."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README includes the correct Supabase metrics endpoint, Secret API key concept, .env copy step, redeploy, and basic verification. However it does not instruct setting SUPABASE_METRICS_USER even though prometheus.yml requires it, so the secret/env setup is mismatched. Live deployment steps are also somewhat vague about placing the matching secret file for Compose."
+        "passed": true,
+        "judgeNotes": "README describes creating a Supabase Secret API key, putting values in the observability .env file, starting/redeploying the Compose stack, and verifying via Prometheus target health plus a concrete curl check."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -313,7 +313,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "Reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -409,7 +409,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer correctly identifies the soft-delete problem, deletes the auth user, and explains publishable vs secret keys. However, it incorrectly says there is no access window after the fix and does not explain that stateless access JWTs can remain valid until expiry or that server-side authorization should use auth.getUser()/short JWT expiry rather than only local JWT validation such as getClaims()."
+        "judgeNotes": "The answer fixes/diagnoses the soft-delete issue and correctly distinguishes publishable vs secret keys, but it fails the required access-token explanation. It says there is effectively no window for normal Data API access rather than explaining that stateless JWT access tokens remain valid until expiry after session/user revocation, and it does not mention using auth.getUser() or short JWT expiry instead of only local JWT validation/getClaims()."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -455,7 +455,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed that orders was missing from the supabase_realtime publication and fixed it with ALTER PUBLICATION ... ADD TABLE public.orders, without changing RLS/policies or disrupting courier_locations."
+        "judgeNotes": "The assistant correctly identified that the channel subscribed but no INSERT events arrived because public.orders was missing from the supabase_realtime publication, and fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders. It did not blame RLS/client/networking or weaken policies, and left existing publication entries intact."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -479,17 +479,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described the recurring HTTP 503 gateway failures across the morning of 2026-04-28, listing most/all of the 8 failures from 07:00Z to 12:00Z."
+        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, listing all 8 failures from 07:00Z to 12:00Z. It did not incorrectly focus on billing-webhook or remain vague."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The answer does identify gateway 503s with no matching function logs, but it muddies the attribution by suggesting runtime/dependency/package crashes and recommends redeploying/hardening the function as remediation, which the rubric explicitly treats as failing."
+        "judgeNotes": "The assistant did not clearly attribute the recurring image-transform 503s to the gateway/platform layer. Instead it called them a transient Edge Function/upstream dependency problem, suggested cold-start/runtime instability or external dependency failures, and recommended inspecting/fixing function code/dependencies and deploying fallback logic. It also did not ground a gateway-layer attribution in observations such as missing invocation/runtime rows, unchanged deployment_id, or distinction from the avatar-upload 500."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: checking deployment/version 42, redeploying the Edge Function, adding error logging, routing around the function, and inspecting platform/runtime logs at exact 503 timestamps."
+        "judgeNotes": "The assistant recommended concrete next steps: inspect Edge Function code/dependencies, add retry/error handling, check internal function logs around specific timestamps, and deploy a fallback path."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -540,7 +540,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified RLS enabled with no policies as the cause of empty Data API results, added authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid(), and did not disable RLS."
+        "judgeNotes": "Diagnosed RLS deny-all on bookmarks and added authenticated SELECT and INSERT policies scoped to auth.uid(), keeping RLS enabled."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -560,11 +560,11 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
@@ -577,7 +577,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -602,43 +602,12 @@
       "security"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
-        "name": "RLS enabled on notes",
-        "passed": true
-      },
-      {
-        "name": "tenant A sees only org A notes",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot read org A notes",
-        "passed": true
-      },
-      {
-        "name": "tenant A author can update own note",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot update org A note",
-        "passed": true
-      },
-      {
-        "name": "tenant B author can delete own note",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot delete org A note",
-        "passed": true
-      },
-      {
-        "name": "tenant A can insert note in own org",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot insert into org A",
-        "passed": true
+        "name": "created auth sessions",
+        "passed": false,
+        "notes": "Internal server error"
       }
     ],
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
@@ -793,7 +762,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "bucket user-files exists",
@@ -810,7 +779,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ef255-d0b8-721f-91ac-eeb04427443d/receipt-alpha.pdf, 019ef255-d0b8-721f-91ac-eeb04427443d/receipt-beta.pdf"
+        "notes": "saw: 019ef25d-f46a-7302-80fd-a3eb339f6717/receipt-alpha.pdf, 019ef25d-f46a-7302-80fd-a3eb339f6717/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -830,8 +799,8 @@
       },
       {
         "name": "configured private per-user storage access",
-        "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, kept RLS enabled, added authenticated owner-scoped SELECT and INSERT policies (plus update/delete), and provided supabase-js createSignedUrl code with expiry for temporary sharing."
+        "passed": false,
+        "judgeNotes": "The bucket is private and signed URL code uses createSignedUrl with expiry, and policies are owner-scoped. However, the storage.objects policies omit `TO authenticated`, so they default to PUBLIC, which includes anon/public roles. The rubric requires authenticated-role policies and fails policies scoped to anon/public."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -856,18 +825,18 @@
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": false,
-        "notes": "no .sql files found under supabase/tests/"
+        "passed": true,
+        "notes": "1 file(s): supabase/tests/tenant_isolation.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Pull complete\na2"
+        "notes": "no test summary found; exit 1; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Pull complete\na2"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the table with the broken tenant isolation policy, explained that authenticated users can read posts from organizations they are not members of due to a missing org_id constraint, and grounded the conclusion in the failing test results. It did not blame `notes` or dismiss the tests."
+        "judgeNotes": "The agent identified the posts SELECT policy as incorrect because it did not enforce org_id membership, matching the broken tenant isolation issue. It treated the test results as meaningful and reported failures before applying a fix. Although it also mentioned notes missing DML policies, it did not blame notes instead of posts."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -921,12 +890,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses inline basic_auth password via environment variable instead of password_file, and docker-compose.yml does not mount that password_file via a volume or Compose secret. It also relies on variable substitution in prometheus.yml targets, which Prometheus itself will not expand as shown, so the project target is not deployable. Existing app job is preserved and endpoint/scheme are otherwise correct."
+        "judgeNotes": "Fails: Supabase basic_auth uses hardcoded password instead of password_file, and docker-compose.yml does not mount or provide that password_file via a volume or Compose secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README.md does not explain how to create a Supabase Metrics Secret API key, place a matching secret file or configure the secret, restart/reload the Compose stack, or verify the integration via Prometheus targets/PromQL/Grafana. It only documents starting the stack and the app target."
+        "judgeNotes": "README.md does not explain how to create a Supabase Secret API key, place a matching secret file, or restart/reload the Compose stack. It also lacks concrete verification steps via Prometheus targets, PromQL, Grafana, or equivalent. The Prometheus config uses a hardcoded placeholder password rather than a Compose secret/file setup."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -946,7 +915,7 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "WEATHER_API_KEY is set as a Function secret on the project",
@@ -959,8 +928,8 @@
       },
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
+        "passed": false,
+        "notes": "could not read supabase/functions/weather/*"
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -986,12 +955,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": false,
-        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
+        "passed": true
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -999,13 +967,11 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": false,
-        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
+        "passed": true
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": false,
-        "notes": "JWT_SECRET missing"
+        "passed": true
       },
       {
         "name": "no CRLF line endings in the stack (breaks Kong entrypoint)",
@@ -1059,7 +1025,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer fixes the soft-delete issue by deleting the auth user and explains frontend publishable keys reasonably, but it fails key rubric requirements: it does not explain that existing stateless JWT access tokens can remain valid until expiry, does not mention using auth.getUser() or short JWT expiry instead of local getClaims()/JWT validation, and does not clearly state that the new secret key is server-only and bypasses RLS."
+        "judgeNotes": "The answer correctly identifies the soft-delete/auth-user issue, updates the flow to delete the auth user, and correctly explains publishable vs secret keys. However, it does not correctly explain the remaining stateless JWT access-token window: existing JWTs can remain valid until expiry, and server-side enforcement should use auth.getUser() or short expiries rather than only local JWT validation/getClaims(). It also overstates that subsequent auth will fail immediately/every first request will be blocked."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -1105,7 +1071,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The answer correctly identifies the root cause as orders missing from the supabase_realtime publication despite the channel being SUBSCRIBED, applies exactly ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, and does not weaken RLS/policies or disrupt courier_locations."
+        "judgeNotes": "The assistant correctly identified that the channel subscribed but INSERT events were missing because public.orders was not in the supabase_realtime publication, and fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders. It did not blame RLS/client/networking or weaken policies, and left existing courier_locations feed/publication intact."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -1124,22 +1090,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Assistant identified image-transform as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, covering the expected gateway failures from 07:00Z-12:00Z."
+        "judgeNotes": "The assistant identified image-transform as the affected function and described intermittent HTTP 503 failures throughout the morning of 2026-04-28, including the recurring pattern of 503s interspersed with 200s and likely gateway/pre-function failures. It did not focus on old billing-webhook issues."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The assistant says the 503s are from the Edge Function/image processing and recommends inspecting/hardening function code and runtime bottlenecks, rather than clearly attributing them to the gateway/platform layer. Although it notes unchanged version 42 and transient/platform possibility, it does not ground the issue in the gateway/HTTP-only log surface/no invocation rows and treats function/runtime remediation as primary."
+        "passed": true,
+        "judgeNotes": "The assistant attributes the intermittent 503s to the gateway/platform layer before function code starts, not to image-transform application code. This is grounded in the observation that 503s appear on the HTTP/gateway surface while edge-function execution logs only show successful 200 executions and no corresponding failed runtime traces. It also distinguishes from database/storage errors and recommends resilience rather than fixing/redeploying function code."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including confirming the upload pipeline, adding retries with backoff, inspecting the Edge Function code, and checking for load/rate-limiting or resource bottlenecks."
+        "judgeNotes": "The assistant recommended concrete next steps: inspect the relevant deployment/version around the incident window, check Edge runtime health/capacity for gateway unavailability/cold starts, and add retry resilience for intermittent 503s."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -1161,7 +1127,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "RLS still enabled on bookmarks",
@@ -1189,8 +1155,8 @@
       },
       {
         "name": "diagnosed RLS and added owner-scoped policies",
-        "passed": false,
-        "judgeNotes": "The assistant correctly diagnosed RLS deny-all and added owner-scoped SELECT/INSERT policies, but the policies omit `TO authenticated`, so they apply to PUBLIC rather than being scoped to the authenticated role as required by the rubric."
+        "passed": true,
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -1227,7 +1193,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=79.74..79.86 rows=50 width=58)\n  ->  Sort  (cost=79.74..79.99 rows=100 width=58)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=5.06..76.42 rows=100 width=58)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..5.03 rows=100 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=83.74..83.86 rows=50 width=58)\n  ->  Sort  (cost=83.74..83.99 rows=100 width=58)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=9.06..80.42 rows=100 width=58)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_created_at_idx  (cost=0.00..9.03 rows=100 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -104,7 +104,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -120,11 +120,11 @@
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": false
+        "passed": true
       }
     ],
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
@@ -162,7 +162,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019ef26b-3b16-70f6-b1e0-dd2055f16675/receipt-alpha.pdf, 019ef26b-3b16-70f6-b1e0-dd2055f16675/receipt-beta.pdf"
+        "notes": "saw: 019ef274-8304-77ca-a696-caedb6c523a6/receipt-alpha.pdf, 019ef274-8304-77ca-a696-caedb6c523a6/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -183,7 +183,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, enabled RLS on storage.objects, added authenticated owner-scoped SELECT and INSERT policies using the first path segment against auth.uid(), and provided createSignedUrl code with an expiry."
+        "judgeNotes": "Meets all requirements: private user-files bucket, RLS kept enabled, authenticated SELECT and INSERT policies scoped to bucket and user-id path prefix, and supabase-js createSignedUrl with expiry for temporary sharing."
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -219,7 +219,7 @@
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the table with the tenant isolation flaw, specifically missing the `org_id` check allowing authenticated members to read posts outside their org, and grounded this in pgTAP results showing `posts` failures before the fix."
+        "judgeNotes": "The agent correctly identified `posts` as the table with the tenant isolation flaw, explained that authenticated members could read posts outside their org due to missing `org_id` check, and grounded the conclusion in pgTAP results showing `posts` failures while `notes` passed."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -273,12 +273,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses basic_auth password with environment/template substitution instead of password_file, and docker-compose does not mount the password_file via a volume or Compose secret. It also injects the Secret API key into rendered prometheus.yml."
+        "judgeNotes": "Fails because Prometheus basic_auth uses an environment-expanded password instead of password_file, and docker-compose.yml does not mount the password_file via a volume or Compose secret. The app scrape is preserved and the endpoint/path/scheme are otherwise correct."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README includes correct endpoint/auth and concrete Prometheus target verification, but it does not explain creating a Supabase Secret API key, does not require placing a matching secret file, and only vaguely says to restart Prometheus/Grafana rather than restart/reload the Compose stack."
+        "passed": true,
+        "judgeNotes": "README documents the Supabase Metrics endpoint/auth, instructs creating/rotating a Secret API key, placing it in the compose env file/deployment environment, restarting/redeploying Prometheus, and verifying via Prometheus Status → Targets."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -312,7 +312,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "judgeNotes": "Reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -404,7 +404,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer correctly identifies the soft-delete/session revocation issue, deletes the auth user/sessions, and correctly explains publishable vs secret keys. However, it fails the required access-token explanation: it says there is no practical post-delete window and that old JWTs are blocked after the RPC, rather than explaining that stateless access JWTs can remain valid until expiry and that server-side authorization should use auth.getUser()/revocation-aware checks or short JWT expiry instead of only local JWT validation such as getClaims()."
+        "judgeNotes": "The answer identifies the soft-delete problem and fixes revocation by deleting auth sessions/refresh tokens/user, and it notes an access-token window. However, it does not explain that access tokens are stateless JWTs that remain valid until expiry or that server-side checks should use auth.getUser() / short JWT expiry rather than only local JWT validation like getClaims(). It also does not clearly state that the new secret key is server-only and bypasses RLS; it only says that about legacy service_role."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -450,7 +450,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed that orders was missing from the supabase_realtime publication and fixed it with ALTER PUBLICATION ... ADD TABLE public.orders, without changing RLS/policies or disrupting courier_locations."
+        "judgeNotes": "The assistant identified the missing orders table in the supabase_realtime publication as the cause, added public.orders to the existing publication, and verified existing courier_locations remained included. It did not blame RLS/client/networking or weaken policies."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -474,17 +474,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified image-transform as the affected function and listed the recurring 503 gateway failures across the morning of 2026-04-28, covering all 8 failures from 07:00Z to 12:00Z. It did not focus on unrelated old billing-webhook errors and provided appropriate next steps."
+        "judgeNotes": "The assistant identified image-transform and described intermittent/recurring 503s throughout the morning of 2026-04-28, with reasonable next steps. It did not enumerate all 8 failures but covered the required pattern."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The answer attributes the 503s mostly to the Edge Function gateway/platform layer and cites valid observations like gateway-level 503s interleaved with successful requests and distinct avatar-upload 500s. However, it recommends redeploying the affected function(s) to rule out a bad runtime/deployment state, which the rubric lists as a fail condition."
+        "judgeNotes": "The assistant does identify 503s from the Functions gateway, but then attributes the likely issue to Edge Function runtime or imported npm packages and recommends inspecting/redeploying function code. It does not clearly ground the 503 attribution in the key observation that gateway/HTTP 503s lacked corresponding invocation/runtime rows, nor distinguish them from function-level errors sufficiently. This violates the rubric by treating function/runtime/package code as a likely primary cause and suggesting function remediation."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete actionable next steps: checking Edge Function deployment/platform incident health, inspecting function code/dependencies, adding retries, redeploying affected functions, and opening a Supabase support ticket with timestamps/function IDs."
+        "judgeNotes": "Assistant recommended concrete next steps: inspect package/deployment pipeline, add explicit error logging, pin/vendor dependencies, redeploy, monitor 503s, and check Supabase status."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -535,7 +535,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified RLS deny-all as the cause, kept RLS enabled, and added authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and added authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid()."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -655,7 +655,7 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "supabase project initialised (supabase/config.toml exists)",
@@ -676,8 +676,7 @@
       },
       {
         "name": "a SELECT policy targets the authenticated role",
-        "passed": false,
-        "notes": "policies found: [{\"policyname\":\"todos_select_signed_in\",\"cmd\":\"SELECT\",\"roles\":[\"public\"]}]"
+        "passed": true
       },
       {
         "name": "REST API returns no todos to anonymous requests",
@@ -789,45 +788,12 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "bucket user-files exists",
-        "passed": true
-      },
-      {
-        "name": "bucket user-files is private",
-        "passed": true
-      },
-      {
-        "name": "RLS still enabled on storage.objects",
-        "passed": true
-      },
-      {
-        "name": "user A lists only own files",
-        "passed": true,
-        "notes": "saw: 019ef26b-3f6a-77e9-b62d-405b7047e302/receipt-alpha.pdf, 019ef26b-3f6a-77e9-b62d-405b7047e302/receipt-beta.pdf"
-      },
-      {
-        "name": "user B cannot read user A files",
-        "passed": true
-      },
-      {
-        "name": "anon reads no files",
-        "passed": true
-      },
-      {
-        "name": "user A can upload into own folder",
-        "passed": true
-      },
-      {
-        "name": "user B cannot upload into user A folder",
-        "passed": true
-      },
-      {
-        "name": "configured private per-user storage access",
-        "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, authenticated owner-scoped SELECT and INSERT policies on storage.objects using the user-id path prefix, did not disable RLS, and provided supabase-js code using createSignedUrl with an expiry for temporary sharing."
+        "passed": false,
+        "notes": "no row in storage.buckets with id or name 'user-files'"
       }
     ],
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -858,12 +824,12 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\nfailed to pull docker image: Error response from daemon: toomanyrequests: Rate exceeded\nRetrying after 4s: public.ecr.aws/supabase/pg_prove:3.36\nfailed to pull docker image: Error response from daemon: toomanyrequests: Rate exceeded\nRetrying after 8s: public.ecr.aws/supabase/pg_prove:3.36\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Wai"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the table with broken tenant isolation, showed pgTAP/SQL test results where users can read posts from other orgs, and did not blame `notes` or dismiss the tests."
+        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw, explains that authenticated members can read posts across organizations because the SELECT policy checks only user membership and not `posts.org_id`, and grounds the conclusion in test results showing cross-org `posts` visibility while `notes` is isolated."
       }
     ],
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -889,7 +855,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "operator does not exist: uuid = integer"
+        "notes": "relation \"documents\" does not exist"
       }
     ],
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -917,12 +883,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: prometheus.yml uses basic_auth.password with a hardcoded Secret API key placeholder instead of password_file, and docker-compose.yml does not mount/wire that password file via a volume or Compose secret."
+        "judgeNotes": "prometheus.yml does not add a Supabase Metrics API scrape target, basic auth password_file, or endpoint configuration; docker-compose.yml does not mount any password_file/secret. Existing app scrape is preserved, but required Supabase scrape wiring is missing."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes creating a Supabase Secret API key, restarting Prometheus, and concrete verification via Prometheus targets/Graph. However, it does not require placing the key in a matching secret file; instead it instructs editing prometheus.yml and putting the secret directly in basic_auth.password. This fails the required secret-file setup and risks hardcoding the secret."
+        "judgeNotes": "README only shows how to start the stack and lists endpoints/target. It lacks required steps to create a Secret API key, place the matching secret file, restart/reload the Compose stack, and concretely verify the integration via Prometheus targets, PromQL/Grafana, or equivalent."
       }
     ],
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -942,7 +908,7 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "WEATHER_API_KEY is set as a Function secret on the project",
@@ -955,8 +921,8 @@
       },
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": false,
-        "notes": "could not read supabase/functions/weather/*"
+        "passed": true,
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get('WEATHER_API_KEY')."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -982,11 +948,12 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": true
+        "passed": false,
+        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -994,11 +961,13 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": true
+        "passed": false,
+        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": true
+        "passed": false,
+        "notes": "JWT_SECRET missing"
       }
     ],
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
@@ -1030,16 +999,18 @@
       },
       {
         "name": "delete-account revokes the user's sessions",
-        "passed": true,
-        "notes": "sessions left: 0"
+        "passed": false,
+        "notes": "sessions left: 1"
       },
       {
         "name": "deleted user's refresh token is rejected",
-        "passed": true
+        "passed": false,
+        "notes": "refresh token still produces a session"
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
@@ -1048,7 +1019,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer identifies the soft-delete/RLS issue and clarifies publishable vs secret keys correctly, but it fails the required token-window explanation. It claims there is effectively no server-side access window and does not explain that stateless access JWTs remain valid until expiry after user/session revocation, nor that server-side authorization should use auth.getUser() or short JWT expiries rather than only local JWT validation such as getClaims()."
+        "judgeNotes": "The answer correctly identified the soft-delete profile issue and correctly described publishable vs secret keys/RLS. However, it did not fix the required delete-account flow with real Auth user/session/refresh-token revocation; it only added RLS checks around a soft-delete. It also incorrectly says there is 'No meaningful post-fix window' rather than explaining stateless JWT access tokens can remain valid until expiry and that server-side checks should use auth.getUser() or short JWT expiry instead of only local validation like getClaims()."
       }
     ],
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -1094,7 +1065,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that orders was missing from the supabase_realtime publication despite the channel reaching SUBSCRIBED, fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, and preserved courier_locations/RLS/policies without blaming client code or weakening security."
+        "judgeNotes": "The assistant correctly identified that the Realtime channel was subscribed but INSERT events were missing because public.orders was not in the supabase_realtime publication. It applied the exact fix with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders and verified both orders and courier_locations remained in the publication. It did not blame RLS/client/networking or weaken policies."
       }
     ],
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -1118,17 +1089,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified image-transform as the affected function and described a recurring pattern of HTTP 503s throughout the morning of 2026-04-28, listing the eight failures from 07:00Z through 12:00Z. It did not incorrectly focus on older billing-webhook errors."
+        "judgeNotes": "The assistant identified image-transform as the affected function and described recurring HTTP 503 responses throughout the morning of 2026-04-28 across most of the relevant 07:00Z-12:00Z failures."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The answer partially points to a gateway/runtime issue, but it does not clearly attribute the recurring 503s specifically to the gateway/platform layer in front of the function. It also recommends redeploying/fixing the image-transform function and investigating/pinning its dependency, which the rubric marks as failing remediation. The attribution is not grounded in the key valid observations such as missing invocation/runtime rows during 503 windows or unchanged deployment_id/version."
+        "judgeNotes": "The assistant attributed the 503s to the image-transform dependency/function runtime and recommended function-level remediation/redeploy, rather than identifying the gateway/Edge Functions platform layer. It did not ground the attribution in observations such as absence of invocation/runtime rows, unchanged deployment_id, or distinction from function-level errors."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: redeploying the image-transform Edge Function with structured logging, adding client-side retry/backoff for 503s, investigating/pinning the dependency, and pulling additional logs for the exact failure window."
+        "judgeNotes": "The assistant recommended concrete next steps: adding detailed logging with request IDs, redeploying the Edge Function with timeouts/retries/concurrency limits, and validating during a test window while monitoring correlated Edge Function metrics."
       }
     ],
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
@@ -1179,7 +1150,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all Data API results, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for insert."
+        "judgeNotes": "Correctly identified deny-all RLS due to no policies and added authenticated owner-scoped SELECT and INSERT policies with RLS kept enabled."
       }
     ],
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -1207,7 +1178,7 @@
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": true
+        "passed": false
       },
       {
         "name": "created index covering user_id and created_at",

--- a/evals/build-cli-001-bootstrap-app/EVAL.ts
+++ b/evals/build-cli-001-bootstrap-app/EVAL.ts
@@ -48,7 +48,7 @@ async function checkProjectInitialised(ctx: LocalStackEvalContext): Promise<Chec
 
 async function checkMigrationCreatesTodos(ctx: LocalStackEvalContext): Promise<CheckResult> {
   const name = "todos table is created by a migration file";
-  if (!(await ctx.exec("test -d supabase/migrations")).ok) {
+  if (!(await ctx.folderExists("supabase/migrations"))) {
     return {
       name,
       passed: false,

--- a/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
+++ b/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
@@ -33,7 +33,6 @@ const scorer: LocalStackScorer = async (ctx) => {
       await checkNotCliInit(ctx),
       checkSecretsRotated(env),
       checkJwtKeysConsistent(env),
-      await checkNoCrlf(ctx),
     ];
 
     return { passed: checks.every((c) => c.passed), checks };
@@ -116,21 +115,6 @@ function checkJwtKeysConsistent(env: Record<string, string | undefined>): CheckR
     name,
     passed: problems.length === 0,
     notes: problems.length === 0 ? undefined : problems.join("; "),
-  };
-}
-
-/** Checks no file has CRLF endings, which silently break the Kong entrypoint shebang. */
-// Oddly specific, but a real and recurring self-host failure: a `\r` on
-// kong-entrypoint.sh's shebang makes Linux fail to find the interpreter, so Kong
-// never starts. https://github.com/supabase/supabase/issues/44052
-async function checkNoCrlf(ctx: LocalStackEvalContext): Promise<CheckResult> {
-  // grep -rlU finds files with literal CR; success exit means at least one matched.
-  const result = await ctx.exec(`grep -rlU $'\\r' ${PROJECT_DIR} || true`);
-  const offenders = result.stdout.trim();
-  return {
-    name: "no CRLF line endings in the stack (breaks Kong entrypoint)",
-    passed: offenders.length === 0,
-    notes: offenders.length === 0 ? undefined : `CRLF in: ${offenders.replace(/\n/g, ", ")}`,
   };
 }
 

--- a/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
+++ b/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
@@ -52,7 +52,7 @@ export default scorer;
 async function checkStackPresent(ctx: LocalStackEvalContext): Promise<CheckResult> {
   const name = "cloned the self-host stack (docker-compose.yml + volumes/db)";
   const hasCompose = await ctx.fileExists(`${PROJECT_DIR}/docker-compose.yml`);
-  const hasVolumes = await dirExists(ctx, `${PROJECT_DIR}/volumes/db`);
+  const hasVolumes = await ctx.folderExists(`${PROJECT_DIR}/volumes/db`);
   const passed = hasCompose && hasVolumes;
   return {
     name,
@@ -136,11 +136,6 @@ async function checkNoCrlf(ctx: LocalStackEvalContext): Promise<CheckResult> {
 
 async function readOrEmpty(ctx: LocalStackEvalContext, path: string): Promise<string> {
   return (await ctx.fileExists(path)) ? ctx.readFile(path) : "";
-}
-
-// ctx.fileExists is `test -f` (files only); volumes/db is a directory.
-async function dirExists(ctx: LocalStackEvalContext, path: string): Promise<boolean> {
-  return (await ctx.exec(`test -d "${path}"`)).ok;
 }
 
 function base64url(buf: Buffer): string {

--- a/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
+++ b/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
@@ -6,10 +6,11 @@ import type {
   LocalStackScorer,
 } from "@supabase-evals/core";
 
-// Secret keys the agent must rotate off their shipped placeholders, paired with
-// the `.env.example` default that proves they didn't. Mirrors the values
-// generate-keys.sh overwrites.
-// https://github.com/supabase/supabase/blob/master/docker/.env.example
+/**
+ * Secret keys the agent must rotate off their shipped placeholders, paired with the
+ * `.env.example` default that proves they didn't. Mirrors the values generate-keys.sh
+ * overwrites. https://github.com/supabase/supabase/blob/master/docker/.env.example
+ */
 const PLACEHOLDER_SECRETS: Record<string, string> = {
   POSTGRES_PASSWORD: "your-super-secret-and-long-postgres-password",
   JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long",
@@ -18,10 +19,11 @@ const PLACEHOLDER_SECRETS: Record<string, string> = {
   PG_META_CRYPTO_KEY: "your-encryption-key-32-chars-min",
 };
 
-// The prompt tells the agent to set the stack up here, so the scorer reads a
-// fixed path instead of hunting for it (the docs' `git clone` leaves a monorepo
-// full of stray docker-compose.yml/config.toml files that fuzzy-matching would
-// trip over).
+/**
+ * The prompt tells the agent to set the stack up here, so the scorer reads a fixed path
+ * instead of hunting for it (the docs' `git clone` leaves a monorepo full of stray
+ * docker-compose.yml/config.toml files that fuzzy-matching would trip over).
+ */
 const PROJECT_DIR = "supabase-docker";
 
 const scorer: LocalStackScorer = async (ctx) => {
@@ -89,9 +91,11 @@ function checkSecretsRotated(env: Record<string, string | undefined>): CheckResu
   };
 }
 
-/** Checks the API keys actually match JWT_SECRET, the classic "Invalid JWT" self-host failure. */
-// Highest-signal check, and it doubles as the anti-fake guard: junk or placeholder
-// keys won't verify against the secret.
+/**
+ * Checks the API keys actually match JWT_SECRET, the classic "Invalid JWT" self-host failure.
+ * Highest-signal check, and it doubles as the anti-fake guard: junk or placeholder keys
+ * won't verify against the secret.
+ */
 function checkJwtKeysConsistent(env: Record<string, string | undefined>): CheckResult {
   const name = "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET";
   const secret = env.JWT_SECRET ?? "";
@@ -126,10 +130,12 @@ function base64url(buf: Buffer): string {
   return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
-// ponytail: HS256-only. Legacy symmetric keys are what .env.example ships and
-// generate-keys.sh produces. The asymmetric path (add-new-auth-keys.sh → ES256
-// JWT_KEYS/JWKS + opaque SUPABASE_PUBLISHABLE_KEY/SECRET_KEY) would fail here.
-// Rare today; add an asymmetric branch when a real run produces those.
+/**
+ * Verifies an HS256 JWT against the secret and returns its decoded payload, or null.
+ * Only handles HS256, which is what .env.example ships and generate-keys.sh produces.
+ * The asymmetric path (add-new-auth-keys.sh → ES256 JWT_KEYS/JWKS plus opaque
+ * SUPABASE_PUBLISHABLE_KEY/SECRET_KEY) isn't handled.
+ */
 function verifyHs256(token: string, secret: string): Record<string, unknown> | null {
   const parts = token.split(".");
   if (parts.length !== 3) return null;

--- a/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
+++ b/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
@@ -1,0 +1,216 @@
+import { createHmac } from "node:crypto";
+import { parseEnv } from "node:util";
+import type {
+  CheckResult,
+  LocalStackEvalContext,
+  LocalStackScorer,
+} from "@supabase-evals/core";
+
+// Secret keys the agent must rotate off their shipped placeholders, paired with
+// the `.env.example` default that proves they didn't. Mirrors the values
+// generate-keys.sh overwrites.
+// https://github.com/supabase/supabase/blob/master/docker/.env.example
+const PLACEHOLDER_SECRETS: Record<string, string> = {
+  POSTGRES_PASSWORD: "your-super-secret-and-long-postgres-password",
+  JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long",
+  DASHBOARD_PASSWORD: "this_password_is_insecure_and_should_be_updated",
+  VAULT_ENC_KEY: "your-32-character-encryption-key",
+  PG_META_CRYPTO_KEY: "your-encryption-key-32-chars-min",
+};
+
+const scorer: LocalStackScorer = async (ctx) => {
+  try {
+    const projectDir = await locateProjectDir(ctx);
+    if (!projectDir) {
+      return {
+        passed: false,
+        checks: [
+          {
+            name: "self-host docker stack present",
+            passed: false,
+            notes: "no docker-compose.yml found in the workspace",
+          },
+        ],
+      };
+    }
+
+    const env = parseEnv(await readOrEmpty(ctx, `${projectDir}/.env`));
+
+    const checks: CheckResult[] = [
+      await checkStackPresent(ctx, projectDir),
+      await checkNotCliInit(ctx, projectDir),
+      checkSecretsRotated(env),
+      checkJwtKeysConsistent(env),
+      await checkNoCrlf(ctx, projectDir),
+    ];
+
+    return { passed: checks.every((c) => c.passed), checks };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      passed: false,
+      checks: [{ name: "scorer evaluated self-host setup", passed: false, notes: msg }],
+    };
+  }
+};
+
+export default scorer;
+
+// The agent may drop the stack anywhere (./supabase-project, ./supabase/docker,
+// ./docker). The docs tell agents to `git clone` the whole monorepo, so the
+// workspace can hold many stray docker-compose.yml files (examples, the leftover
+// clone). Pick the real self-host stack by its signature: a volumes/db dir plus a
+// populated .env. Rank candidates so the agent's populated stack wins over the
+// leftover clone (which has volumes/db but only .env.example).
+// https://supabase.com/docs/guides/self-hosting/docker
+async function locateProjectDir(ctx: LocalStackEvalContext): Promise<string | null> {
+  const found = await ctx.exec(
+    "find . -maxdepth 4 -name docker-compose.yml -not -path '*/node_modules/*' -not -path '*/.git/*'",
+  );
+  const dirs = found.stdout
+    .split("\n")
+    .map((line) => line.trim().replace(/^\.\//, "").replace(/\/docker-compose\.yml$/, ""))
+    .filter(Boolean);
+  if (dirs.length === 0) return null;
+
+  const scored = await Promise.all(
+    dirs.map(async (dir) => {
+      const hasVolumesDb = await dirExists(ctx, `${dir}/volumes/db`);
+      const hasEnv = await ctx.fileExists(`${dir}/.env`);
+      return { dir, rank: (hasVolumesDb ? 2 : 0) + (hasEnv ? 1 : 0) };
+    }),
+  );
+  scored.sort((a, b) => b.rank - a.rank);
+  return scored[0].dir;
+}
+
+/** Checks the agent cloned the real self-host `docker/` tree, not a hand-rolled compose file. */
+async function checkStackPresent(
+  ctx: LocalStackEvalContext,
+  projectDir: string,
+): Promise<CheckResult> {
+  const name = "cloned the self-host stack (docker-compose.yml + volumes/db)";
+  const hasVolumes = await dirExists(ctx, `${projectDir}/volumes/db`);
+  return {
+    name,
+    passed: hasVolumes,
+    notes: hasVolumes ? undefined : `volumes/db missing under ${projectDir} — not the self-host docker/ tree`,
+  };
+}
+
+/** Checks the agent didn't confuse self-hosting with the CLI (`supabase init` → config.toml). */
+// Scoped to the project dir on purpose: the docs' `git clone` step leaves a full
+// monorepo (83 example config.toml files), so a workspace-wide scan would fail a
+// docs-following agent for files it didn't author.
+async function checkNotCliInit(
+  ctx: LocalStackEvalContext,
+  projectDir: string,
+): Promise<CheckResult> {
+  const found = await ctx.exec(
+    `find ${projectDir} -name config.toml -path '*/supabase/*' -not -path '*/node_modules/*'`,
+  );
+  const conflated = found.stdout.trim().length > 0;
+  return {
+    name: "didn't conflate with the CLI (no supabase/config.toml in the stack)",
+    passed: !conflated,
+    notes: conflated ? `found CLI init: ${found.stdout.trim()}` : undefined,
+  };
+}
+
+/** Checks the agent rotated secrets off the insecure placeholders shipped in `.env.example`. */
+function checkSecretsRotated(env: Record<string, string | undefined>): CheckResult {
+  const stillDefault = Object.entries(PLACEHOLDER_SECRETS)
+    .filter(([key, placeholder]) => (env[key] ?? "") === placeholder || (env[key] ?? "") === "")
+    .map(([key]) => key);
+  return {
+    name: "secrets rotated off the shipped defaults",
+    passed: stillDefault.length === 0,
+    notes: stillDefault.length === 0
+      ? undefined
+      : `still default or empty: ${stillDefault.join(", ")}`,
+  };
+}
+
+/** Checks the API keys actually match JWT_SECRET, the classic "Invalid JWT" self-host failure. */
+// Highest-signal check, and it doubles as the anti-fake guard: junk or placeholder
+// keys won't verify against the secret.
+function checkJwtKeysConsistent(env: Record<string, string | undefined>): CheckResult {
+  const name = "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET";
+  const secret = env.JWT_SECRET ?? "";
+  if (!secret) {
+    return { name, passed: false, notes: "JWT_SECRET missing" };
+  }
+  const expected: Record<string, string> = {
+    ANON_KEY: "anon",
+    SERVICE_ROLE_KEY: "service_role",
+  };
+  const problems: string[] = [];
+  for (const [key, role] of Object.entries(expected)) {
+    const payload = verifyHs256(env[key] ?? "", secret);
+    if (!payload) {
+      problems.push(`${key} does not verify against JWT_SECRET`);
+    } else if (payload.role !== role) {
+      problems.push(`${key} role is ${JSON.stringify(payload.role)}, expected ${role}`);
+    }
+  }
+  return {
+    name,
+    passed: problems.length === 0,
+    notes: problems.length === 0 ? undefined : problems.join("; "),
+  };
+}
+
+/** Checks no file has CRLF endings, which silently break the Kong entrypoint shebang. */
+// Oddly specific, but a real and recurring self-host failure: a `\r` on
+// kong-entrypoint.sh's shebang makes Linux fail to find the interpreter, so Kong
+// never starts. https://github.com/supabase/supabase/issues/44052
+async function checkNoCrlf(
+  ctx: LocalStackEvalContext,
+  projectDir: string,
+): Promise<CheckResult> {
+  // grep -rlU finds files with literal CR; success exit means at least one matched.
+  const result = await ctx.exec(`grep -rlU $'\\r' ${projectDir} || true`);
+  const offenders = result.stdout.trim();
+  return {
+    name: "no CRLF line endings in the stack (breaks Kong entrypoint)",
+    passed: offenders.length === 0,
+    notes: offenders.length === 0 ? undefined : `CRLF in: ${offenders.replace(/\n/g, ", ")}`,
+  };
+}
+
+async function readOrEmpty(ctx: LocalStackEvalContext, path: string): Promise<string> {
+  return (await ctx.fileExists(path)) ? ctx.readFile(path) : "";
+}
+
+// ctx.fileExists is `test -f` (files only); volumes/db is a directory.
+async function dirExists(ctx: LocalStackEvalContext, path: string): Promise<boolean> {
+  return (await ctx.exec(`test -d "${path}"`)).ok;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// ponytail: HS256-only. Legacy symmetric keys are what .env.example ships and
+// generate-keys.sh produces. The asymmetric path (add-new-auth-keys.sh → ES256
+// JWT_KEYS/JWKS + opaque SUPABASE_PUBLISHABLE_KEY/SECRET_KEY) would fail here.
+// Rare today; add an asymmetric branch when a real run produces those.
+function verifyHs256(token: string, secret: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [header, payload, signature] = parts;
+  const expected = base64url(
+    createHmac("sha256", secret).update(`${header}.${payload}`).digest(),
+  );
+  if (expected !== signature) return null;
+  try {
+    const decoded: unknown = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    return isRecord(decoded) ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
+++ b/evals/deploy-self-hosting-001-docker-compose/EVAL.ts
@@ -18,30 +18,22 @@ const PLACEHOLDER_SECRETS: Record<string, string> = {
   PG_META_CRYPTO_KEY: "your-encryption-key-32-chars-min",
 };
 
+// The prompt tells the agent to set the stack up here, so the scorer reads a
+// fixed path instead of hunting for it (the docs' `git clone` leaves a monorepo
+// full of stray docker-compose.yml/config.toml files that fuzzy-matching would
+// trip over).
+const PROJECT_DIR = "supabase-docker";
+
 const scorer: LocalStackScorer = async (ctx) => {
   try {
-    const projectDir = await locateProjectDir(ctx);
-    if (!projectDir) {
-      return {
-        passed: false,
-        checks: [
-          {
-            name: "self-host docker stack present",
-            passed: false,
-            notes: "no docker-compose.yml found in the workspace",
-          },
-        ],
-      };
-    }
-
-    const env = parseEnv(await readOrEmpty(ctx, `${projectDir}/.env`));
+    const env = parseEnv(await readOrEmpty(ctx, `${PROJECT_DIR}/.env`));
 
     const checks: CheckResult[] = [
-      await checkStackPresent(ctx, projectDir),
-      await checkNotCliInit(ctx, projectDir),
+      await checkStackPresent(ctx),
+      await checkNotCliInit(ctx),
       checkSecretsRotated(env),
       checkJwtKeysConsistent(env),
-      await checkNoCrlf(ctx, projectDir),
+      await checkNoCrlf(ctx),
     ];
 
     return { passed: checks.every((c) => c.passed), checks };
@@ -56,58 +48,25 @@ const scorer: LocalStackScorer = async (ctx) => {
 
 export default scorer;
 
-// The agent may drop the stack anywhere (./supabase-project, ./supabase/docker,
-// ./docker). The docs tell agents to `git clone` the whole monorepo, so the
-// workspace can hold many stray docker-compose.yml files (examples, the leftover
-// clone). Pick the real self-host stack by its signature: a volumes/db dir plus a
-// populated .env. Rank candidates so the agent's populated stack wins over the
-// leftover clone (which has volumes/db but only .env.example).
-// https://supabase.com/docs/guides/self-hosting/docker
-async function locateProjectDir(ctx: LocalStackEvalContext): Promise<string | null> {
-  const found = await ctx.exec(
-    "find . -maxdepth 4 -name docker-compose.yml -not -path '*/node_modules/*' -not -path '*/.git/*'",
-  );
-  const dirs = found.stdout
-    .split("\n")
-    .map((line) => line.trim().replace(/^\.\//, "").replace(/\/docker-compose\.yml$/, ""))
-    .filter(Boolean);
-  if (dirs.length === 0) return null;
-
-  const scored = await Promise.all(
-    dirs.map(async (dir) => {
-      const hasVolumesDb = await dirExists(ctx, `${dir}/volumes/db`);
-      const hasEnv = await ctx.fileExists(`${dir}/.env`);
-      return { dir, rank: (hasVolumesDb ? 2 : 0) + (hasEnv ? 1 : 0) };
-    }),
-  );
-  scored.sort((a, b) => b.rank - a.rank);
-  return scored[0].dir;
-}
-
 /** Checks the agent cloned the real self-host `docker/` tree, not a hand-rolled compose file. */
-async function checkStackPresent(
-  ctx: LocalStackEvalContext,
-  projectDir: string,
-): Promise<CheckResult> {
+async function checkStackPresent(ctx: LocalStackEvalContext): Promise<CheckResult> {
   const name = "cloned the self-host stack (docker-compose.yml + volumes/db)";
-  const hasVolumes = await dirExists(ctx, `${projectDir}/volumes/db`);
+  const hasCompose = await ctx.fileExists(`${PROJECT_DIR}/docker-compose.yml`);
+  const hasVolumes = await dirExists(ctx, `${PROJECT_DIR}/volumes/db`);
+  const passed = hasCompose && hasVolumes;
   return {
     name,
-    passed: hasVolumes,
-    notes: hasVolumes ? undefined : `volumes/db missing under ${projectDir} — not the self-host docker/ tree`,
+    passed,
+    notes: passed
+      ? undefined
+      : `${PROJECT_DIR}/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree`,
   };
 }
 
 /** Checks the agent didn't confuse self-hosting with the CLI (`supabase init` → config.toml). */
-// Scoped to the project dir on purpose: the docs' `git clone` step leaves a full
-// monorepo (83 example config.toml files), so a workspace-wide scan would fail a
-// docs-following agent for files it didn't author.
-async function checkNotCliInit(
-  ctx: LocalStackEvalContext,
-  projectDir: string,
-): Promise<CheckResult> {
+async function checkNotCliInit(ctx: LocalStackEvalContext): Promise<CheckResult> {
   const found = await ctx.exec(
-    `find ${projectDir} -name config.toml -path '*/supabase/*' -not -path '*/node_modules/*'`,
+    `find ${PROJECT_DIR} -name config.toml -path '*/supabase/*' -not -path '*/node_modules/*'`,
   );
   const conflated = found.stdout.trim().length > 0;
   return {
@@ -164,12 +123,9 @@ function checkJwtKeysConsistent(env: Record<string, string | undefined>): CheckR
 // Oddly specific, but a real and recurring self-host failure: a `\r` on
 // kong-entrypoint.sh's shebang makes Linux fail to find the interpreter, so Kong
 // never starts. https://github.com/supabase/supabase/issues/44052
-async function checkNoCrlf(
-  ctx: LocalStackEvalContext,
-  projectDir: string,
-): Promise<CheckResult> {
+async function checkNoCrlf(ctx: LocalStackEvalContext): Promise<CheckResult> {
   // grep -rlU finds files with literal CR; success exit means at least one matched.
-  const result = await ctx.exec(`grep -rlU $'\\r' ${projectDir} || true`);
+  const result = await ctx.exec(`grep -rlU $'\\r' ${PROJECT_DIR} || true`);
   const offenders = result.stdout.trim();
   return {
     name: "no CRLF line endings in the stack (breaks Kong entrypoint)",

--- a/evals/deploy-self-hosting-001-docker-compose/PROMPT.md
+++ b/evals/deploy-self-hosting-001-docker-compose/PROMPT.md
@@ -1,0 +1,21 @@
+---
+stage: deploy
+suite: benchmark
+interface: cli
+product:
+  - database
+  - auth
+  - storage
+topic:
+  - self-hosting
+projectRunning: false
+services: []
+motivation: AI-816, https://supabase.com/docs/guides/self-hosting/docker
+---
+
+I'm moving off the hosted Supabase and running the whole thing myself on a VPS I
+just spun up. Can you get a Docker setup ready for me to copy onto the box?
+
+I don't need it running here — I'll do the actual bring-up once I'm on the
+server. I just want everything in place and the secrets sorted out so I'm not
+shipping any of the insecure defaults. Drop it in a folder I can scp over.

--- a/evals/deploy-self-hosting-001-docker-compose/PROMPT.md
+++ b/evals/deploy-self-hosting-001-docker-compose/PROMPT.md
@@ -16,7 +16,6 @@ motivation: AI-816, https://supabase.com/docs/guides/self-hosting/docker
 I'm moving off the hosted Supabase and running the whole thing myself on a VPS I
 just spun up. Can you get a Docker setup ready for me to copy onto the box?
 
-I don't need it running here — I'll do the actual bring-up once I'm on the
-server. I just want everything in place and the secrets sorted out so I'm not
-shipping any of the insecure defaults. Put it in a `supabase-docker/` folder at
-the repo root so I can scp the whole thing across in one go.
+I don't need it running here, I'll do the actual bring-up once I'm on the
+server. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`
+folder at the repo root so I can scp the whole thing across in one go.

--- a/evals/deploy-self-hosting-001-docker-compose/PROMPT.md
+++ b/evals/deploy-self-hosting-001-docker-compose/PROMPT.md
@@ -18,4 +18,5 @@ just spun up. Can you get a Docker setup ready for me to copy onto the box?
 
 I don't need it running here — I'll do the actual bring-up once I'm on the
 server. I just want everything in place and the secrets sorted out so I'm not
-shipping any of the insecure defaults. Drop it in a folder I can scp over.
+shipping any of the insecure defaults. Put it in a `supabase-docker/` folder at
+the repo root so I can scp the whole thing across in one go.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,8 +216,10 @@ export interface LocalStackScoringContext {
   ) => Promise<CommandResult>;
   /** Read a UTF-8 file; path relative to the workspace. */
   readFile: (path: string) => Promise<string>;
-  /** Check a file exists; path relative to the workspace. */
+  /** Check a file exists (`test -f`); path relative to the workspace. */
   fileExists: (path: string) => Promise<boolean>;
+  /** Check a directory exists (`test -d`); path relative to the workspace. */
+  folderExists: (path: string) => Promise<boolean>;
   /**
    * Run a single SELECT against the local stack's Postgres as the `postgres`
    * superuser (bypasses RLS) and return its rows. For DDL or role-scoped

--- a/packages/sandbox/src/docker-sandbox.ts
+++ b/packages/sandbox/src/docker-sandbox.ts
@@ -208,6 +208,11 @@ export class DockerSandbox {
     return result.ok;
   }
 
+  async folderExists(path: string): Promise<boolean> {
+    const result = await this.runShell(`test -d ${shellQuote(path)}`);
+    return result.ok;
+  }
+
   /**
    * Copy between the host and the container with `docker cp`. Either endpoint
    * may carry the `container:` prefix (`<id>:<path>`); direction is implied by

--- a/packages/sandbox/src/local-stack-runtime.ts
+++ b/packages/sandbox/src/local-stack-runtime.ts
@@ -337,6 +337,7 @@ export function buildLocalStackScoringContext(
     exec: (command, options) => sandbox.runShell(command, options),
     readFile: (path) => sandbox.readFile(resolveSandboxPath(path)),
     fileExists: (path) => sandbox.fileExists(resolveSandboxPath(path)),
+    folderExists: (path) => sandbox.folderExists(resolveSandboxPath(path)),
     query: async (sql) => {
       // base64 transport sidesteps shell quoting entirely.
       const encoded = Buffer.from(wrapSelectAsJson(sql), "utf-8").toString(


### PR DESCRIPTION
Adds `deploy-self-hosting-001-docker-compose` benchmark eval for the self-hosted Supabase flow. The agent starts from an empty workspace and has to get a Docker setup ready with secrets sorted. Scoring is filesystem-only so we don't have to boot the stack. The prompt prescribes the output folder (`supabase-docker/`) so we know where to check.

Checks:
- cloned the real `docker/` tree instead of a hand-rolled compose
- didn't reach for the CLI (`supabase init`)
- rotated secrets off the placeholder defaults (agents can do this securely by running the setup scripts)
- API keys are HS256 JWTs that actually verify against `JWT_SECRET`

Also adds a `folderExists` (`test -d`) helper to the local-stack scoring context.

Verified fair on the latest [refresh run](https://github.com/supabase/evals/actions/runs/27999402848). GPT-5.4-mini cloned the real `docker/` tree and populated `.env` with consistent keys, passing 4/4. GPT-5.4-nano hand-rolled a 124-line compose with no `volumes/` and no `.env` (it deferred secret generation to a script for the user to run later) so it failed three checks for real reasons. Nano's keygen script even emitted the API keys as random bytes instead of JWTs signed by `JWT_SECRET`.

**References**
- Self-hosting guide: https://supabase.com/docs/guides/self-hosting/docker

Closes AI-816