### PR TITLE
chore(claude-code): bump pinned CLI to 2.1.191 for Opus 4.8 support

### DIFF
--- a/packages/core/src/agents/claude-code/runner.ts
+++ b/packages/core/src/agents/claude-code/runner.ts
@@ -25,7 +25,7 @@ export const claudeCodeRunner: AgentRunner<AnthropicModel> = {
   cliPackage: "@anthropic-ai/claude-code",
   // Pinned: Claude Code's transcript format evolves; bump deliberately and
   // re-check the parser. See ./parser.ts.
-  defaultCliVersion: "2.1.101",
+  defaultCliVersion: "2.1.191",
   defaultModel: "claude-sonnet-4-6",
 
   async install(sandbox, version) {


### PR DESCRIPTION
Bump the default pinned CLI version `2.1.101` -> `2.1.191` to support `claude code Opus 4.8` model