### PR TITLE
feat: default --runs to 1 and force re-run

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -217,8 +217,7 @@ jobs:
             --experiment "${{ matrix.experiment }}" \
             --eval "${{ matrix.eval_id }}" \
             --runs "${{ needs.prepare.outputs.runs }}" \
-            --timeout-sec "${{ needs.prepare.outputs.timeout_sec }}" \
-            --force
+            --timeout-sec "${{ needs.prepare.outputs.timeout_sec }}"
 
       - name: Upload raw results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Agent-backed runs require the relevant provider key in `.env` (e.g. `OPENAI_API_
 Run one eval:
 
 ```bash
-pnpm eval -- --eval investigate-security-001-public-table --experiment openai-gpt-5.4-mini --runs 1 --force
+pnpm eval -- --eval investigate-security-001-public-table --experiment openai-gpt-5.4-mini
 ```
 
 View results in the web app at `http://localhost:5173`:
@@ -66,7 +66,7 @@ Running evals executes experiment x eval pairs and writes local result files und
 Target a single experiment by filename stem:
 
 ```bash
-pnpm eval -- --experiment openai-gpt-5.4-mini --runs 1 --force
+pnpm eval -- --experiment openai-gpt-5.4-mini
 ```
 
 Target multiple experiments or eval scenarios by repeating flags:
@@ -77,9 +77,7 @@ pnpm eval -- \
   --experiment openai-gpt-5.4-nano \
   --suite benchmark \
   --eval investigate-security-001-public-table \
-  --eval investigate-db-001-table-row-counts \
-  --runs 1 \
-  --force
+  --eval investigate-db-001-table-row-counts
 ```
 
 Target a single model id:
@@ -87,9 +85,6 @@ Target a single model id:
 ```bash
 pnpm eval -- --model gpt-5.4-mini
 ```
-
-> [!NOTE]
-> Use `--runs 1 --force` when you want a fresh single-attempt result. Without `--force`, existing result files are skipped; without `--runs 1`, the runner defaults to up to four attempts with stop-on-pass.
 
 Or run everything:
 

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -47,7 +47,7 @@ const HOSTED_ACCESS_TOKEN = "sbp_" + "0".repeat(40);
 
 const rawArgs = process.argv.slice(2);
 const args = new Set(rawArgs);
-const FORCE = args.has("--force");
+const FORCE = !args.has("--no-force");
 const SMOKE = args.has("--smoke");
 const DRY = args.has("--dry");
 const EXPERIMENT_FILTERS = readRepeatedFlag(rawArgs, "experiment").map(
@@ -56,7 +56,7 @@ const EXPERIMENT_FILTERS = readRepeatedFlag(rawArgs, "experiment").map(
 const MODEL_FILTER = readFlag("model");
 const EVAL_FILTERS = readRepeatedFlag(rawArgs, "eval");
 const SUITE_FILTERS = readSuiteFilters(rawArgs);
-const RUNS = Number(readFlag("runs") ?? 4);
+const RUNS = Number(readFlag("runs") ?? 1);
 const TIMEOUT_SEC = Number(readFlag("timeout-sec") ?? 720);
 const CONCURRENCY = Number(readFlag("concurrency") ?? 1);
 const STOP_ON_PASS = !args.has("--run-all-attempts");

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -47,7 +47,7 @@ const HOSTED_ACCESS_TOKEN = "sbp_" + "0".repeat(40);
 
 const rawArgs = process.argv.slice(2);
 const args = new Set(rawArgs);
-const FORCE = !args.has("--no-force");
+const FORCE = !args.has("--skip-existing");
 const SMOKE = args.has("--smoke");
 const DRY = args.has("--dry");
 const EXPERIMENT_FILTERS = readRepeatedFlag(rawArgs, "experiment").map(

--- a/apps/framework/package.json
+++ b/apps/framework/package.json
@@ -8,7 +8,6 @@
     "eval": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts",
     "eval:dry": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --dry",
     "eval:smoke": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --smoke",
-    "eval:force": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --force",
     "typecheck": "tsc --noEmit",
     "test:framework": "node --env-file-if-exists=../../.env --import tsx/esm scripts/smoke-framework.ts",
     "export-results": "node --import tsx/esm scripts/export-results.ts",


### PR DESCRIPTION
**Changes**
- `--runs` defaults to 1 (was 4)
- `--force` is now the default; opt out with `--skip-existing` to skip already-completed results
- Removed stale `--force` from CI workflow and `eval:force` package.json script
- Updated README examples to drop the now-redundant flags

Closes AI-857