### PR TITLE
feat: explicit suite on every eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pnpm web
 
 ### Add an experiment
 
-Add a file under `experiments/` for the agent/model/runtime setup you want to compare. Set `suite: "benchmark"` to include it in benchmark runs.
+Add a file under `experiments/` for the agent/model/runtime setup you want to compare. Set `suite: ["benchmark"]` to include it in benchmark runs (it's a list, so one experiment can run in multiple suites, e.g. `["benchmark", "regression"]`).
 
 ### Run evals
 
@@ -114,6 +114,7 @@ motivation: AI-123
 ```
 
 Allowed metadata values are defined in `packages/core/src/eval-metadata.ts`.
+`suite` is required on every eval (`benchmark`, `regression`, or `other`). Run a suite with `--suite regression` / `--suite other`, which selects experiments tagged with that suite against evals declaring it.
 Benchmark evals should include `motivation` with the issue or other reference that explains why the scenario belongs in the suite.
 
 ## Eval Modes

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -575,7 +575,9 @@ async function main() {
     const experiments = await loadExperiments();
     const filtered =
       SUITE_FILTERS.length > 0
-        ? experiments.filter((e) => e.config.suite && SUITE_FILTERS.includes(e.config.suite as EvalSuite))
+        ? experiments.filter((e) =>
+            (e.config.suite ?? []).some((s) => SUITE_FILTERS.includes(s)),
+          )
         : experiments;
     console.log(JSON.stringify(filtered.map((e) => e.name)));
     return;
@@ -596,7 +598,11 @@ async function main() {
       !EXPERIMENT_FILTERS.includes(name)
     )
       return false;
-    if (SUITE_FILTERS.length > 0 && !SUITE_FILTERS.includes(config.suite as EvalSuite)) return false;
+    if (
+      SUITE_FILTERS.length > 0 &&
+      !(config.suite ?? []).some((s) => SUITE_FILTERS.includes(s))
+    )
+      return false;
     return true;
   });
   if (EXPERIMENT_FILTERS.length > 0) {

--- a/evals/build-frontend-001-todos-app/PROMPT.md
+++ b/evals/build-frontend-001-todos-app/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: other
 product:
   - database
   - auth

--- a/evals/build-functions-001-order-total/PROMPT.md
+++ b/evals/build-functions-001-order-total/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: other
 product:
   - edge-functions
   - data-api

--- a/evals/build-functions-002-edge-auth-db/PROMPT.md
+++ b/evals/build-functions-002-edge-auth-db/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: other
 product:
   - edge-functions
   - database

--- a/evals/build-functions-003-todos-crud-api/PROMPT.md
+++ b/evals/build-functions-003-todos-crud-api/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: other
 product:
   - edge-functions
   - database

--- a/evals/build-realtime-001-live-chat-updates/PROMPT.md
+++ b/evals/build-realtime-001-live-chat-updates/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: regression
 product:
   - realtime
   - database

--- a/evals/build-rls-002-own-todos-client/PROMPT.md
+++ b/evals/build-rls-002-own-todos-client/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: other
 product:
   - database
   - auth

--- a/evals/build-rls-003-org-roles-permissions/PROMPT.md
+++ b/evals/build-rls-003-org-roles-permissions/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: build
+suite: other
 product:
   - database
   - auth

--- a/evals/investigate-db-001-table-row-counts/PROMPT.md
+++ b/evals/investigate-db-001-table-row-counts/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: investigate
+suite: other
 product:
   - database
 topic:

--- a/evals/investigate-logs-001-top-error-function/PROMPT.md
+++ b/evals/investigate-logs-001-top-error-function/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: investigate
+suite: other
 product:
   - edge-functions
 topic:

--- a/evals/investigate-reliability-001-error-rate-spike/PROMPT.md
+++ b/evals/investigate-reliability-001-error-rate-spike/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: investigate
+suite: other
 product:
   - edge-functions
 topic:

--- a/evals/investigate-reliability-002-subtle-error-spike/PROMPT.md
+++ b/evals/investigate-reliability-002-subtle-error-spike/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: investigate
+suite: other
 product:
   - edge-functions
 topic:

--- a/evals/investigate-security-001-public-table/PROMPT.md
+++ b/evals/investigate-security-001-public-table/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: investigate
+suite: other
 product:
   - database
 topic:

--- a/evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md
+++ b/evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: resolve
+suite: regression
 product:
   - database
 topic:

--- a/evals/resolve-security-001-rls-cross-user-leak/PROMPT.md
+++ b/evals/resolve-security-001-rls-cross-user-leak/PROMPT.md
@@ -1,5 +1,6 @@
 ---
 stage: resolve
+suite: other
 product:
   - database
   - auth

--- a/experiments/claude-code-opus-4.8.ts
+++ b/experiments/claude-code-opus-4.8.ts
@@ -7,7 +7,7 @@ import {
 import { localStackRuntime } from "@supabase-evals/sandbox";
 
 export default defineExperiment({
-  suite: "benchmark",
+  suite: ["benchmark"],
   agent: claudeCodeAgent({
     model: "claude-opus-4-8",
     reasoningEffort: "high",

--- a/experiments/claude-code-sonnet-4.6.ts
+++ b/experiments/claude-code-sonnet-4.6.ts
@@ -7,7 +7,7 @@ import {
 import { localStackRuntime } from "@supabase-evals/sandbox";
 
 export default defineExperiment({
-  suite: "benchmark",
+  suite: ["benchmark", "regression"],
   agent: claudeCodeAgent({
     model: "claude-sonnet-4-6",
     reasoningEffort: "high",

--- a/experiments/codex-gpt-5.4-mini.ts
+++ b/experiments/codex-gpt-5.4-mini.ts
@@ -7,7 +7,7 @@ import {
 import { localStackRuntime } from "@supabase-evals/sandbox";
 
 export default defineExperiment({
-  suite: "benchmark",
+  suite: ["benchmark"],
   agent: codexAgent({
     model: "gpt-5.4-mini",
     reasoningEffort: "medium",

--- a/experiments/codex-gpt-5.5.ts
+++ b/experiments/codex-gpt-5.5.ts
@@ -7,7 +7,7 @@ import {
 import { localStackRuntime } from "@supabase-evals/sandbox";
 
 export default defineExperiment({
-  suite: "benchmark",
+  suite: ["benchmark"],
   agent: codexAgent({
     model: "gpt-5.5",
     reasoningEffort: "medium",

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -40,7 +40,7 @@ export const evalTopicSchema = z.enum([
 export const EVAL_TOPICS = evalTopicSchema.options;
 export type EvalTopic = z.infer<typeof evalTopicSchema>;
 
-export const evalSuiteSchema = z.enum(["benchmark", "regression"]);
+export const evalSuiteSchema = z.enum(["benchmark", "regression", "other"]);
 export const EVAL_SUITES = evalSuiteSchema.options;
 export type EvalSuite = z.infer<typeof evalSuiteSchema>;
 
@@ -120,7 +120,7 @@ export const evalMetadataSchema = z.object({
   stage: evalStageSchema,
   product: z.array(evalProductSchema).min(1),
   topic: z.array(evalTopicSchema).min(1),
-  suite: evalSuiteSchema.default("regression"),
+  suite: evalSuiteSchema,
   interface: evalInterfaceSchema.optional(),
   services: z.array(z.string().min(1)).optional(),
   // Real YAML booleans or quoted string forms ("true"/"false", yes/no/on/off);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -462,7 +462,8 @@ export type LocalStackRuntime = {
 };
 
 export type ExperimentConfig = {
-  suite?: EvalSuite;
+  /** Suites this experiment runs in. Omitted/empty means no suite (skipped by `--suite`). */
+  suite?: EvalSuite[];
   agent: AgentHarness;
   runtime: EvalRuntime;
   /** Local-stack environment (e.g. localStackRuntime() from @supabase-evals/sandbox). */

--- a/packages/sandbox/test/unit.test.ts
+++ b/packages/sandbox/test/unit.test.ts
@@ -165,6 +165,7 @@ describe("services frontmatter → computeExcludedServices (regression)", () => 
     [
       "---",
       "stage: build",
+      "suite: regression",
       "product: [database]",
       "topic: [migrations]",
       `services: ${services}`,


### PR DESCRIPTION
Makes `suite` required on every eval (`benchmark` | `regression` | `other`) so future evals are accounted for, and tags the existing 31: 17 benchmark, 12 other (Saxon's bootstrap evals), 2 regression.

Experiment `suite` becomes a list so one config can run in multiple suites. `claude-code-sonnet-4.6` is now `["benchmark", "regression"]`, so `--suite regression` runs it against the regression eval set. A single `--suite X` selects experiments tagged X against evals declaring X.

Closes AI-859