### PR TITLE
feat: print results path after each eval run

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -10,7 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { jsonSchema, tool, type ToolSet } from "ai";
 import { parseEvalMarkdown } from "@supabase-evals/core/eval-markdown";
@@ -696,7 +696,7 @@ async function main() {
         );
         const elapsed = Math.round((Date.now() - start) / 1000);
         console.log(
-          `${res.passed ? "✅ PASS" : "❌ FAIL"} ${name} x ${ev.id} (${formatRunSummary(res)}, ${elapsed}s)`,
+          `${res.passed ? "✅ PASS" : "❌ FAIL"} ${name} x ${ev.id} (${formatRunSummary(res)}, ${elapsed}s)\n   → ${relative(ROOT, out)}`,
         );
       } catch (e) {
         const elapsed = Math.round((Date.now() - start) / 1000);


### PR DESCRIPTION
After each eval completes, prints the relative path to the saved result file on a line below the PASS/FAIL summary. 

Benefits:
- Cmd+Click for quick human inspection
- Agents know immediately where to read results file from terminal output

```
⏳ RUN  openai-gpt-5.4-mini x investigate-logs-001-top-error-function
⏳ RUN  openai-gpt-5.4-mini x investigate-security-001-public-table
✅ PASS openai-gpt-5.4-mini x investigate-logs-001-top-error-function (checks 3/3, attempts 1, 14s)
   → results/openai-gpt-5.4-mini/investigate-logs-001-top-error-function.json
✅ PASS openai-gpt-5.4-mini x investigate-security-001-public-table (checks 4/4, attempts 1, 17s)
   → results/openai-gpt-5.4-mini/investigate-security-001-public-table.json
```

Closes AI-856