### PR TITLE
feat: track skill activation in eval results

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -26,7 +26,10 @@ import {
 } from "../lib/cli-args.js";
 import { bootPlatformBackend } from "./platform-backend.js";
 import { viteBuild, vitestRun } from "./project-runner.js";
-import { getExperimentDisplayMetadata } from "@supabase-evals/core";
+import {
+  buildSkillResult,
+  getExperimentDisplayMetadata,
+} from "@supabase-evals/core";
 import type {
   ExperimentConfig,
   EvalInterface,
@@ -36,6 +39,8 @@ import type {
   ToolScorer,
   LocalStackScorer,
   ScoreResult,
+  SkillResult,
+  ToolCallRecord,
   TranscriptPart,
 } from "./types.js";
 
@@ -338,7 +343,8 @@ async function runOne(
 ): Promise<
   ScoreResult & {
     attempts: number;
-    toolCalls: unknown[];
+    skills: SkillResult;
+    toolCalls: ToolCallRecord[];
     transcript: TranscriptPart[];
     agentReport: string;
     stoppedReason: string;
@@ -354,6 +360,7 @@ async function runOne(
   // load_skill tool. Skill sources (name+dir) are shared by both paths.
   const agentRunsInSandbox = exp.agent.runsInSandbox ?? false;
   const skillSources = resolveSkillSources(exp.skills);
+  const availableSkills = skillSources.map((skill) => skill.name);
   const toolsSkills =
     ev.mode === "tools" && !agentRunsInSandbox ? loadToolsSkills(exp.skills) : [];
   const scorer = (await import(pathToFileURL(ev.evalPath).href)).default as
@@ -363,7 +370,7 @@ async function runOne(
     passed: false,
     checks: [{ name: "ran at least one attempt", passed: false }],
   };
-  let lastToolCalls: unknown[] = [];
+  let lastToolCalls: ToolCallRecord[] = [];
   let lastTranscript: TranscriptPart[] = [];
   let lastAgentReport = "";
   let lastStoppedReason = "not_started";
@@ -456,6 +463,7 @@ async function runOne(
         return {
           ...last,
           attempts: attempt,
+          skills: buildSkillResult(availableSkills, run.toolCalls),
           toolCalls: run.toolCalls,
           transcript: run.transcript,
           agentReport: run.agentReport,
@@ -516,6 +524,7 @@ async function runOne(
       return {
         ...last,
         attempts: attempt,
+        skills: buildSkillResult(availableSkills, run.toolCalls),
         toolCalls: run.toolCalls,
         transcript: run.transcript,
         agentReport: run.agentReport,
@@ -527,6 +536,7 @@ async function runOne(
   return {
     ...last,
     attempts: RUNS,
+    skills: buildSkillResult(availableSkills, lastToolCalls),
     toolCalls: lastToolCalls,
     transcript: lastTranscript,
     agentReport: lastAgentReport,

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -14,6 +14,7 @@ export type {
   JudgeInput,
   JudgeResult,
   CommandResult,
+  SkillResult,
   VitestResult,
   ProjectResult,
   EdgeFunctionsInvokeInput,

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -93,6 +93,7 @@ async function readResultFile(
     interface: promptData?.interface ?? parsedResult.interface,
     passed: parsedResult.passed === true,
     checks: parsedResult.checks,
+    skills: parsedResult.skills,
     prompt: promptData?.prompt,
     promptSourcePath: promptData?.promptSourcePath,
     attempts: parsedResult.attempts,

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -19,41 +19,38 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "supabase project initialised (supabase/config.toml exists)",
-        "passed": false
+        "passed": true
       },
       {
         "name": "todos table is created by a migration file",
-        "passed": false,
-        "notes": "supabase/migrations does not exist — was a Supabase project initialised?"
+        "passed": true
       },
       {
         "name": "todos table exists with at least 2 seeded rows",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
+        "passed": true,
+        "notes": "found 2 rows"
       },
       {
         "name": "row level security is enabled on todos",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
+        "passed": true
       },
       {
         "name": "a SELECT policy targets the authenticated role",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
+        "passed": true
       },
       {
         "name": "REST API returns no todos to anonymous requests",
-        "passed": false,
-        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
+        "passed": true,
+        "notes": "error 42501: permission denied for table todos"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
-        "passed": false,
-        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
+        "passed": true,
+        "notes": "2 rows"
       }
     ],
     "skills": {
@@ -61,7 +58,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
@@ -100,12 +99,11 @@
       },
       {
         "name": "a new migration was generated for the change",
-        "passed": false,
-        "notes": "found 1 migration file(s)"
+        "passed": true
       },
       {
         "name": "description column exists in the live database",
-        "passed": false
+        "passed": true
       }
     ],
     "skills": {
@@ -113,7 +111,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
@@ -142,22 +142,22 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "pg_cron job 'enqueue-tasks' scheduled to run every minute",
-        "passed": false,
-        "notes": "job not found in cron.job"
+        "passed": true,
+        "notes": "schedule='* * * * *', active=true"
       },
       {
         "name": "cron command enqueues to the 'tasks' queue",
-        "passed": false,
-        "notes": "job not found, so its command can't run"
+        "passed": true,
+        "notes": "queue depth 0 -> 1"
       },
       {
         "name": "process-tasks function drains the queue",
-        "passed": false,
-        "notes": "couldn't enqueue a test message. Is the 'tasks' queue created? query failed: ERROR:  relation \"pgmq.q_tasks\" does not exist\nLINE 2:         INSERT INTO pgmq.q_tasks (vt, message, headers)\n                            ^\nQUERY:  \n        INSERT INTO pgmq.q_tasks (vt, message, headers)\n        VALUES ($2, $1, $3)\n        RETURNING msg_id;\n        \nCONTEXT:  PL/pgSQL function pgmq.send(text,jsonb,jsonb,timestamp with time zone) line 14 at RETURN QUERY\nSQL function \"send\" statement 1\n"
+        "passed": true,
+        "notes": "function removed the seeded message (id 6) from the queue"
       }
     ],
     "skills": {
@@ -165,7 +165,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
@@ -190,12 +192,27 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
-        "name": "scorer completed without errors",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-ab1f7659\nTry rerunning the command with --debug to troubleshoot the error.\n"
+        "name": "all 3 tables exist (teams, members, tasks)",
+        "passed": true
+      },
+      {
+        "name": "row counts match (teams=5, members=10, tasks=13)",
+        "passed": true
+      },
+      {
+        "name": "foreign key constraints survived the restore",
+        "passed": true
+      },
+      {
+        "name": "tasks_team_status_idx index survived the restore",
+        "passed": true
+      },
+      {
+        "name": "sequences synced (next insert won't conflict with existing IDs)",
+        "passed": true
       }
     ],
     "skills": {
@@ -203,7 +220,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
@@ -231,7 +250,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -243,15 +262,15 @@
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": false
+        "passed": true
       }
     ],
     "skills": {
@@ -259,7 +278,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
@@ -285,12 +306,45 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "bucket user-files exists",
-        "passed": false,
-        "notes": "no row in storage.buckets with id or name 'user-files'"
+        "passed": true
+      },
+      {
+        "name": "bucket user-files is private",
+        "passed": true
+      },
+      {
+        "name": "RLS still enabled on storage.objects",
+        "passed": true
+      },
+      {
+        "name": "user A lists only own files",
+        "passed": true,
+        "notes": "saw: 019f1f4a-d76d-73bf-bb8f-794c18c7bf5d/receipt-alpha.pdf, 019f1f4a-d76d-73bf-bb8f-794c18c7bf5d/receipt-beta.pdf"
+      },
+      {
+        "name": "user B cannot read user A files",
+        "passed": true
+      },
+      {
+        "name": "anon reads no files",
+        "passed": true
+      },
+      {
+        "name": "user A can upload into own folder",
+        "passed": true
+      },
+      {
+        "name": "user B cannot upload into user A folder",
+        "passed": true
+      },
+      {
+        "name": "configured private per-user storage access",
+        "passed": true,
+        "judgeNotes": "Meets requirements: creates private user-files bucket, keeps RLS enabled, adds authenticated owner-scoped SELECT and INSERT policies with matching WITH CHECK using storage.foldername/auth.uid, and provides supabase-js createSignedUrl with expiry. Does not use public bucket/getPublicUrl/service role."
       }
     ],
     "skills": {
@@ -298,7 +352,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
@@ -324,22 +380,22 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": false,
-        "notes": "no .sql files found under supabase/tests/"
+        "passed": true,
+        "notes": "1 file(s): supabase/tests/database/tenant_isolation_test.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
-        "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Pull complete\na2"
+        "passed": true,
+        "notes": "6 passed, 2 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
-        "passed": false,
-        "judgeNotes": "The response does not analyze the pgTAP results or identify the broken tenant isolation policy. It fails to conclude that the posts table is the one with the policy flaw."
+        "passed": true,
+        "judgeNotes": "The agent correctly identifies `posts` as the broken tenant isolation policy, explains that authenticated members can read posts from organizations they do not belong to, and grounds the conclusion in pgTAP failures (posts negative/isolation tests failing while notes pass). It treats the test results as authoritative and does not blame notes or dismiss the failures."
       }
     ],
     "skills": {
@@ -347,7 +403,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
@@ -378,7 +436,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "relation \"documents\" does not exist"
+        "notes": "relation \"document_sections\" does not exist"
       }
     ],
     "skills": {
@@ -386,7 +444,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
@@ -419,12 +479,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "prometheus.yml only preserves the app scrape; it does not add a Supabase Metrics API scrape target, HTTPS /customer/v1/privileged/metrics path, or HTTP Basic Auth with password_file. docker-compose.yml also does not mount or wire any password_file/secret."
+        "judgeNotes": "Supabase scrape uses placeholder YOUR_PROJECT_REF and is explicitly inert/not deployable; rubric requires a deployable project target for <project-ref>.supabase.co or .supabase.red."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README lacks required steps to create a Secret API key, place the matching secret file, and restart/reload the Compose stack. It also lacks concrete verification via Prometheus targets, PromQL/Grafana, or equivalent."
+        "passed": true,
+        "judgeNotes": "README includes go-live steps to set project ref, create a Supabase Secret API key, write it to the mounted secret file, apply/reload the Docker Compose stack, and verify via curl plus Prometheus Targets showing the supabase job UP."
       }
     ],
     "skills": {
@@ -432,7 +492,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
@@ -457,22 +519,21 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "WEATHER_API_KEY is set as a Function secret on the project",
-        "passed": false,
-        "notes": "secrets present: []"
+        "passed": true
       },
       {
         "name": "the weather function is deployed to the project",
-        "passed": false,
-        "notes": "function not found on the project (status 404)"
+        "passed": true,
+        "notes": "status ACTIVE"
       },
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": false,
-        "notes": "could not read supabase/functions/weather/*"
+        "passed": true,
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -484,7 +545,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
@@ -511,12 +574,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": false,
-        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
+        "passed": true
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -524,13 +586,11 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": false,
-        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
+        "passed": true
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": false,
-        "notes": "JWT_SECRET missing"
+        "passed": true
       }
     ],
     "skills": {
@@ -538,7 +598,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
@@ -575,13 +637,12 @@
       },
       {
         "name": "delete-account revokes the user's sessions",
-        "passed": false,
-        "notes": "sessions left: 1"
+        "passed": true,
+        "notes": "sessions left: 0"
       },
       {
         "name": "deleted user's refresh token is rejected",
-        "passed": false,
-        "notes": "refresh token still produces a session"
+        "passed": true
       },
       {
         "name": "deleted user cannot sign back in",
@@ -595,7 +656,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "The answer does not address the account deletion/auth revocation issue, access-token validity window, or publishable vs secret key clarification. It only reports an API usage limit error."
+        "judgeNotes": "The answer correctly diagnoses the soft-delete/RLS issue, revokes auth.sessions, explains JWT expiry nuance, and clarifies publishable vs secret keys. However, it does not actually delete/remove the auth user or identity, so the user could potentially sign in again and get new sessions. It also does not clearly state that server-side checks needing immediate revocation should use auth.getUser() or short JWT expiry instead of local JWT validation/getClaims()."
       }
     ],
     "skills": {
@@ -603,7 +664,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -628,11 +691,11 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "orders table added to supabase_realtime publication",
-        "passed": false
+        "passed": true
       },
       {
         "name": "courier_locations still in supabase_realtime publication",
@@ -653,8 +716,8 @@
       },
       {
         "name": "diagnosed missing publication membership",
-        "passed": false,
-        "judgeNotes": "The response does not diagnose the missing orders table in the supabase_realtime publication or provide the required ALTER PUBLICATION fix."
+        "passed": true,
+        "judgeNotes": "The assistant correctly identified the root cause as orders missing from the supabase_realtime publication despite channel SUBSCRIBED, added only public.orders to the existing publication, preserved courier_locations, and did not weaken RLS or blame client/RLS/networking."
       }
     ],
     "skills": {
@@ -662,7 +725,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
@@ -686,22 +751,22 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
-        "passed": false,
-        "judgeNotes": "The assistant did not identify image-transform or the recurring HTTP 503 pattern on 2026-04-28; it only reported an API usage limit error."
+        "passed": true,
+        "judgeNotes": "The assistant correctly identified image-transform as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, covering all 8 gateway failures from 07:00Z through 12:00Z. It also avoided misattributing the old billing-webhook 503s as the main issue."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The response does not attribute the 503s to the gateway/platform layer or ground the attribution in any observations. It only reports an unrelated API usage limit error."
+        "passed": true,
+        "judgeNotes": "Attributes recurring image-transform 503s to the API gateway/platform layer, not function code. Grounded in valid observations: 503s appear only in API gateway logs and not Edge Function execution logs, while execution logs show 200s; distinguishes gateway 503s from avatar-upload's function-level 500."
       },
       {
         "name": "recommended a concrete next step",
-        "passed": false,
-        "judgeNotes": "The assistant only reported the API limit error and did not recommend any concrete next step such as escalation, incident creation with request IDs/time window, checking platform health, or reviewing configuration/logs."
+        "passed": true,
+        "judgeNotes": "The assistant recommended concrete next steps: checking image-transform resource limits/metrics for the specific timestamps, adding retry backoff, reducing invocation load, and grabbing the avatar-upload stack trace. These are specific actionable steps beyond vague log checking."
       }
     ],
     "skills": {
@@ -709,7 +774,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
@@ -736,7 +803,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "RLS still enabled on bookmarks",
@@ -744,7 +811,7 @@
       },
       {
         "name": "user A reads own bookmarks",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user B cannot read user A bookmarks",
@@ -756,8 +823,7 @@
       },
       {
         "name": "user A can save a new bookmark",
-        "passed": false,
-        "notes": "new row violates row-level security policy for table \"bookmarks\""
+        "passed": true
       },
       {
         "name": "user B cannot insert a bookmark as user A",
@@ -765,8 +831,8 @@
       },
       {
         "name": "diagnosed RLS and added owner-scoped policies",
-        "passed": false,
-        "judgeNotes": "The answer does not diagnose the empty Data API results as an RLS deny-all issue and does not create authenticated owner-scoped SELECT and INSERT policies while keeping RLS enabled."
+        "passed": true,
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API results, created authenticated SELECT and INSERT owner-scoped policies using auth.uid()/user_id with WITH CHECK for inserts, and kept RLS enabled."
       }
     ],
     "skills": {
@@ -774,7 +840,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -799,24 +867,24 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": false
+        "passed": true
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": false
+        "passed": true
       },
       {
         "name": "created index covering user_id and created_at",
-        "passed": false
+        "passed": true
       },
       {
         "name": "query plan uses an index and avoids sequential scan",
-        "passed": false,
-        "notes": "Limit  (cost=118.52..118.57 rows=20 width=88)\n  ->  Sort  (cost=118.52..118.57 rows=20 width=88)\n        Sort Key: created_at DESC\n        ->  Seq Scan on events  (cost=0.00..118.09 rows=20 width=88)\n              Filter: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "passed": true,
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -828,7 +896,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -854,7 +924,7 @@
       "security"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "RLS enabled on notes",
@@ -862,11 +932,11 @@
       },
       {
         "name": "tenant A sees only org A notes",
-        "passed": false
+        "passed": true
       },
       {
         "name": "tenant B cannot read org A notes",
-        "passed": false
+        "passed": true
       },
       {
         "name": "tenant A author can update own note",
@@ -898,7 +968,9 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
@@ -912,912 +984,6 @@
       "modelProvider": "anthropic",
       "modelId": "claude-sonnet-4-6",
       "reasoningEffort": "high"
-    },
-    "eval": "build-cli-001-bootstrap-app",
-    "stage": "build",
-    "product": [
-      "database",
-      "data-api"
-    ],
-    "topic": [
-      "migrations",
-      "rls"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "supabase project initialised (supabase/config.toml exists)",
-        "passed": false
-      },
-      {
-        "name": "todos table is created by a migration file",
-        "passed": false,
-        "notes": "supabase/migrations does not exist — was a Supabase project initialised?"
-      },
-      {
-        "name": "todos table exists with at least 2 seeded rows",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
-      },
-      {
-        "name": "row level security is enabled on todos",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
-      },
-      {
-        "name": "a SELECT policy targets the authenticated role",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
-      },
-      {
-        "name": "REST API returns no todos to anonymous requests",
-        "passed": false,
-        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
-      },
-      {
-        "name": "REST API returns the todos to authenticated requests",
-        "passed": false,
-        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
-    "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-cli-001-bootstrap-app.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": false
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": false,
-        "notes": "description not found in any schema file"
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": false,
-        "notes": "found 1 migration file(s)"
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": false
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-cli-002-declarative-schema.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-003-pg-cron-queue-workflow",
-    "stage": "build",
-    "product": [
-      "database",
-      "edge-functions",
-      "cron",
-      "queues"
-    ],
-    "topic": [
-      "sql",
-      "sdk"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "pg_cron job 'enqueue-tasks' scheduled to run every minute",
-        "passed": false,
-        "notes": "job not found in cron.job"
-      },
-      {
-        "name": "cron command enqueues to the 'tasks' queue",
-        "passed": false,
-        "notes": "job not found, so its command can't run"
-      },
-      {
-        "name": "process-tasks function drains the queue",
-        "passed": false,
-        "notes": "couldn't enqueue a test message. Is the 'tasks' queue created? query failed: ERROR:  relation \"pgmq.q_tasks\" does not exist\nLINE 2:         INSERT INTO pgmq.q_tasks (vt, message, headers)\n                            ^\nQUERY:  \n        INSERT INTO pgmq.q_tasks (vt, message, headers)\n        VALUES ($2, $1, $3)\n        RETURNING msg_id;\n        \nCONTEXT:  PL/pgSQL function pgmq.send(text,jsonb,jsonb,timestamp with time zone) line 14 at RETURN QUERY\nSQL function \"send\" statement 1\n"
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
-    "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-cli-003-pg-cron-queue-workflow.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-database-001-migrate-postgres-to-supabase",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "scorer completed without errors",
-        "passed": false,
-        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-c396dbf2\nTry rerunning the command with --debug to troubleshoot the error.\n"
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
-    "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-database-001-migrate-postgres-to-supabase.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-functions-004-service-role-bypass",
-    "stage": "build",
-    "product": [
-      "edge-functions",
-      "auth",
-      "database"
-    ],
-    "topic": [
-      "rls",
-      "security",
-      "sdk"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "rejects missing auth",
-        "passed": true
-      },
-      {
-        "name": "user A reads own note",
-        "passed": true
-      },
-      {
-        "name": "reads only with the caller's JWT",
-        "passed": false
-      },
-      {
-        "name": "user A cannot force-read user B note",
-        "passed": false
-      },
-      {
-        "name": "user B cannot force-read user A note",
-        "passed": false
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
-    "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-functions-004-service-role-bypass.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-storage-001-private-bucket-access",
-    "stage": "build",
-    "product": [
-      "storage",
-      "database"
-    ],
-    "topic": [
-      "rls",
-      "sdk"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "bucket user-files exists",
-        "passed": false,
-        "notes": "no row in storage.buckets with id or name 'user-files'"
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
-    "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-storage-001-private-bucket-access.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-tests-001-rls-tenant-isolation",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "tests",
-      "rls"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": false,
-        "notes": "no .sql files found under supabase/tests/"
-      },
-      {
-        "name": "pgTAP isolation tests ran and pass",
-        "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\nfailed to pull docker image: Error response from daemon: toomanyrequests: Rate exceeded\nRetrying after 4s: public.ecr.aws/supabase/pg_prove:3.36\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad"
-      },
-      {
-        "name": "agent correctly identifies the posts isolation bug from test results",
-        "passed": false,
-        "judgeNotes": "The response does not analyze the pgTAP results or identify the posts table policy flaw; it only reports an API usage error."
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
-    "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-tests-001-rls-tenant-isolation.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-vectors-001-rag-with-permissions",
-    "stage": "build",
-    "product": [
-      "database",
-      "vectors"
-    ],
-    "topic": [
-      "sql",
-      "rls"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "scorer evaluated vector search",
-        "passed": false,
-        "notes": "relation \"documents\" does not exist"
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
-    "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/build-vectors-001-rag-with-permissions.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "deploy-database-001-prometheus-metrics",
-    "stage": "deploy",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "observability"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "preserved existing app scrape job",
-        "passed": true
-      },
-      {
-        "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "prometheus.yml only preserves the existing app scrape and does not add a Supabase Metrics API scrape target, HTTPS scheme, /customer/v1/privileged/metrics path, or HTTP Basic Auth with password_file. docker-compose.yml also does not mount or wire a password file/secret."
-      },
-      {
-        "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README lacks required instructions to create a Secret API key, place the matching secret file, restart/reload the Compose stack, and concretely verify the integration via Prometheus targets/PromQL/Grafana or equivalent."
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
-    "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/deploy-database-001-prometheus-metrics.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "deploy-functions-001-edge-function-secrets",
-    "stage": "deploy",
-    "product": [
-      "edge-functions"
-    ],
-    "topic": [
-      "security"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "WEATHER_API_KEY is set as a Function secret on the project",
-        "passed": false,
-        "notes": "secrets present: []"
-      },
-      {
-        "name": "the weather function is deployed to the project",
-        "passed": false,
-        "notes": "function not found on the project (status 404)"
-      },
-      {
-        "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": false,
-        "notes": "could not read supabase/functions/weather/*"
-      },
-      {
-        "name": "WEATHER_API_KEY value is not committed to the repo",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
-    "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/deploy-functions-001-edge-function-secrets.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "deploy-self-hosting-001-docker-compose",
-    "stage": "deploy",
-    "product": [
-      "database",
-      "auth",
-      "storage"
-    ],
-    "topic": [
-      "self-hosting"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": false,
-        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
-      },
-      {
-        "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
-        "passed": true
-      },
-      {
-        "name": "secrets rotated off the shipped defaults",
-        "passed": false,
-        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
-      },
-      {
-        "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": false,
-        "notes": "JWT_SECRET missing"
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
-    "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/deploy-self-hosting-001-docker-compose.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "investigate-auth-001-deleted-user-access",
-    "stage": "investigate",
-    "product": [
-      "auth"
-    ],
-    "topic": [
-      "security",
-      "sdk"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "victim session active before delete-account",
-        "passed": true
-      },
-      {
-        "name": "delete_account flow ran for the victim",
-        "passed": true
-      },
-      {
-        "name": "delete-account revokes the user's sessions",
-        "passed": false,
-        "notes": "sessions left: 1"
-      },
-      {
-        "name": "deleted user's refresh token is rejected",
-        "passed": false,
-        "notes": "refresh token still produces a session"
-      },
-      {
-        "name": "deleted user cannot sign back in",
-        "passed": false,
-        "notes": "deleted account can still sign in"
-      },
-      {
-        "name": "other users keep their sessions and access",
-        "passed": true
-      },
-      {
-        "name": "diagnosed and explained session revocation",
-        "passed": false,
-        "judgeNotes": "The response is just an API usage error and does not address the delete-account/auth revocation issue, access-token window, or publishable vs secret key clarification."
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
-    "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/investigate-auth-001-deleted-user-access.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "investigate-realtime-001-subscribed-no-events",
-    "stage": "investigate",
-    "product": [
-      "realtime",
-      "database"
-    ],
-    "topic": [
-      "sdk"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "orders table added to supabase_realtime publication",
-        "passed": false
-      },
-      {
-        "name": "courier_locations still in supabase_realtime publication",
-        "passed": true
-      },
-      {
-        "name": "publication still publishes INSERT events",
-        "passed": true
-      },
-      {
-        "name": "RLS still enabled on orders",
-        "passed": true
-      },
-      {
-        "name": "staff can still read orders through RLS",
-        "passed": true,
-        "notes": "authenticated sees 2 of 2 orders"
-      },
-      {
-        "name": "diagnosed missing publication membership",
-        "passed": false,
-        "judgeNotes": "The answer does not diagnose the missing orders table in the supabase_realtime publication or provide the required ALTER PUBLICATION fix."
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
-    "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/investigate-realtime-001-subscribed-no-events.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "investigate-reliability-003-edge-function-5xx-correlation",
-    "stage": "investigate",
-    "product": [
-      "edge-functions"
-    ],
-    "topic": [
-      "observability"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "identified image-transform and the recurring 503 pattern",
-        "passed": false,
-        "judgeNotes": "The assistant did not identify image-transform or the recurring HTTP 503 pattern on 2026-04-28; it only reported an API usage limit error."
-      },
-      {
-        "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The assistant did not address the cause of the 503s or attribute them to the gateway/platform layer with supporting observations; it only reported an API usage limit error."
-      },
-      {
-        "name": "recommended a concrete next step",
-        "passed": false,
-        "judgeNotes": "The assistant only reported the API usage limit error and did not recommend any concrete next step such as escalation, incident creation with request IDs/time window, platform health checks, deployment/routing review, or infrastructure log investigation."
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
-    "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/investigate-reliability-003-edge-function-5xx-correlation.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "resolve-dataapi-001-empty-results",
-    "stage": "resolve",
-    "product": [
-      "data-api",
-      "database",
-      "auth"
-    ],
-    "topic": [
-      "rls",
-      "sdk"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "RLS still enabled on bookmarks",
-        "passed": true
-      },
-      {
-        "name": "user A reads own bookmarks",
-        "passed": false
-      },
-      {
-        "name": "user B cannot read user A bookmarks",
-        "passed": true
-      },
-      {
-        "name": "anon reads no bookmarks",
-        "passed": true
-      },
-      {
-        "name": "user A can save a new bookmark",
-        "passed": false,
-        "notes": "new row violates row-level security policy for table \"bookmarks\""
-      },
-      {
-        "name": "user B cannot insert a bookmark as user A",
-        "passed": true
-      },
-      {
-        "name": "diagnosed RLS and added owner-scoped policies",
-        "passed": false,
-        "judgeNotes": "The answer does not diagnose or fix the empty Data API results as an RLS issue, and it does not create authenticated owner-scoped SELECT/INSERT policies while keeping RLS enabled."
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
-    "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/resolve-dataapi-001-empty-results.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "resolve-performance-001-slow-query-cpu-spike",
-    "stage": "resolve",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "observability",
-      "sql"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "inspected pg_stat_statements for query performance",
-        "passed": false
-      },
-      {
-        "name": "ran EXPLAIN on the expensive query",
-        "passed": false
-      },
-      {
-        "name": "created index covering user_id and created_at",
-        "passed": false
-      },
-      {
-        "name": "query plan uses an index and avoids sequential scan",
-        "passed": false,
-        "notes": "Limit  (cost=118.52..118.57 rows=20 width=88)\n  ->  Sort  (cost=118.52..118.57 rows=20 width=88)\n        Sort Key: created_at DESC\n        ->  Seq Scan on events  (cost=0.00..118.09 rows=20 width=88)\n              Filter: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
-      },
-      {
-        "name": "inserts still work",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
-    "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/resolve-performance-001-slow-query-cpu-spike.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-4.6",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-4-6",
-      "reasoningEffort": "high"
-    },
-    "eval": "resolve-security-002-rls-cross-tenant-leak",
-    "stage": "resolve",
-    "product": [
-      "database",
-      "auth"
-    ],
-    "topic": [
-      "rls",
-      "security"
-    ],
-    "suite": "benchmark",
-    "passed": false,
-    "checks": [
-      {
-        "name": "RLS enabled on notes",
-        "passed": true
-      },
-      {
-        "name": "tenant A sees only org A notes",
-        "passed": false
-      },
-      {
-        "name": "tenant B cannot read org A notes",
-        "passed": false
-      },
-      {
-        "name": "tenant A author can update own note",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot update org A note",
-        "passed": true
-      },
-      {
-        "name": "tenant B author can delete own note",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot delete org A note",
-        "passed": true
-      },
-      {
-        "name": "tenant A can insert note in own org",
-        "passed": true
-      },
-      {
-        "name": "tenant B cannot insert into org A",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
-    "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "claude-code-sonnet-4.6/resolve-security-002-rls-cross-tenant-leak.json"
-  },
-  {
-    "experiment": "codex-gpt-5.4-mini",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.4-mini",
-      "reasoningEffort": "medium"
     },
     "eval": "build-cli-001-bootstrap-app",
     "stage": "build",
@@ -1863,6 +1029,986 @@
         "name": "REST API returns the todos to authenticated requests",
         "passed": true,
         "notes": "2 rows"
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
+    "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-cli-001-bootstrap-app.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": false
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": false,
+        "notes": "description not found in any schema file"
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-cli-002-declarative-schema.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-003-pg-cron-queue-workflow",
+    "stage": "build",
+    "product": [
+      "database",
+      "edge-functions",
+      "cron",
+      "queues"
+    ],
+    "topic": [
+      "sql",
+      "sdk"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "pg_cron job 'enqueue-tasks' scheduled to run every minute",
+        "passed": true,
+        "notes": "schedule='* * * * *', active=true"
+      },
+      {
+        "name": "cron command enqueues to the 'tasks' queue",
+        "passed": true,
+        "notes": "queue depth 1 -> 2"
+      },
+      {
+        "name": "process-tasks function drains the queue",
+        "passed": true,
+        "notes": "function removed the seeded message (id 5) from the queue"
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
+    "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-cli-003-pg-cron-queue-workflow.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-database-001-migrate-postgres-to-supabase",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "all 3 tables exist (teams, members, tasks)",
+        "passed": true
+      },
+      {
+        "name": "row counts match (teams=5, members=10, tasks=13)",
+        "passed": true
+      },
+      {
+        "name": "foreign key constraints survived the restore",
+        "passed": true
+      },
+      {
+        "name": "tasks_team_status_idx index survived the restore",
+        "passed": true
+      },
+      {
+        "name": "sequences synced (next insert won't conflict with existing IDs)",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
+    "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-database-001-migrate-postgres-to-supabase.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-functions-004-service-role-bypass",
+    "stage": "build",
+    "product": [
+      "edge-functions",
+      "auth",
+      "database"
+    ],
+    "topic": [
+      "rls",
+      "security",
+      "sdk"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "rejects missing auth",
+        "passed": true
+      },
+      {
+        "name": "user A reads own note",
+        "passed": true
+      },
+      {
+        "name": "reads only with the caller's JWT",
+        "passed": true
+      },
+      {
+        "name": "user A cannot force-read user B note",
+        "passed": true
+      },
+      {
+        "name": "user B cannot force-read user A note",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
+    "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-functions-004-service-role-bypass.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-storage-001-private-bucket-access",
+    "stage": "build",
+    "product": [
+      "storage",
+      "database"
+    ],
+    "topic": [
+      "rls",
+      "sdk"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "bucket user-files exists",
+        "passed": true
+      },
+      {
+        "name": "bucket user-files is private",
+        "passed": true
+      },
+      {
+        "name": "RLS still enabled on storage.objects",
+        "passed": true
+      },
+      {
+        "name": "user A lists only own files",
+        "passed": true,
+        "notes": "saw: 019f1f4a-8d82-72ff-b3cf-efd67212cf42/receipt-alpha.pdf, 019f1f4a-8d82-72ff-b3cf-efd67212cf42/receipt-beta.pdf"
+      },
+      {
+        "name": "user B cannot read user A files",
+        "passed": true
+      },
+      {
+        "name": "anon reads no files",
+        "passed": true
+      },
+      {
+        "name": "user A can upload into own folder",
+        "passed": true
+      },
+      {
+        "name": "user B cannot upload into user A folder",
+        "passed": true
+      },
+      {
+        "name": "configured private per-user storage access",
+        "passed": true,
+        "judgeNotes": "Meets rubric: private user-files bucket, authenticated owner-scoped SELECT and INSERT policies with WITH CHECK, RLS not disabled, and supabase-js createSignedUrl with expiry for temporary sharing."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
+    "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-storage-001-private-bucket-access.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-tests-001-rls-tenant-isolation",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "tests",
+      "rls"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "pgTAP test file(s) written under supabase/tests/",
+        "passed": true,
+        "notes": "1 file(s): supabase/tests/tenant_isolation.test.sql"
+      },
+      {
+        "name": "pgTAP isolation tests ran and pass",
+        "passed": true,
+        "notes": "5 passed, 3 failed"
+      },
+      {
+        "name": "agent correctly identifies the posts isolation bug from test results",
+        "passed": true,
+        "judgeNotes": "The agent correctly identifies `posts` as the table with the broken tenant isolation policy, explains that authenticated users with any membership can read posts from other orgs, and grounds the conclusion in pgTAP results showing `notes` pass while `posts` fail."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
+    "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-tests-001-rls-tenant-isolation.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-vectors-001-rag-with-permissions",
+    "stage": "build",
+    "product": [
+      "database",
+      "vectors"
+    ],
+    "topic": [
+      "sql",
+      "rls"
+    ],
+    "suite": "benchmark",
+    "passed": false,
+    "checks": [
+      {
+        "name": "scorer evaluated vector search",
+        "passed": false,
+        "notes": "column \"owner_id\" of relation \"documents\" does not exist"
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
+    "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/build-vectors-001-rag-with-permissions.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "deploy-database-001-prometheus-metrics",
+    "stage": "deploy",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "observability"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "preserved existing app scrape job",
+        "passed": true
+      },
+      {
+        "name": "configured the Supabase Metrics API scrape correctly",
+        "passed": true,
+        "judgeNotes": "Meets requirements: app scrape preserved; Supabase scrape uses HTTPS, correct metrics path, Basic Auth with password_file; target is a Supabase project host placeholder; docker-compose mounts the same password_file path read-only."
+      },
+      {
+        "name": "documented live deployment and verification steps",
+        "passed": true,
+        "judgeNotes": "README includes correct Supabase endpoint/auth, instructs replacing project ref, creating the mounted secret key file from the Supabase Secret key, starting the Compose stack, and verifying via Prometheus targets and direct curl."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
+    "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/deploy-database-001-prometheus-metrics.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "deploy-functions-001-edge-function-secrets",
+    "stage": "deploy",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "WEATHER_API_KEY is set as a Function secret on the project",
+        "passed": true
+      },
+      {
+        "name": "the weather function is deployed to the project",
+        "passed": true,
+        "notes": "status ACTIVE"
+      },
+      {
+        "name": "the weather function reads WEATHER_API_KEY from the environment",
+        "passed": true,
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+      },
+      {
+        "name": "WEATHER_API_KEY value is not committed to the repo",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
+    "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/deploy-functions-001-edge-function-secrets.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "deploy-self-hosting-001-docker-compose",
+    "stage": "deploy",
+    "product": [
+      "database",
+      "auth",
+      "storage"
+    ],
+    "topic": [
+      "self-hosting"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
+        "passed": true
+      },
+      {
+        "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
+        "passed": true
+      },
+      {
+        "name": "secrets rotated off the shipped defaults",
+        "passed": true
+      },
+      {
+        "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
+    "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/deploy-self-hosting-001-docker-compose.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "investigate-auth-001-deleted-user-access",
+    "stage": "investigate",
+    "product": [
+      "auth"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "victim session active before delete-account",
+        "passed": true
+      },
+      {
+        "name": "delete_account flow ran for the victim",
+        "passed": true
+      },
+      {
+        "name": "delete-account revokes the user's sessions",
+        "passed": true,
+        "notes": "sessions left: 0"
+      },
+      {
+        "name": "deleted user's refresh token is rejected",
+        "passed": true
+      },
+      {
+        "name": "deleted user cannot sign back in",
+        "passed": true
+      },
+      {
+        "name": "other users keep their sessions and access",
+        "passed": true
+      },
+      {
+        "name": "diagnosed and explained session revocation",
+        "passed": true,
+        "judgeNotes": "Covers the root cause, replaces soft delete with deletion of auth user/session revocation, explains stateless JWT expiry window and mitigation, and correctly distinguishes publishable frontend keys from secret server-only keys that bypass RLS."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
+    "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/investigate-auth-001-deleted-user-access.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "investigate-realtime-001-subscribed-no-events",
+    "stage": "investigate",
+    "product": [
+      "realtime",
+      "database"
+    ],
+    "topic": [
+      "sdk"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "orders table added to supabase_realtime publication",
+        "passed": true
+      },
+      {
+        "name": "courier_locations still in supabase_realtime publication",
+        "passed": true
+      },
+      {
+        "name": "publication still publishes INSERT events",
+        "passed": true
+      },
+      {
+        "name": "RLS still enabled on orders",
+        "passed": true
+      },
+      {
+        "name": "staff can still read orders through RLS",
+        "passed": true,
+        "notes": "authenticated sees 2 of 2 orders"
+      },
+      {
+        "name": "diagnosed missing publication membership",
+        "passed": true,
+        "judgeNotes": "Identifies orders missing from supabase_realtime publication as root cause, applies ALTER PUBLICATION ADD TABLE public.orders, preserves courier_locations/RLS/policies, and does not blame client/RLS/networking."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
+    "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/investigate-realtime-001-subscribed-no-events.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "investigate-reliability-003-edge-function-5xx-correlation",
+    "stage": "investigate",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "observability"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "identified image-transform and the recurring 503 pattern",
+        "passed": true,
+        "judgeNotes": "The assistant correctly identified `image-transform` as the main affected function and described a recurring pattern of API gateway HTTP 503s throughout the morning of 2026-04-28, spanning 07:00Z through 12:00Z and distinguishing it from older billing-webhook 503s."
+      },
+      {
+        "name": "attributed recurring 503s to gateway/platform layer, not function code",
+        "passed": true,
+        "judgeNotes": "The assistant attributes the recurring image-transform 503s to the gateway/platform layer/cold routing before the function runs, not application logic. This is grounded in the observation that 503s appear only in API gateway logs with no corresponding edge function execution logs, while nearby invocations succeed. It also distinguishes avatar-upload's isolated logged 500 as a separate runtime/function-level issue."
+      },
+      {
+        "name": "recommended a concrete next step",
+        "passed": true,
+        "judgeNotes": "The assistant recommended concrete next steps: adding a pg_cron keep-warm ping, adding client retry logic, adding structured error logging, and reviewing a separate outage."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
+    "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/investigate-reliability-003-edge-function-5xx-correlation.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-dataapi-001-empty-results",
+    "stage": "resolve",
+    "product": [
+      "data-api",
+      "database",
+      "auth"
+    ],
+    "topic": [
+      "rls",
+      "sdk"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "RLS still enabled on bookmarks",
+        "passed": true
+      },
+      {
+        "name": "user A reads own bookmarks",
+        "passed": true
+      },
+      {
+        "name": "user B cannot read user A bookmarks",
+        "passed": true
+      },
+      {
+        "name": "anon reads no bookmarks",
+        "passed": true
+      },
+      {
+        "name": "user A can save a new bookmark",
+        "passed": true
+      },
+      {
+        "name": "user B cannot insert a bookmark as user A",
+        "passed": true
+      },
+      {
+        "name": "diagnosed RLS and added owner-scoped policies",
+        "passed": true,
+        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
+    "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/resolve-dataapi-001-empty-results.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-performance-001-slow-query-cpu-spike",
+    "stage": "resolve",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "observability",
+      "sql"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "inspected pg_stat_statements for query performance",
+        "passed": true
+      },
+      {
+        "name": "ran EXPLAIN on the expensive query",
+        "passed": true
+      },
+      {
+        "name": "created index covering user_id and created_at",
+        "passed": true
+      },
+      {
+        "name": "query plan uses an index and avoids sequential scan",
+        "passed": true,
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on idx_events_user_id_created_at  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+      },
+      {
+        "name": "inserts still work",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
+    "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/resolve-performance-001-slow-query-cpu-spike.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-4.6",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-4-6",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-security-002-rls-cross-tenant-leak",
+    "stage": "resolve",
+    "product": [
+      "database",
+      "auth"
+    ],
+    "topic": [
+      "rls",
+      "security"
+    ],
+    "suite": "benchmark",
+    "passed": true,
+    "checks": [
+      {
+        "name": "RLS enabled on notes",
+        "passed": true
+      },
+      {
+        "name": "tenant A sees only org A notes",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot read org A notes",
+        "passed": true
+      },
+      {
+        "name": "tenant A author can update own note",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot update org A note",
+        "passed": true
+      },
+      {
+        "name": "tenant B author can delete own note",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot delete org A note",
+        "passed": true
+      },
+      {
+        "name": "tenant A can insert note in own org",
+        "passed": true
+      },
+      {
+        "name": "tenant B cannot insert into org A",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
+    "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-4.6/resolve-security-002-rls-cross-tenant-leak.json"
+  },
+  {
+    "experiment": "codex-gpt-5.4-mini",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.4-mini",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-cli-001-bootstrap-app",
+    "stage": "build",
+    "product": [
+      "database",
+      "data-api"
+    ],
+    "topic": [
+      "migrations",
+      "rls"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "supabase project initialised (supabase/config.toml exists)",
+        "passed": true
+      },
+      {
+        "name": "todos table is created by a migration file",
+        "passed": true
+      },
+      {
+        "name": "todos table exists with at least 2 seeded rows",
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-822c090c\nTry rerunning the command with --debug to troubleshoot the error.\n"
+      },
+      {
+        "name": "row level security is enabled on todos",
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-822c090c\nTry rerunning the command with --debug to troubleshoot the error.\n"
+      },
+      {
+        "name": "a SELECT policy targets the authenticated role",
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-822c090c\nTry rerunning the command with --debug to troubleshoot the error.\n"
+      },
+      {
+        "name": "REST API returns no todos to anonymous requests",
+        "passed": false,
+        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-822c090c\nTry rerunning the command with --debug to troubleshoot the error.\n"
+      },
+      {
+        "name": "REST API returns the todos to authenticated requests",
+        "passed": false,
+        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-822c090c\nTry rerunning the command with --debug to troubleshoot the error.\n"
       }
     ],
     "skills": {
@@ -1968,7 +2114,7 @@
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 3) from the queue"
+        "notes": "function removed the seeded message (id 4) from the queue"
       }
     ],
     "skills": {
@@ -2003,27 +2149,12 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
-        "name": "all 3 tables exist (teams, members, tasks)",
-        "passed": true
-      },
-      {
-        "name": "row counts match (teams=5, members=10, tasks=13)",
-        "passed": true
-      },
-      {
-        "name": "foreign key constraints survived the restore",
-        "passed": true
-      },
-      {
-        "name": "tasks_team_status_idx index survived the restore",
-        "passed": true
-      },
-      {
-        "name": "sequences synced (next insert won't conflict with existing IDs)",
-        "passed": true
+        "name": "scorer completed without errors",
+        "passed": false,
+        "notes": "query failed: psql: error: connection to server at \"127.0.0.1\", port 54322 failed: FATAL:  password authentication failed for user \"postgres\"\n"
       }
     ],
     "skills": {
@@ -2061,7 +2192,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -2077,11 +2208,11 @@
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": false
+        "passed": true
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": false
+        "passed": true
       }
     ],
     "skills": {
@@ -2134,7 +2265,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f159f-9368-735a-abb1-273d93b0f6f9/receipt-alpha.pdf, 019f159f-9368-735a-abb1-273d93b0f6f9/receipt-beta.pdf"
+        "notes": "saw: 019f1f4a-65d0-7078-aa3d-0c42be9e49e0/receipt-alpha.pdf, 019f1f4a-65d0-7078-aa3d-0c42be9e49e0/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -2155,7 +2286,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets rubric: private user-files bucket, authenticated owner-scoped SELECT and INSERT WITH CHECK policies on storage.objects, no RLS disabling or public access, and createSignedUrl with a 15-minute expiry."
+        "judgeNotes": "The answer creates a private user-files bucket with public=false, keeps/enables RLS on storage.objects, adds authenticated SELECT and INSERT policies scoped to the bucket and first path segment matching auth.uid() via WITH CHECK for insert, and provides supabase-js createSignedUrl code with a 15-minute expiry. No public bucket, permissive public/anon policies, getPublicUrl, or client-side service role key usage."
       }
     ],
     "skills": {
@@ -2207,7 +2338,7 @@
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw, explains that its policy failed to check the row's `org_id` and could leak other tenants' posts, and does not blame `notes` or dismiss the pgTAP verification."
+        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw: authenticated members can read posts outside their org because the SELECT policy ignores `org_id`. It grounds the conclusion in pgTAP/test work and does not blame `notes` or dismiss the test results. Extra mention of `memberships` does not undermine the required finding."
       }
     ],
     "skills": {
@@ -2216,8 +2347,7 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
       ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -2247,37 +2377,9 @@
     "passed": false,
     "checks": [
       {
-        "name": "document_sections.embedding is vector(384)",
-        "passed": true,
-        "notes": "vector(384)"
-      },
-      {
-        "name": "HNSW index on the embedding column",
-        "passed": true,
-        "notes": "CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
-      },
-      {
-        "name": "index operator class matches the search operator",
+        "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "match_document_sections not found"
-      },
-      {
-        "name": "user A search returns only own sections, best match first",
-        "passed": false,
-        "notes": "Could not find the function public.match_document_sections(match_count, query_embedding) in the schema cache"
-      },
-      {
-        "name": "user B search returns only own sections, best match first",
-        "passed": false,
-        "notes": "Could not find the function public.match_document_sections(match_count, query_embedding) in the schema cache"
-      },
-      {
-        "name": "user A reads only own sections through the API",
-        "passed": false
-      },
-      {
-        "name": "user A reads only own documents through the API",
-        "passed": false
+        "notes": "relation \"document_sections\" does not exist"
       }
     ],
     "skills": {
@@ -2311,7 +2413,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -2319,13 +2421,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Fails because the Supabase scrape uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount/provide that password_file via a volume or Compose secret. The app job is preserved and endpoint/scheme/target are otherwise appropriate."
+        "passed": true,
+        "judgeNotes": "Meets all required criteria: HTTPS Supabase metrics endpoint, correct path, Basic Auth with password_file, app scrape preserved, and docker-compose mounts the secrets directory containing the password file."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README mentions creating a Supabase Secret API key and setting environment variables, but it does not require placing a matching secret file, restarting/reloading the Compose stack, or provide concrete verification steps via Prometheus targets, PromQL, Grafana, or equivalent."
+        "passed": true,
+        "judgeNotes": "README includes Supabase Secret API key placement, matching Prometheus password_file path, Compose start instructions, and concrete verification via Prometheus /targets."
       }
     ],
     "skills": {
@@ -2341,60 +2443,6 @@
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
     "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini/deploy-database-001-prometheus-metrics.json"
-  },
-  {
-    "experiment": "codex-gpt-5.4-mini",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.4-mini",
-      "reasoningEffort": "medium"
-    },
-    "eval": "deploy-functions-001-edge-function-secrets",
-    "stage": "deploy",
-    "product": [
-      "edge-functions"
-    ],
-    "topic": [
-      "security"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "WEATHER_API_KEY is set as a Function secret on the project",
-        "passed": true
-      },
-      {
-        "name": "the weather function is deployed to the project",
-        "passed": true,
-        "notes": "status ACTIVE"
-      },
-      {
-        "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
-      },
-      {
-        "name": "WEATHER_API_KEY value is not committed to the repo",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
-    "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
-    "attempts": 1,
-    "sourcePath": "codex-gpt-5.4-mini/deploy-functions-001-edge-function-secrets.json"
   },
   {
     "experiment": "codex-gpt-5.4-mini",
@@ -2488,7 +2536,8 @@
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
@@ -2497,7 +2546,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "Covers the soft-delete bug, deletes auth.users, notes JWTs remain valid until exp, and explains publishable vs secret keys correctly. However it does not clarify that server-side checks should use auth.getUser() or short JWT expiry rather than only local JWT validation/getClaims(), which is required by the rubric."
+        "judgeNotes": "The answer correctly diagnoses the soft-delete/RLS issue and clarifies publishable vs secret keys. It discusses JWT access windows, but incorrectly says there is “no meaningful post-commit window” and implies RLS/session checks eliminate stale JWT access, rather than clearly explaining that stateless access tokens remain valid until expiry and server-side validation should use auth.getUser() (or short JWT expiry) instead of only local validation/getClaims. It also fixes by marking auth.users deleted/banned and deleting sessions rather than actually deleting the auth user or using Auth Admin delete; this is arguably equivalent session/identity revocation, but the JWT-window explanation is not rubric-compliant."
       }
     ],
     "skills": {
@@ -2558,7 +2607,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that orders INSERT events were silent because public.orders was missing from the supabase_realtime publication despite the channel subscribing. It fixed exactly that with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, preserved courier_locations in the publication, and did not disable RLS or weaken policies."
+        "judgeNotes": "Identified orders missing from supabase_realtime publication, added only public.orders via ALTER PUBLICATION, verified courier_locations remained, and did not change RLS or policies."
       }
     ],
     "skills": {
@@ -2567,8 +2616,7 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
       ]
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -2598,17 +2646,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant identified `image-transform` as the affected function and explicitly described the recurring HTTP 503 pattern across the morning of 2026-04-28, listing all 8 gateway failures from 07:00Z through 12:00Z."
+        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, including all 8 gateway failure timestamps from 07:00Z through 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The response mentions `image-transform` 503s at the gateway, but ultimately attributes the likely failure to the packages/function runtime path and recommends inspecting/redeploying the functions. It does not clearly ground the recurring 503s as originating in the gateway/platform layer in front of the function."
+        "judgeNotes": "The response notes gateway-level 503s and lack of function errors, but it does not clearly attribute them to the gateway/platform layer. It repeatedly frames the function path/runtime/dependencies as suspect and recommends inspecting and redeploying the function, which the rubric says should fail."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including inspecting the underlying function packages, adding explicit error logging, redeploying/retrying the functions, and checking the storage path if failures persist."
+        "judgeNotes": "Recommended concrete next steps including inspecting function dependencies, redeploying, adding retry/backoff, and escalating with exact timestamps and deployment id."
       }
     ],
     "skills": {
@@ -2674,7 +2722,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated SELECT and INSERT owner-scoped policies using auth.uid() = user_id / WITH CHECK. No permissive or anon policies were used."
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated owner-scoped SELECT and INSERT policies using auth.uid()/user_id, with additional owner-scoped update/delete policies."
       }
     ],
     "skills": {
@@ -2739,8 +2787,7 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
       ]
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
@@ -2880,7 +2927,8 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
       ]
     },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
@@ -2972,12 +3020,12 @@
       {
         "name": "cron command enqueues to the 'tasks' queue",
         "passed": true,
-        "notes": "queue depth 0 -> 1"
+        "notes": "queue depth 1 -> 2"
       },
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 4) from the queue"
+        "notes": "function removed the seeded message (id 5) from the queue"
       }
     ],
     "skills": {
@@ -3126,45 +3174,12 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
-        "name": "bucket user-files exists",
-        "passed": true
-      },
-      {
-        "name": "bucket user-files is private",
-        "passed": true
-      },
-      {
-        "name": "RLS still enabled on storage.objects",
-        "passed": true
-      },
-      {
-        "name": "user A lists only own files",
-        "passed": true,
-        "notes": "saw: 019f159f-b71a-75ab-add1-1cf4ed5ab113/receipt-alpha.pdf, 019f159f-b71a-75ab-add1-1cf4ed5ab113/receipt-beta.pdf"
-      },
-      {
-        "name": "user B cannot read user A files",
-        "passed": true
-      },
-      {
-        "name": "anon reads no files",
-        "passed": true
-      },
-      {
-        "name": "user A can upload into own folder",
-        "passed": true
-      },
-      {
-        "name": "user B cannot upload into user A folder",
-        "passed": true
-      },
-      {
-        "name": "configured private per-user storage access",
-        "passed": true,
-        "judgeNotes": "Creates a private user-files bucket, keeps RLS implied/enabled, defines authenticated owner-prefix SELECT and INSERT policies with WITH CHECK, avoids public/anon/service-role misuse, and provides supabase-js createSignedUrl with expiry for sharing."
+        "name": "scorer evaluated private storage access",
+        "passed": false,
+        "notes": "current transaction is aborted, commands ignored until end of transaction block"
       }
     ],
     "skills": {
@@ -3205,17 +3220,17 @@
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/database/tenant_isolation.test.sql"
+        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "9 passed, 0 failed"
+        "notes": "13 passed, 0 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identified `posts` as the broken tenant isolation policy, specifically that membership in any org allowed reading posts from other orgs. It grounded this in pgTAP/test workflow and reported passing tests after fixing `posts`, without blaming `notes` or dismissing test results."
+        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw: its RLS allowed membership in any org rather than the post’s org. It does not blame `notes` and treats pgTAP testing as meaningful, reporting test outcomes after adding coverage."
       }
     ],
     "skills": {
@@ -3224,8 +3239,7 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
       ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -3257,7 +3271,7 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "relation \"document_sections\" does not exist"
+        "notes": "operator does not exist: uuid = integer"
       }
     ],
     "skills": {
@@ -3266,8 +3280,7 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
       ]
     },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -3301,12 +3314,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Prometheus config has the correct HTTPS Supabase metrics scrape with basic_auth password_file and preserves the app job, but docker-compose.yml does not mount the password_file via a volume or Compose secret; it writes it from an environment variable at runtime."
+        "judgeNotes": "Prometheus uses file_sd_configs but no Supabase target file/content is provided, so the required <project-ref>.supabase.co/.red scrape target is missing/not verifiable. Other required pieces (HTTPS, metrics path, basic_auth password_file, app job preserved, secret directory mounted) are present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README covers creating/using a Supabase Secret API key, restarting/reloading, and verifying via Prometheus targets/direct curl. However, it does not include a required step to place/create the matching secret file for Prometheus basic_auth password_file; it only documents an environment variable."
+        "judgeNotes": "README includes the correct endpoint/auth setup, matching secret file path, reload/restart commands, and Prometheus targets verification. However, it does not provide steps to create/generate the Supabase Secret API key itself; it only says to create the local secret file containing one."
       }
     ],
     "skills": {
@@ -3447,11 +3460,12 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "victim session active before delete-account",
-        "passed": true
+        "passed": false,
+        "notes": "new row violates row-level security policy for table \"notes\""
       },
       {
         "name": "delete_account flow ran for the victim",
@@ -3468,16 +3482,18 @@
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
-        "passed": true
+        "passed": false,
+        "notes": "new row violates row-level security policy for table \"notes\""
       },
       {
         "name": "diagnosed and explained session revocation",
         "passed": true,
-        "judgeNotes": "The answer identifies the original soft-delete-only delete_account flow, implements deletion of auth.sessions and auth.users (with cascading/profile/note cleanup), explains stale JWT/access-token caveats and need for server-side/active-user checks beyond auth.uid/local JWT validation, and correctly distinguishes frontend publishable keys from server-only secret keys that bypass RLS."
+        "judgeNotes": "The answer identifies the soft-delete-only root cause, implements real session/refresh-token revocation and RLS checks, explains the remaining stateless JWT expiry/in-flight window, and correctly distinguishes publishable vs secret keys including RLS bypass for secret keys. Minor note: it revokes sessions rather than deleting auth.users, but the rubric allows equivalent identity/session removal."
       }
     ],
     "skills": {
@@ -3539,7 +3555,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified the root cause as orders missing from the supabase_realtime publication despite successful subscription, added only public.orders to the existing publication, and preserved courier_locations, RLS, and policies."
+        "judgeNotes": "Identified the root cause as orders missing from supabase_realtime despite SUBSCRIBED status, added only public.orders to the existing publication, preserved courier_locations, RLS, and policies. Did not blame or weaken RLS/client/networking."
       }
     ],
     "skills": {
@@ -3578,17 +3594,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified image-transform as the affected function and listed the recurring HTTP 503 gateway failures throughout the morning of 2026-04-28, covering all 8 timestamps from 07:00Z to 12:00Z."
+        "judgeNotes": "Identified image-transform as the affected function and described the recurring HTTP 503 pattern across 2026-04-28 morning, covering all 8 gateway failures from 07:00Z to 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "The assistant attributes the recurring 503s to the Edge Functions/API gateway/platform layer rather than the function code, and grounds this in valid observations: repeated gateway 503s for image-transform with only successful Edge Function execution logs nearby, implying failures occurred before normal function execution logging. It also distinguishes avatar-upload's 500 from the gateway-level image-transform 503s and recommends escalation/retries rather than redeploying or fixing function code."
+        "judgeNotes": "Attributes the recurring image-transform 503s to the gateway/runtime invocation layer before function code, not application logic. Grounds this in observations: gateway/API logs show repeated 503s while Edge Function logs only show successful 200 executions nearby, Postgres logs empty/other functions healthy, and distinguishes the separate avatar-upload 500 as an in-function error."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including treating it as an Edge Function/gateway incident, adding retries and structured logging, and escalating to Supabase support with failing timestamps and function path."
+        "judgeNotes": "Recommended concrete next steps including opening a Supabase support ticket with gateway log IDs and investigating runtime/gateway-level failures."
       }
     ],
     "skills": {
@@ -3654,7 +3670,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated-only SELECT and INSERT owner-scoped policies using user_id = auth.uid() / WITH CHECK."
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated SELECT and INSERT owner-scoped policies using auth.uid() with WITH CHECK for insert."
       }
     ],
     "skills": {

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -19,40 +19,50 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "supabase project initialised (supabase/config.toml exists)",
-        "passed": true
+        "passed": false
       },
       {
         "name": "todos table is created by a migration file",
-        "passed": true
+        "passed": false,
+        "notes": "supabase/migrations does not exist — was a Supabase project initialised?"
       },
       {
         "name": "todos table exists with at least 2 seeded rows",
-        "passed": true,
-        "notes": "found 2 rows"
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "row level security is enabled on todos",
-        "passed": true
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "a SELECT policy targets the authenticated role",
-        "passed": true
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "REST API returns no todos to anonymous requests",
-        "passed": true,
-        "notes": "0 rows"
+        "passed": false,
+        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
-        "passed": true,
-        "notes": "2 rows"
+        "passed": false,
+        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-125fdd5f\nTry rerunning the command with --debug to troubleshoot the error.\n"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -77,25 +87,34 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "supabase db diff used to generate the migration",
-        "passed": true
+        "passed": false
       },
       {
         "name": "schema file updated to include description column",
-        "passed": true
+        "passed": false,
+        "notes": "description not found in any schema file"
       },
       {
         "name": "a new migration was generated for the change",
-        "passed": true
+        "passed": false,
+        "notes": "found 1 migration file(s)"
       },
       {
         "name": "description column exists in the live database",
-        "passed": true
+        "passed": false
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -123,24 +142,31 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "pg_cron job 'enqueue-tasks' scheduled to run every minute",
-        "passed": true,
-        "notes": "schedule='* * * * *', active=true"
+        "passed": false,
+        "notes": "job not found in cron.job"
       },
       {
         "name": "cron command enqueues to the 'tasks' queue",
-        "passed": true,
-        "notes": "queue depth 1 -> 2"
+        "passed": false,
+        "notes": "job not found, so its command can't run"
       },
       {
         "name": "process-tasks function drains the queue",
-        "passed": true,
-        "notes": "function removed the seeded message (id 5) from the queue"
+        "passed": false,
+        "notes": "couldn't enqueue a test message. Is the 'tasks' queue created? query failed: ERROR:  relation \"pgmq.q_tasks\" does not exist\nLINE 2:         INSERT INTO pgmq.q_tasks (vt, message, headers)\n                            ^\nQUERY:  \n        INSERT INTO pgmq.q_tasks (vt, message, headers)\n        VALUES ($2, $1, $3)\n        RETURNING msg_id;\n        \nCONTEXT:  PL/pgSQL function pgmq.send(text,jsonb,jsonb,timestamp with time zone) line 14 at RETURN QUERY\nSQL function \"send\" statement 1\n"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
     "attempts": 1,
@@ -164,29 +190,21 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
-        "name": "all 3 tables exist (teams, members, tasks)",
-        "passed": true
-      },
-      {
-        "name": "row counts match (teams=5, members=10, tasks=13)",
-        "passed": true
-      },
-      {
-        "name": "foreign key constraints survived the restore",
-        "passed": true
-      },
-      {
-        "name": "tasks_team_status_idx index survived the restore",
-        "passed": true
-      },
-      {
-        "name": "sequences synced (next insert won't conflict with existing IDs)",
-        "passed": true
+        "name": "scorer completed without errors",
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-ab1f7659\nTry rerunning the command with --debug to troubleshoot the error.\n"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
     "attempts": 1,
@@ -213,7 +231,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -225,17 +243,24 @@
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": false
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -260,47 +285,21 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "bucket user-files exists",
-        "passed": true
-      },
-      {
-        "name": "bucket user-files is private",
-        "passed": true
-      },
-      {
-        "name": "RLS still enabled on storage.objects",
-        "passed": true
-      },
-      {
-        "name": "user A lists only own files",
-        "passed": true,
-        "notes": "saw: 019f0440-4700-7139-92d1-c9806bfa30e4/receipt-alpha.pdf, 019f0440-4700-7139-92d1-c9806bfa30e4/receipt-beta.pdf"
-      },
-      {
-        "name": "user B cannot read user A files",
-        "passed": true
-      },
-      {
-        "name": "anon reads no files",
-        "passed": true
-      },
-      {
-        "name": "user A can upload into own folder",
-        "passed": true
-      },
-      {
-        "name": "user B cannot upload into user A folder",
-        "passed": true
-      },
-      {
-        "name": "configured private per-user storage access",
-        "passed": true,
-        "judgeNotes": "Meets requirements: private user-files bucket, owner-scoped authenticated SELECT/INSERT policies on storage.objects with RLS kept enabled, and supabase-js createSignedUrl with expiry for temporary sharing."
+        "passed": false,
+        "notes": "no row in storage.buckets with id or name 'user-files'"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
@@ -325,24 +324,31 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
-        "passed": true,
-        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
+        "passed": false,
+        "notes": "no .sql files found under supabase/tests/"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
-        "passed": true,
-        "notes": "5 passed, 3 failed"
+        "passed": false,
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\ndcccee43ad5d: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Pull complete\n06d62d0de6d7: Pull complete\na2"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
-        "passed": true,
-        "judgeNotes": "The agent correctly identifies posts (not notes) as the broken tenant isolation policy, explains that authenticated members can read posts from organizations they are not members of, and grounds the conclusion in the pgTAP failures."
+        "passed": false,
+        "judgeNotes": "The response does not analyze the pgTAP results or identify the broken tenant isolation policy. It fails to conclude that the posts table is the one with the policy flaw."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
     "attempts": 1,
@@ -372,9 +378,16 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "column \"owner_id\" of relation \"documents\" does not exist"
+        "notes": "relation \"documents\" does not exist"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -397,7 +410,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -405,15 +418,22 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets requirements: app scrape preserved; Supabase scrape uses HTTPS, correct metrics_path, Basic Auth with password_file, project target under supabase.co, and docker-compose mounts the password file location via a read-only secrets volume."
+        "passed": false,
+        "judgeNotes": "prometheus.yml only preserves the app scrape; it does not add a Supabase Metrics API scrape target, HTTPS /customer/v1/privileged/metrics path, or HTTP Basic Auth with password_file. docker-compose.yml also does not mount or wire any password_file/secret."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": true,
-        "judgeNotes": "README includes correct endpoint/auth with Secret API key in a password_file, instructions to create/place the secret file, replace project ref, restart/reload the Compose stack, and verify via curl plus Prometheus Targets/querying series."
+        "passed": false,
+        "judgeNotes": "README lacks required steps to create a Secret API key, place the matching secret file, and restart/reload the Compose stack. It also lacks concrete verification via Prometheus targets, PromQL/Grafana, or equivalent."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
     "attempts": 1,
@@ -437,27 +457,35 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "WEATHER_API_KEY is set as a Function secret on the project",
-        "passed": true
+        "passed": false,
+        "notes": "secrets present: []"
       },
       {
         "name": "the weather function is deployed to the project",
-        "passed": true,
-        "notes": "status ACTIVE"
+        "passed": false,
+        "notes": "function not found on the project (status 404)"
       },
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "passed": false,
+        "notes": "could not read supabase/functions/weather/*"
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -483,11 +511,12 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": true
+        "passed": false,
+        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -495,13 +524,22 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": true
+        "passed": false,
+        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": true
+        "passed": false,
+        "notes": "JWT_SECRET missing"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -537,12 +575,13 @@
       },
       {
         "name": "delete-account revokes the user's sessions",
-        "passed": true,
-        "notes": "sessions left: 0"
+        "passed": false,
+        "notes": "sessions left: 1"
       },
       {
         "name": "deleted user's refresh token is rejected",
-        "passed": true
+        "passed": false,
+        "notes": "refresh token still produces a session"
       },
       {
         "name": "deleted user cannot sign back in",
@@ -555,10 +594,17 @@
       },
       {
         "name": "diagnosed and explained session revocation",
-        "passed": true,
-        "judgeNotes": "Meets the rubric: identifies soft-delete-only root cause, implements auth-layer revocation/session and refresh token removal, explains JWT expiry window and mitigations via live server/RLS checks, and correctly distinguishes publishable frontend key from secret server-only RLS-bypassing key."
+        "passed": false,
+        "judgeNotes": "The answer does not address the account deletion/auth revocation issue, access-token validity window, or publishable vs secret key clarification. It only reports an API usage limit error."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
     "attempts": 1,
@@ -582,11 +628,11 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "orders table added to supabase_realtime publication",
-        "passed": true
+        "passed": false
       },
       {
         "name": "courier_locations still in supabase_realtime publication",
@@ -607,10 +653,17 @@
       },
       {
         "name": "diagnosed missing publication membership",
-        "passed": true,
-        "judgeNotes": "Identifies orders missing from supabase_realtime despite SUBSCRIBED, applies ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, preserves courier_locations/RLS/policies, and does not blame client/RLS/networking."
+        "passed": false,
+        "judgeNotes": "The response does not diagnose the missing orders table in the supabase_realtime publication or provide the required ALTER PUBLICATION fix."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
     "attempts": 1,
@@ -633,24 +686,31 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
-        "passed": true,
-        "judgeNotes": "The assistant identified `image-transform` as the affected function and clearly described the recurring HTTP 503 pattern throughout the morning of 2026-04-28, listing all 8 failures from 07:00Z to 12:00Z. It also distinguished this from the unrelated older billing-webhook 503s."
+        "passed": false,
+        "judgeNotes": "The assistant did not identify image-transform or the recurring HTTP 503 pattern on 2026-04-28; it only reported an API usage limit error."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": true,
-        "judgeNotes": "Attributes image-transform 503s to the API gateway/edge platform layer, grounded in the observation that 503s appear only in gateway logs with no corresponding function execution logs while execution logs show 200s. It distinguishes this from the avatar-upload function-level 500."
+        "passed": false,
+        "judgeNotes": "The response does not attribute the 503s to the gateway/platform layer or ground the attribution in any observations. It only reports an unrelated API usage limit error."
       },
       {
         "name": "recommended a concrete next step",
-        "passed": true,
-        "judgeNotes": "The assistant recommended multiple concrete next steps, including confirming the user-flow mapping, investigating image-transform resource usage/memory limits, adding logging, considering Supabase built-in image transformation, and tracking the specific avatar-upload 500 separately."
+        "passed": false,
+        "judgeNotes": "The assistant only reported the API limit error and did not recommend any concrete next step such as escalation, incident creation with request IDs/time window, checking platform health, or reviewing configuration/logs."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
     "attempts": 1,
@@ -676,7 +736,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "RLS still enabled on bookmarks",
@@ -684,7 +744,7 @@
       },
       {
         "name": "user A reads own bookmarks",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user B cannot read user A bookmarks",
@@ -696,7 +756,8 @@
       },
       {
         "name": "user A can save a new bookmark",
-        "passed": true
+        "passed": false,
+        "notes": "new row violates row-level security policy for table \"bookmarks\""
       },
       {
         "name": "user B cannot insert a bookmark as user A",
@@ -704,10 +765,17 @@
       },
       {
         "name": "diagnosed RLS and added owner-scoped policies",
-        "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies as deny-all causing empty Data API results, kept RLS enabled, and created authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() using USING and WITH CHECK."
+        "passed": false,
+        "judgeNotes": "The answer does not diagnose the empty Data API results as an RLS deny-all issue and does not create authenticated owner-scoped SELECT and INSERT policies while keeping RLS enabled."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
     "attempts": 1,
@@ -731,30 +799,37 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": true
+        "passed": false
       },
       {
         "name": "created index covering user_id and created_at",
-        "passed": true
+        "passed": false
       },
       {
         "name": "query plan uses an index and avoids sequential scan",
-        "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "passed": false,
+        "notes": "Limit  (cost=118.52..118.57 rows=20 width=88)\n  ->  Sort  (cost=118.52..118.57 rows=20 width=88)\n        Sort Key: created_at DESC\n        ->  Seq Scan on events  (cost=0.00..118.09 rows=20 width=88)\n              Filter: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
     "attempts": 1,
@@ -779,7 +854,7 @@
       "security"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "RLS enabled on notes",
@@ -787,11 +862,11 @@
       },
       {
         "name": "tenant A sees only org A notes",
-        "passed": true
+        "passed": false
       },
       {
         "name": "tenant B cannot read org A notes",
-        "passed": true
+        "passed": false
       },
       {
         "name": "tenant A author can update own note",
@@ -818,6 +893,13 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -843,40 +925,50 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "supabase project initialised (supabase/config.toml exists)",
-        "passed": true
+        "passed": false
       },
       {
         "name": "todos table is created by a migration file",
-        "passed": true
+        "passed": false,
+        "notes": "supabase/migrations does not exist — was a Supabase project initialised?"
       },
       {
         "name": "todos table exists with at least 2 seeded rows",
-        "passed": true,
-        "notes": "found 2 rows"
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "row level security is enabled on todos",
-        "passed": true
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "a SELECT policy targets the authenticated role",
-        "passed": true
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "REST API returns no todos to anonymous requests",
-        "passed": true,
-        "notes": "error 42501: permission denied for table todos"
+        "passed": false,
+        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
-        "passed": true,
-        "notes": "2 rows"
+        "passed": false,
+        "notes": "could not read API_URL/PUBLISHABLE_KEY from `supabase status -o json` after 5 attempts — the local stack must be running and include the auth service (status only reports API keys while gotrue is up; add `gotrue` to the eval's services). Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-58f131d7\nTry rerunning the command with --debug to troubleshoot the error.\n"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -909,17 +1001,26 @@
       },
       {
         "name": "schema file updated to include description column",
-        "passed": true
+        "passed": false,
+        "notes": "description not found in any schema file"
       },
       {
         "name": "a new migration was generated for the change",
-        "passed": true
+        "passed": false,
+        "notes": "found 1 migration file(s)"
       },
       {
         "name": "description column exists in the live database",
-        "passed": true
+        "passed": false
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -947,24 +1048,31 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "pg_cron job 'enqueue-tasks' scheduled to run every minute",
-        "passed": true,
-        "notes": "schedule='* * * * *', active=true"
+        "passed": false,
+        "notes": "job not found in cron.job"
       },
       {
         "name": "cron command enqueues to the 'tasks' queue",
-        "passed": true,
-        "notes": "queue depth 0 -> 1"
+        "passed": false,
+        "notes": "job not found, so its command can't run"
       },
       {
         "name": "process-tasks function drains the queue",
-        "passed": true,
-        "notes": "function removed the seeded message (id 39) from the queue"
+        "passed": false,
+        "notes": "couldn't enqueue a test message. Is the 'tasks' queue created? query failed: ERROR:  relation \"pgmq.q_tasks\" does not exist\nLINE 2:         INSERT INTO pgmq.q_tasks (vt, message, headers)\n                            ^\nQUERY:  \n        INSERT INTO pgmq.q_tasks (vt, message, headers)\n        VALUES ($2, $1, $3)\n        RETURNING msg_id;\n        \nCONTEXT:  PL/pgSQL function pgmq.send(text,jsonb,jsonb,timestamp with time zone) line 14 at RETURN QUERY\nSQL function \"send\" statement 1\n"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
     "attempts": 1,
@@ -988,29 +1096,21 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
-        "name": "all 3 tables exist (teams, members, tasks)",
-        "passed": true
-      },
-      {
-        "name": "row counts match (teams=5, members=10, tasks=13)",
-        "passed": true
-      },
-      {
-        "name": "foreign key constraints survived the restore",
-        "passed": true
-      },
-      {
-        "name": "tasks_team_status_idx index survived the restore",
-        "passed": true
-      },
-      {
-        "name": "sequences synced (next insert won't conflict with existing IDs)",
-        "passed": true
+        "name": "scorer completed without errors",
+        "passed": false,
+        "notes": "could not read DB_URL from `supabase status -o json` after 5 attempts — the local stack must be running. Last status: failed to inspect container health: Error response from daemon: No such container: supabase_db_sandbox-c396dbf2\nTry rerunning the command with --debug to troubleshoot the error.\n"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
     "attempts": 1,
@@ -1037,7 +1137,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -1049,17 +1149,24 @@
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": false
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -1084,47 +1191,21 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "bucket user-files exists",
-        "passed": true
-      },
-      {
-        "name": "bucket user-files is private",
-        "passed": true
-      },
-      {
-        "name": "RLS still enabled on storage.objects",
-        "passed": true
-      },
-      {
-        "name": "user A lists only own files",
-        "passed": true,
-        "notes": "saw: 019f043f-f9b4-70a8-a54c-d8c4c9da1fc1/receipt-alpha.pdf, 019f043f-f9b4-70a8-a54c-d8c4c9da1fc1/receipt-beta.pdf"
-      },
-      {
-        "name": "user B cannot read user A files",
-        "passed": true
-      },
-      {
-        "name": "anon reads no files",
-        "passed": true
-      },
-      {
-        "name": "user A can upload into own folder",
-        "passed": true
-      },
-      {
-        "name": "user B cannot upload into user A folder",
-        "passed": true
-      },
-      {
-        "name": "configured private per-user storage access",
-        "passed": true,
-        "judgeNotes": "Configured a private user-files bucket, owner-scoped authenticated SELECT and INSERT storage.objects policies with WITH CHECK for uploads, did not disable RLS, and provided supabase-js createSignedUrl code with expiry for temporary sharing."
+        "passed": false,
+        "notes": "no row in storage.buckets with id or name 'user-files'"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
@@ -1159,14 +1240,21 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": false,
-        "notes": "no test summary found; exit 0; output: Connecting to local database...\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad5d: Verifying Checksum\ndcccee43ad5d: Download complete\n06d62d0de6d7: Verifying Checksum\n06d62d0de6d7: Download complete\ndcccee43ad5d: Pull comple"
+        "notes": "no test summary found; exit 0; output: Connecting to local database...\nfailed to pull docker image: Error response from daemon: toomanyrequests: Rate exceeded\nRetrying after 4s: public.ecr.aws/supabase/pg_prove:3.36\n3.36: Pulling from supabase/pg_prove\ndcccee43ad5d: Pulling fs layer\n06d62d0de6d7: Pulling fs layer\na22cb17b3b93: Pulling fs layer\n4f4fb700ef54: Pulling fs layer\n4f4fb700ef54: Waiting\na22cb17b3b93: Verifying Checksum\na22cb17b3b93: Download complete\n4f4fb700ef54: Verifying Checksum\n4f4fb700ef54: Download complete\ndcccee43ad"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
-        "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as having a broken tenant isolation policy, explains that authenticated members of any org can read posts from other orgs due to the missing `m.org_id = posts.org_id` condition, and grounds this in failing tests T04/T09. It also correctly states that `notes` is isolated."
+        "passed": false,
+        "judgeNotes": "The response does not analyze the pgTAP results or identify the posts table policy flaw; it only reports an API usage error."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
     "attempts": 1,
@@ -1196,9 +1284,16 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "operator does not exist: uuid = integer"
+        "notes": "relation \"documents\" does not exist"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -1229,15 +1324,22 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets requirements: Supabase scrape uses HTTPS, correct metrics path, Basic Auth with password_file, target is <project-ref>.supabase.co:443, app job is preserved, and docker-compose mounts the password file at the matching path."
+        "passed": false,
+        "judgeNotes": "prometheus.yml only preserves the existing app scrape and does not add a Supabase Metrics API scrape target, HTTPS scheme, /customer/v1/privileged/metrics path, or HTTP Basic Auth with password_file. docker-compose.yml also does not mount or wire a password file/secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README.md does not explain how to make the Supabase integration live: it lacks steps to create/use a Secret API key, place it at observability/secrets/supabase_key, restart/reload the Compose stack, and verify the scrape via Prometheus targets, PromQL, Grafana, or equivalent."
+        "judgeNotes": "README lacks required instructions to create a Secret API key, place the matching secret file, restart/reload the Compose stack, and concretely verify the integration via Prometheus targets/PromQL/Grafana or equivalent."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
     "attempts": 1,
@@ -1261,27 +1363,35 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "WEATHER_API_KEY is set as a Function secret on the project",
-        "passed": true
+        "passed": false,
+        "notes": "secrets present: []"
       },
       {
         "name": "the weather function is deployed to the project",
-        "passed": true,
-        "notes": "status ACTIVE"
+        "passed": false,
+        "notes": "function not found on the project (status 404)"
       },
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
-        "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "passed": false,
+        "notes": "could not read supabase/functions/weather/*"
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -1307,11 +1417,12 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": true
+        "passed": false,
+        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -1319,13 +1430,22 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": true
+        "passed": false,
+        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": true
+        "passed": false,
+        "notes": "JWT_SECRET missing"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -1361,16 +1481,18 @@
       },
       {
         "name": "delete-account revokes the user's sessions",
-        "passed": true,
-        "notes": "sessions left: 0"
+        "passed": false,
+        "notes": "sessions left: 1"
       },
       {
         "name": "deleted user's refresh token is rejected",
-        "passed": true
+        "passed": false,
+        "notes": "refresh token still produces a session"
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
@@ -1379,9 +1501,16 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "Fails because it incorrectly claims revoked/deleted sessions make existing JWTs rejected on the very next request with practically no access-token window. The rubric requires explaining that access tokens are stateless JWTs that can remain valid until expiry unless server-side validation such as auth.getUser() is used, and that local JWT validation/getClaims() will not see revocation immediately. Other parts identify the soft-delete issue, hard-delete/revoke sessions, and clarify publishable vs secret keys correctly."
+        "judgeNotes": "The response is just an API usage error and does not address the delete-account/auth revocation issue, access-token window, or publishable vs secret key clarification."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
     "attempts": 1,
@@ -1405,11 +1534,11 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "orders table added to supabase_realtime publication",
-        "passed": true
+        "passed": false
       },
       {
         "name": "courier_locations still in supabase_realtime publication",
@@ -1430,10 +1559,17 @@
       },
       {
         "name": "diagnosed missing publication membership",
-        "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel can reach SUBSCRIBED while INSERT events for orders are silent because public.orders was missing from the supabase_realtime publication, applied ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verified the publication contents, and did not weaken RLS/policies or disturb courier_locations."
+        "passed": false,
+        "judgeNotes": "The answer does not diagnose the missing orders table in the supabase_realtime publication or provide the required ALTER PUBLICATION fix."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
     "attempts": 1,
@@ -1460,20 +1596,27 @@
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
-        "passed": true,
-        "judgeNotes": "The assistant correctly identified `image-transform` as the primary affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, listing all 8 gateway failures from 07:00Z through 12:00Z. It also distinguished the older billing-webhook 503s as separate."
+        "passed": false,
+        "judgeNotes": "The assistant did not identify image-transform or the recurring HTTP 503 pattern on 2026-04-28; it only reported an API usage limit error."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": false,
-        "judgeNotes": "The response attributes image-transform 503s to cold start timeouts involving the Edge Function runtime and recommends reviewing/fixing initialization code/keep-alives. While it notes gateway IDs vs function executions, it does not clearly attribute the origin to the gateway/platform layer in front of the function rather than the function/runtime; it frames the primary cause as cold starts and partly function initialization."
+        "judgeNotes": "The assistant did not address the cause of the 503s or attribute them to the gateway/platform layer with supporting observations; it only reported an API usage limit error."
       },
       {
         "name": "recommended a concrete next step",
-        "passed": true,
-        "judgeNotes": "Recommended concrete actionable next steps including keep-alive pings, retry/backoff, reviewing function initialization code, adding structured logging, and verifying webhook provider retry logs."
+        "passed": false,
+        "judgeNotes": "The assistant only reported the API usage limit error and did not recommend any concrete next step such as escalation, incident creation with request IDs/time window, platform health checks, deployment/routing review, or infrastructure log investigation."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
     "attempts": 1,
@@ -1499,7 +1642,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "RLS still enabled on bookmarks",
@@ -1507,7 +1650,7 @@
       },
       {
         "name": "user A reads own bookmarks",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user B cannot read user A bookmarks",
@@ -1519,7 +1662,8 @@
       },
       {
         "name": "user A can save a new bookmark",
-        "passed": true
+        "passed": false,
+        "notes": "new row violates row-level security policy for table \"bookmarks\""
       },
       {
         "name": "user B cannot insert a bookmark as user A",
@@ -1527,10 +1671,17 @@
       },
       {
         "name": "diagnosed RLS and added owner-scoped policies",
-        "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and created authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "passed": false,
+        "judgeNotes": "The answer does not diagnose or fix the empty Data API results as an RLS issue, and it does not create authenticated owner-scoped SELECT/INSERT policies while keeping RLS enabled."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
     "attempts": 1,
@@ -1554,30 +1705,37 @@
       "sql"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "inspected pg_stat_statements for query performance",
-        "passed": true
+        "passed": false
       },
       {
         "name": "ran EXPLAIN on the expensive query",
-        "passed": true
+        "passed": false
       },
       {
         "name": "created index covering user_id and created_at",
-        "passed": true
+        "passed": false
       },
       {
         "name": "query plan uses an index and avoids sequential scan",
-        "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "passed": false,
+        "notes": "Limit  (cost=118.52..118.57 rows=20 width=88)\n  ->  Sort  (cost=118.52..118.57 rows=20 width=88)\n        Sort Key: created_at DESC\n        ->  Seq Scan on events  (cost=0.00..118.09 rows=20 width=88)\n              Filter: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
     "attempts": 1,
@@ -1602,7 +1760,7 @@
       "security"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "RLS enabled on notes",
@@ -1610,11 +1768,11 @@
       },
       {
         "name": "tenant A sees only org A notes",
-        "passed": true
+        "passed": false
       },
       {
         "name": "tenant B cannot read org A notes",
-        "passed": true
+        "passed": false
       },
       {
         "name": "tenant A author can update own note",
@@ -1641,6 +1799,13 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -1700,6 +1865,15 @@
         "notes": "2 rows"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -1743,6 +1917,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -1770,7 +1953,7 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "pg_cron job 'enqueue-tasks' scheduled to run every minute",
@@ -1784,10 +1967,19 @@
       },
       {
         "name": "process-tasks function drains the queue",
-        "passed": false,
-        "notes": "HTTP 500: Internal Server Error"
+        "passed": true,
+        "notes": "function removed the seeded message (id 3) from the queue"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
     "attempts": 1,
@@ -1811,14 +2003,38 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
-        "name": "scorer completed without errors",
-        "passed": false,
-        "notes": "query failed: psql: error: connection to server at \"127.0.0.1\", port 54322 failed: FATAL:  password authentication failed for user \"postgres\"\n"
+        "name": "all 3 tables exist (teams, members, tasks)",
+        "passed": true
+      },
+      {
+        "name": "row counts match (teams=5, members=10, tasks=13)",
+        "passed": true
+      },
+      {
+        "name": "foreign key constraints survived the restore",
+        "passed": true
+      },
+      {
+        "name": "tasks_team_status_idx index survived the restore",
+        "passed": true
+      },
+      {
+        "name": "sequences synced (next insert won't conflict with existing IDs)",
+        "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
     "attempts": 1,
@@ -1845,7 +2061,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "rejects missing auth",
@@ -1861,13 +2077,22 @@
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": false
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": false
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -1909,7 +2134,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f043f-7d18-7255-b0a6-5c4334431667/receipt-alpha.pdf, 019f043f-7d18-7255-b0a6-5c4334431667/receipt-beta.pdf"
+        "notes": "saw: 019f159f-9368-735a-abb1-273d93b0f6f9/receipt-alpha.pdf, 019f159f-9368-735a-abb1-273d93b0f6f9/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -1930,9 +2155,19 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets all required criteria: private user-files bucket, RLS remains enabled, authenticated owner-scoped SELECT and INSERT WITH CHECK policies on storage.objects, and supabase-js createSignedUrl with a short expiry. No public bucket, permissive anon/public policies, getPublicUrl, RLS disabling, or client service-role usage."
+        "judgeNotes": "Meets rubric: private user-files bucket, authenticated owner-scoped SELECT and INSERT WITH CHECK policies on storage.objects, no RLS disabling or public access, and createSignedUrl with a 15-minute expiry."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
@@ -1962,7 +2197,7 @@
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/database/tenant_isolation.test.sql"
+        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
@@ -1972,9 +2207,19 @@
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as having a tenant-isolation flaw: its policy checked only that `auth.uid()` had any membership and did not scope access by `org_id`, allowing cross-org post reads. It does not blame `notes` or dismiss pgTAP; it adds tests and reports the pgTAP suite as verification after fixing the policy."
+        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw, explains that its policy failed to check the row's `org_id` and could leak other tenants' posts, and does not blame `notes` or dismiss the pgTAP verification."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
     "attempts": 1,
@@ -2009,12 +2254,12 @@
       {
         "name": "HNSW index on the embedding column",
         "passed": true,
-        "notes": "CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_ip_ops) WHERE (embedding IS NOT NULL)"
+        "notes": "CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
       },
       {
         "name": "index operator class matches the search operator",
-        "passed": true,
-        "notes": "function operators: <#>\nindexes: CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_ip_ops) WHERE (embedding IS NOT NULL)"
+        "passed": false,
+        "notes": "match_document_sections not found"
       },
       {
         "name": "user A search returns only own sections, best match first",
@@ -2035,6 +2280,15 @@
         "passed": false
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -2066,14 +2320,23 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "prometheus.yml does not add a Supabase Metrics API scrape job, and docker-compose.yml does not mount a password_file via volume or Compose secret. The existing app scrape is preserved, but required Supabase scrape/auth wiring is missing."
+        "judgeNotes": "Fails because the Supabase scrape uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount/provide that password_file via a volume or Compose secret. The app job is preserved and endpoint/scheme/target are otherwise appropriate."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes creating a Supabase Secret API key, putting project ref/secret in observability/.env, and starting/restarting the Compose stack. However, verification is too vague: it says to verify Prometheus is scraping but does not give concrete steps such as Prometheus /targets, a PromQL query, Grafana panel check, or equivalent. Also the shown prometheus.yml does not include the Supabase scrape job, creating potential mismatch with the documented setup."
+        "judgeNotes": "README mentions creating a Supabase Secret API key and setting environment variables, but it does not require placing a matching secret file, restarting/reloading the Compose stack, or provide concrete verification steps via Prometheus targets, PromQL, Grafana, or equivalent."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
     "attempts": 1,
@@ -2118,6 +2381,16 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -2162,6 +2435,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -2185,7 +2467,7 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "victim session active before delete-account",
@@ -2214,10 +2496,19 @@
       },
       {
         "name": "diagnosed and explained session revocation",
-        "passed": true,
-        "judgeNotes": "The answer identifies the soft-delete-only bug, patches the flow to delete the auth user with session/refresh-token cascade, explains JWT residual validity and server-side validation caveat, and correctly distinguishes publishable vs secret keys. It also avoids claiming instant invalidation everywhere by limiting immediacy to the RLS/Data API path and noting other backends must not trust JWTs alone."
+        "passed": false,
+        "judgeNotes": "Covers the soft-delete bug, deletes auth.users, notes JWTs remain valid until exp, and explains publishable vs secret keys correctly. However it does not clarify that server-side checks should use auth.getUser() or short JWT expiry rather than only local JWT validation/getClaims(), which is required by the rubric."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
     "attempts": 1,
@@ -2267,9 +2558,19 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel could be subscribed while INSERT events for orders were absent because public.orders was missing from the supabase_realtime publication. It fixed exactly that with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verified courier_locations remained in the publication, and did not disable RLS or alter policies."
+        "judgeNotes": "The assistant correctly identified that orders INSERT events were silent because public.orders was missing from the supabase_realtime publication despite the channel subscribing. It fixed exactly that with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, preserved courier_locations in the publication, and did not disable RLS or weaken policies."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
     "attempts": 1,
@@ -2292,24 +2593,33 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified `image-transform` as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, listing all 8 failures from 07:00Z through 12:00Z. It also distinguished the unrelated `avatar-upload` 500 and did not focus on old billing-webhook errors."
+        "judgeNotes": "The assistant identified `image-transform` as the affected function and explicitly described the recurring HTTP 503 pattern across the morning of 2026-04-28, listing all 8 gateway failures from 07:00Z through 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": true,
-        "judgeNotes": "Attributes the recurring image-transform 503s to the gateway/API/platform layer rather than function code, and grounds this in valid observations: API/gateway logs show 503s while edge-function runtime logs show clean 200s/no matching runtime errors; also distinguishes the separate avatar-upload 500."
+        "passed": false,
+        "judgeNotes": "The response mentions `image-transform` 503s at the gateway, but ultimately attributes the likely failure to the packages/function runtime path and recommends inspecting/redeploying the functions. It does not clearly ground the recurring 503s as originating in the gateway/platform layer in front of the function."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps: checking Supabase platform/gateway incidents, capturing request IDs and timestamps, adding retries, and opening a support case with specific evidence."
+        "judgeNotes": "The assistant recommended concrete next steps, including inspecting the underlying function packages, adding explicit error logging, redeploying/retrying the functions, and checking the storage path if failures persist."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
     "attempts": 1,
@@ -2364,9 +2674,18 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated SELECT and INSERT owner-scoped policies using auth.uid() = user_id / WITH CHECK. No permissive or anon policies were used."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
     "attempts": 1,
@@ -2407,13 +2726,23 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
     "attempts": 1,
@@ -2477,6 +2806,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -2536,6 +2874,15 @@
         "notes": "2 rows"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -2579,6 +2926,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -2616,7 +2972,7 @@
       {
         "name": "cron command enqueues to the 'tasks' queue",
         "passed": true,
-        "notes": "queue depth 1 -> 2"
+        "notes": "queue depth 0 -> 1"
       },
       {
         "name": "process-tasks function drains the queue",
@@ -2624,6 +2980,15 @@
         "notes": "function removed the seeded message (id 4) from the queue"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
     "attempts": 1,
@@ -2670,6 +3035,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
     "attempts": 1,
@@ -2719,6 +3093,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -2760,7 +3143,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f0440-0290-74dd-b2fc-d3279fa0940f/receipt-alpha.pdf, 019f0440-0290-74dd-b2fc-d3279fa0940f/receipt-beta.pdf"
+        "notes": "saw: 019f159f-b71a-75ab-add1-1cf4ed5ab113/receipt-alpha.pdf, 019f159f-b71a-75ab-add1-1cf4ed5ab113/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -2781,9 +3164,18 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets all requirements: private bucket, owner-scoped authenticated SELECT/INSERT policies with RLS enabled, and createSignedUrl with expiry for temporary sharing."
+        "judgeNotes": "Creates a private user-files bucket, keeps RLS implied/enabled, defines authenticated owner-prefix SELECT and INSERT policies with WITH CHECK, avoids public/anon/service-role misuse, and provides supabase-js createSignedUrl with expiry for sharing."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
     "attempts": 1,
@@ -2823,9 +3215,19 @@
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw: authenticated users could read posts outside their org because the policy checked membership by user only, not by the row’s `org_id`. It does not blame `notes` and uses pgTAP test outcomes as validation."
+        "judgeNotes": "The agent correctly identified `posts` as the broken tenant isolation policy, specifically that membership in any org allowed reading posts from other orgs. It grounded this in pgTAP/test workflow and reported passing tests after fixing `posts`, without blaming `notes` or dismissing test results."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
     "attempts": 1,
@@ -2855,9 +3257,19 @@
       {
         "name": "scorer evaluated vector search",
         "passed": false,
-        "notes": "operator does not exist: uuid = integer"
+        "notes": "relation \"document_sections\" does not exist"
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -2880,7 +3292,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -2888,15 +3300,24 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Prometheus preserves the app scrape and adds a Supabase HTTPS scrape at /customer/v1/privileged/metrics using Basic Auth with password_file. docker-compose mounts the password file via a volume and renders the project ref into the target."
+        "passed": false,
+        "judgeNotes": "Prometheus config has the correct HTTPS Supabase metrics scrape with basic_auth password_file and preserves the app job, but docker-compose.yml does not mount the password_file via a volume or Compose secret; it writes it from an environment variable at runtime."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": true,
-        "judgeNotes": "README includes creating a Supabase Secret API key, placing it in observability/secrets/supabase_metrics_api_key, recreating the Prometheus Compose service, and verifying via Prometheus Status > Targets with expected UP status."
+        "passed": false,
+        "judgeNotes": "README covers creating/using a Supabase Secret API key, restarting/reloading, and verifying via Prometheus targets/direct curl. However, it does not include a required step to place/create the matching secret file for Prometheus basic_auth password_file; it only documents an environment variable."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
     "attempts": 1,
@@ -2941,6 +3362,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -2985,6 +3415,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -3008,12 +3447,11 @@
       "sdk"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "victim session active before delete-account",
-        "passed": false,
-        "notes": "new row violates row-level security policy for table \"notes\""
+        "passed": true
       },
       {
         "name": "delete_account flow ran for the victim",
@@ -3034,15 +3472,24 @@
       },
       {
         "name": "other users keep their sessions and access",
-        "passed": false,
-        "notes": "new row violates row-level security policy for table \"notes\""
+        "passed": true
       },
       {
         "name": "diagnosed and explained session revocation",
         "passed": true,
-        "judgeNotes": "Diagnoses soft-delete-only flow, implements real auth/session revocation by deleting sessions and auth user with RLS session guard, explains remaining JWT expiry window for non-session-checking backends, and correctly distinguishes publishable frontend/RLS use from secret backend/bypass-RLS use."
+        "judgeNotes": "The answer identifies the original soft-delete-only delete_account flow, implements deletion of auth.sessions and auth.users (with cascading/profile/note cleanup), explains stale JWT/access-token caveats and need for server-side/active-user checks beyond auth.uid/local JWT validation, and correctly distinguishes frontend publishable keys from server-only secret keys that bypass RLS."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
     "attempts": 1,
@@ -3092,9 +3539,18 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the subscription reached SUBSCRIBED but INSERT events did not arrive because public.orders was missing from the supabase_realtime publication. It applied exactly the narrow fix: ALTER PUBLICATION supabase_realtime ADD TABLE public.orders. It preserved courier_locations in the publication, did not alter/drop the publication, did not weaken RLS or policies, and did not blame RLS/client/networking as the root cause."
+        "judgeNotes": "The assistant correctly identified the root cause as orders missing from the supabase_realtime publication despite successful subscription, added only public.orders to the existing publication, and preserved courier_locations, RLS, and policies."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
     "attempts": 1,
@@ -3122,19 +3578,28 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as the affected function and explicitly listed the recurring 503 gateway failures across the morning of 2026-04-28, covering all 8 timestamps from 07:00Z to 12:00Z."
+        "judgeNotes": "The assistant correctly identified image-transform as the affected function and listed the recurring HTTP 503 gateway failures throughout the morning of 2026-04-28, covering all 8 timestamps from 07:00Z to 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "The assistant clearly attributes the recurring image-transform 503s to the gateway/platform layer before function runtime, grounded in valid observations: 503s appear in gateway route logs while Edge Function logs show only successful 200s, same deployment/version across successful calls, and the separate avatar-upload 500 is distinguished as app-level and unrelated."
+        "judgeNotes": "The assistant attributes the recurring 503s to the Edge Functions/API gateway/platform layer rather than the function code, and grounds this in valid observations: repeated gateway 503s for image-transform with only successful Edge Function execution logs nearby, implying failures occurred before normal function execution logging. It also distinguishes avatar-upload's 500 from the gateway-level image-transform 503s and recommends escalation/retries rather than redeploying or fixing function code."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including escalating to Supabase support with failing timestamps and route, adding retries, structured request logging, and improving resilience via async transforms."
+        "judgeNotes": "The assistant recommended concrete next steps, including treating it as an Edge Function/gateway incident, adding retries and structured logging, and escalating to Supabase support with failing timestamps and function path."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
     "attempts": 1,
@@ -3189,9 +3654,18 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and added authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated-only SELECT and INSERT owner-scoped policies using user_id = auth.uid() / WITH CHECK."
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
     "attempts": 1,
@@ -3239,6 +3713,16 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
     "attempts": 1,
@@ -3302,6 +3786,15 @@
         "passed": true
       }
     ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,

--- a/packages/core/src/agents/claude-code/parser.test.ts
+++ b/packages/core/src/agents/claude-code/parser.test.ts
@@ -96,6 +96,28 @@ describe("claudeCodeParser", () => {
     expect(assistantMessages.map((e) => e.content)).toEqual([finalText]);
   });
 
+  it("normalizes Claude Code Skill tool calls as loaded skills", () => {
+    const transcript = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_skill",
+            name: "Skill",
+            input: { skill: "supabase-postgres-best-practices" },
+          },
+        ],
+      },
+    });
+
+    const adapted = adaptTranscript(claudeCodeParser.parseTranscript(transcript).events);
+    expect(adapted.toolCalls[0].loadedSkill).toBe(
+      "supabase-postgres-best-practices",
+    );
+  });
+
   it("still emits the result text when it was never streamed as a message", () => {
     // Plain `--print` (no stream-json) yields only the terminal result line.
     const transcript = JSON.stringify({

--- a/packages/core/src/agents/claude-code/parser.ts
+++ b/packages/core/src/agents/claude-code/parser.ts
@@ -18,7 +18,11 @@ import type {
 import type { AgentTranscriptParser } from "../../parsers/types.js";
 import { isRecord, parseJsonlRecords } from "../../json.js";
 import { normalizeToolName, type AgentToolMap } from "../../parsers/shared/normalize.js";
-import { extractArgs, type ArgFieldMap } from "../../parsers/shared/extract.js";
+import {
+  extractArgs,
+  extractLoadedSkillFromText,
+  type ArgFieldMap,
+} from "../../parsers/shared/extract.js";
 
 /** Claude Code's tool names → canonical names (case-sensitive). Owned here, not in shared. */
 const CLAUDE_CODE_TOOLS: AgentToolMap = {
@@ -134,7 +138,20 @@ function enrich(event: TranscriptEvent): TranscriptEvent {
   if (path) event.tool.path = path;
   if (command) event.tool.command = command;
   if (url) event.tool.url = url;
+  event.tool.loadedSkill = loadedSkillFromClaudeCodeCall(event.tool);
   return event;
+}
+
+/** Identifies Claude Code skill loads from tool-specific args or file reads. */
+function loadedSkillFromClaudeCodeCall(
+  tool: NonNullable<TranscriptEvent["tool"]>,
+): string | undefined {
+  if (tool.originalName === "Skill" && typeof tool.args?.skill === "string") {
+    return tool.args.skill;
+  }
+  if (tool.path) return extractLoadedSkillFromText(tool.path);
+  if (tool.command) return extractLoadedSkillFromText(tool.command);
+  return undefined;
 }
 
 function recordToEvents(data: Record<string, unknown>): TranscriptEvent[] {

--- a/packages/core/src/agents/codex/parser.test.ts
+++ b/packages/core/src/agents/codex/parser.test.ts
@@ -91,6 +91,24 @@ describe("codexParser", () => {
     expect(events).toEqual([{ type: "thinking", content: "Thinking about it." }]);
   });
 
+  it("normalizes shell reads of SKILL.md as loaded skills", () => {
+    const stream = JSON.stringify({
+      type: "item.completed",
+      item: {
+        id: "skill_1",
+        type: "command_execution",
+        command:
+          "/bin/zsh -lc \"sed -n '1,220p' .agents/skills/supabase/SKILL.md\"",
+        aggregated_output: "# Supabase",
+        exit_code: 0,
+        status: "completed",
+      },
+    });
+
+    const adapted = adaptTranscript(codexParser.parseTranscript(stream).events);
+    expect(adapted.toolCalls[0].loadedSkill).toBe("supabase");
+  });
+
   it("marks a non-zero exit code as a failed shell call (error surfaced via adapter)", () => {
     const stream = [
       JSON.stringify({

--- a/packages/core/src/agents/codex/parser.ts
+++ b/packages/core/src/agents/codex/parser.ts
@@ -22,7 +22,12 @@ import { isRecord, parseJsonlRecords } from "../../json.js";
 import type { ParsedTranscript, TranscriptEvent } from "../../transcript/types.js";
 import type { AgentTranscriptParser } from "../../parsers/types.js";
 import { normalizeToolName, type AgentToolMap } from "../../parsers/shared/normalize.js";
-import { extractArgs, type ArgFieldMap, type ExtractedArgs } from "../../parsers/shared/extract.js";
+import {
+  extractArgs,
+  extractLoadedSkillFromText,
+  type ArgFieldMap,
+  type ExtractedArgs,
+} from "../../parsers/shared/extract.js";
 
 /**
  * Codex's tool names → canonical names. Codex names built-in tools by item type
@@ -92,10 +97,20 @@ function toolCallPair(
   if (normalized.path) tool.path = normalized.path;
   if (normalized.command) tool.command = normalized.command;
   if (normalized.url) tool.url = normalized.url;
+  tool.loadedSkill = loadedSkillFromCodexCall(tool);
   return [
     { type: "tool_call", tool },
     { type: "tool_result", tool: { name, originalName, id, result, success } },
   ];
+}
+
+/** Identifies Codex skill loads from normalized file paths or shell commands. */
+function loadedSkillFromCodexCall(
+  tool: NonNullable<TranscriptEvent["tool"]>,
+): string | undefined {
+  if (tool.path) return extractLoadedSkillFromText(tool.path);
+  if (tool.command) return extractLoadedSkillFromText(tool.command);
+  return undefined;
 }
 
 function itemToEvents(item: Record<string, unknown>): TranscriptEvent[] {

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -205,6 +205,14 @@ export const checkResultSchema = z.object({
 });
 export type CheckResult = z.infer<typeof checkResultSchema>;
 
+export const skillResultSchema = z.object({
+  // Skills exposed to the agent for this run.
+  available: z.array(z.string()),
+  // Skills whose full instructions were actually loaded during the run.
+  loaded: z.array(z.string()),
+});
+export type SkillResult = z.infer<typeof skillResultSchema>;
+
 // Every dimension that has an authoring enum is enforced against that same
 // enum here — the enum is the single source of truth for both authoring
 // (evalMetadataSchema) and results. Result files are gitignored, regenerated
@@ -223,6 +231,7 @@ const evalResultShape = {
   passed: z.boolean().optional(),
   checks: z.array(checkResultSchema).optional(),
   attempts: z.number().optional(),
+  skills: skillResultSchema.optional(),
 };
 
 // Raw result files may carry extra fields we don't model; tolerate them.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,8 @@ export interface ToolCallRecord {
   path?: string;
   command?: string;
   url?: string;
+  /** Skill name loaded by this call, when the harness can identify one. */
+  loadedSkill?: string;
   result?: unknown;
   error?: string;
   ts: number;
@@ -608,9 +610,15 @@ export function aiSdkAgent(options: {
             options.providerOptions,
           ),
           experimental_onToolCallFinish: (event) => {
+            const input = isRecord(event.toolCall.input) ? event.toolCall.input : {};
+            const loadedSkill =
+              event.toolCall.toolName === "load_skill" && typeof input.name === "string"
+                ? input.name
+                : undefined;
             toolCalls.push({
               endpoint: event.toolCall.toolName,
-              body: isRecord(event.toolCall.input) ? event.toolCall.input : {},
+              body: input,
+              loadedSkill,
               result: event.output,
               ts: Date.now(),
             });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,8 +82,10 @@ export {
   modelProviderSchema,
   rawEvalResultSchema,
   reasoningEffortSchema,
+  skillResultSchema,
 } from "./eval-metadata.js";
 export { parseEvalMarkdown } from "./eval-markdown.js";
+export { buildSkillResult } from "./skill-results.js";
 // CLI agent harnesses (Claude Code, Codex, and the framework for adding more).
 export { createCliAgent } from "./agents/engine.js";
 export { claudeCodeAgent } from "./agents/claude-code/index.js";
@@ -119,6 +121,7 @@ export type {
   ModelProvider,
   ParsedEvalMarkdown,
   ReasoningEffortLevel,
+  SkillResult,
 } from "./eval-metadata.js";
 
 export interface ScoreResult {

--- a/packages/core/src/parsers/adapt.ts
+++ b/packages/core/src/parsers/adapt.ts
@@ -65,6 +65,7 @@ export function adaptTranscript(events: TranscriptEvent[]): AdaptedTranscript {
         path: event.tool.path,
         command: event.tool.command,
         url: event.tool.url,
+        loadedSkill: event.tool.loadedSkill,
         result: resolved?.error === undefined ? resolved?.result : undefined,
         error: resolved?.error,
         ts: parseTs(event.timestamp),

--- a/packages/core/src/parsers/shared/extract.ts
+++ b/packages/core/src/parsers/shared/extract.ts
@@ -26,6 +26,10 @@ export interface ExtractedArgs {
   url?: string;
 }
 
+// Skill reads can appear as bare paths or quoted shell args in tool-call logs.
+const SKILL_ENTRYPOINT_PATTERN =
+  /(?:^|[\s"'`])\S*skills\/([^\s"'`/]+)\/SKILL\.md(?:$|[\s"'`])/;
+
 /**
  * First arg value among `keys` that is a string — or a string[] joined with
  * spaces (an argv-style command). Undefined if none match.
@@ -56,4 +60,10 @@ export function extractArgs(
     command: firstField(args, map.command),
     url: firstField(args, map.url),
   };
+}
+
+/** Extracts the loaded skill name from a SKILL.md path mention. */
+export function extractLoadedSkillFromText(text: string): string | undefined {
+  const match = SKILL_ENTRYPOINT_PATTERN.exec(text);
+  return match?.[1];
 }

--- a/packages/core/src/parsers/shared/skills.test.ts
+++ b/packages/core/src/parsers/shared/skills.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { extractLoadedSkillFromText } from "./extract.js";
+
+describe("extractLoadedSkillFromText", () => {
+  it("extracts skill names from SKILL.md path mentions", () => {
+    expect(
+      extractLoadedSkillFromText(
+        `/bin/zsh -lc "sed -n '1,220p' .agents/skills/supabase/SKILL.md"`,
+      ),
+    ).toBe("supabase");
+
+    expect(
+      extractLoadedSkillFromText(
+        "/tmp/sandbox/.claude/skills/supabase-postgres-best-practices/SKILL.md",
+      ),
+    ).toBe("supabase-postgres-best-practices");
+  });
+
+  it("ignores paths that do not end at the skill entrypoint", () => {
+    expect(
+      extractLoadedSkillFromText(".agents/skills/supabase/references/auth.md"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/skill-results.test.ts
+++ b/packages/core/src/skill-results.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { buildSkillResult } from "./skill-results.js";
+import type { ToolCallRecord } from "./index.js";
+
+/** Builds the minimal tool call record needed by skill-result tests. */
+function toolCall(
+  endpoint: string,
+  body: Record<string, unknown>,
+  options: Pick<ToolCallRecord, "command" | "path"> = {},
+): ToolCallRecord {
+  return {
+    endpoint,
+    body,
+    ...options,
+    ts: 0,
+  };
+}
+
+describe("buildSkillResult", () => {
+  const available = ["supabase", "supabase-postgres-best-practices"];
+
+  it("tracks AI SDK load_skill calls", () => {
+    const result = buildSkillResult(available, [
+      toolCall("load_skill", { name: "supabase" }),
+    ]);
+
+    expect(result).toEqual({
+      available,
+      loaded: ["supabase"],
+    });
+  });
+
+  it("tracks Claude Code Skill calls", () => {
+    const result = buildSkillResult(available, [
+      toolCall("Skill", { skill: "supabase-postgres-best-practices" }),
+    ]);
+
+    expect(result).toEqual({
+      available,
+      loaded: ["supabase-postgres-best-practices"],
+    });
+  });
+
+  it("tracks Codex shell reads from .agents skill installs", () => {
+    const result = buildSkillResult(available, [
+      toolCall(
+        "command_execution",
+        {
+          command:
+            "/bin/bash -lc \"sed -n '1,220p' .agents/skills/supabase/SKILL.md\"",
+        },
+        {
+          command:
+            "/bin/bash -lc \"sed -n '1,220p' .agents/skills/supabase/SKILL.md\"",
+        },
+      ),
+    ]);
+
+    expect(result).toEqual({
+      available,
+      loaded: ["supabase"],
+    });
+  });
+
+  it("tracks .claude skill install reads defensively", () => {
+    const result = buildSkillResult(available, [
+      toolCall("command_execution", {
+        command:
+          "/bin/bash -lc \"sed -n '1,220p' .claude/skills/supabase-postgres-best-practices/SKILL.md\"",
+      }),
+    ]);
+
+    expect(result).toEqual({
+      available,
+      loaded: ["supabase-postgres-best-practices"],
+    });
+  });
+
+  it("tracks exact file-read paths ending at SKILL.md", () => {
+    const result = buildSkillResult(available, [
+      toolCall(
+        "read_file",
+        { file_path: "/tmp/sandbox/.agents/skills/supabase/SKILL.md" },
+        { path: "/tmp/sandbox/.agents/skills/supabase/SKILL.md" },
+      ),
+    ]);
+
+    expect(result).toEqual({
+      available,
+      loaded: ["supabase"],
+    });
+  });
+
+  it("ignores skills that were not available in the run", () => {
+    const result = buildSkillResult(["supabase"], [
+      toolCall("load_skill", { name: "unknown-skill" }),
+    ]);
+
+    expect(result).toEqual({
+      available: ["supabase"],
+      loaded: [],
+    });
+  });
+});

--- a/packages/core/src/skill-results.test.ts
+++ b/packages/core/src/skill-results.test.ts
@@ -19,70 +19,12 @@ function toolCall(
 describe("buildSkillResult", () => {
   const available = ["supabase", "supabase-postgres-best-practices"];
 
-  it("tracks AI SDK load_skill calls", () => {
+  it("tracks normalized skill loads", () => {
     const result = buildSkillResult(available, [
-      toolCall("load_skill", { name: "supabase" }),
-    ]);
-
-    expect(result).toEqual({
-      available,
-      loaded: ["supabase"],
-    });
-  });
-
-  it("tracks Claude Code Skill calls", () => {
-    const result = buildSkillResult(available, [
-      toolCall("Skill", { skill: "supabase-postgres-best-practices" }),
-    ]);
-
-    expect(result).toEqual({
-      available,
-      loaded: ["supabase-postgres-best-practices"],
-    });
-  });
-
-  it("tracks Codex shell reads from .agents skill installs", () => {
-    const result = buildSkillResult(available, [
-      toolCall(
-        "command_execution",
-        {
-          command:
-            "/bin/bash -lc \"sed -n '1,220p' .agents/skills/supabase/SKILL.md\"",
-        },
-        {
-          command:
-            "/bin/bash -lc \"sed -n '1,220p' .agents/skills/supabase/SKILL.md\"",
-        },
-      ),
-    ]);
-
-    expect(result).toEqual({
-      available,
-      loaded: ["supabase"],
-    });
-  });
-
-  it("tracks .claude skill install reads defensively", () => {
-    const result = buildSkillResult(available, [
-      toolCall("command_execution", {
-        command:
-          "/bin/bash -lc \"sed -n '1,220p' .claude/skills/supabase-postgres-best-practices/SKILL.md\"",
-      }),
-    ]);
-
-    expect(result).toEqual({
-      available,
-      loaded: ["supabase-postgres-best-practices"],
-    });
-  });
-
-  it("tracks exact file-read paths ending at SKILL.md", () => {
-    const result = buildSkillResult(available, [
-      toolCall(
-        "read_file",
-        { file_path: "/tmp/sandbox/.agents/skills/supabase/SKILL.md" },
-        { path: "/tmp/sandbox/.agents/skills/supabase/SKILL.md" },
-      ),
+      {
+        ...toolCall("load_skill", { name: "supabase" }),
+        loadedSkill: "supabase",
+      },
     ]);
 
     expect(result).toEqual({
@@ -93,7 +35,10 @@ describe("buildSkillResult", () => {
 
   it("ignores skills that were not available in the run", () => {
     const result = buildSkillResult(["supabase"], [
-      toolCall("load_skill", { name: "unknown-skill" }),
+      {
+        ...toolCall("load_skill", { name: "unknown-skill" }),
+        loadedSkill: "unknown-skill",
+      },
     ]);
 
     expect(result).toEqual({

--- a/packages/core/src/skill-results.ts
+++ b/packages/core/src/skill-results.ts
@@ -1,6 +1,7 @@
 import type { ToolCallRecord } from "./index.js";
 import type { SkillResult } from "./eval-metadata.js";
 
+// Skill reads can appear as bare paths or quoted shell args in tool-call logs.
 const PATH_START_BOUNDARY = String.raw`(?:^|[\s"'` + "`" + String.raw`])`;
 const PATH_END_BOUNDARY = String.raw`(?:$|[\s"'` + "`" + String.raw`])`;
 

--- a/packages/core/src/skill-results.ts
+++ b/packages/core/src/skill-results.ts
@@ -1,19 +1,16 @@
 import type { SkillResult } from "./eval-metadata.js";
 import type { ToolCallRecord } from "./index.js";
 
-/** Checks whether a normalized tool call loaded one configured skill. */
-function callLoadsSkill(call: ToolCallRecord, skill: string): boolean {
-  return call.loadedSkill === skill;
-}
-
 /** Builds the persisted skill activation summary for one eval run. */
 export function buildSkillResult(
   available: string[],
   toolCalls: ToolCallRecord[],
 ): SkillResult {
-  const loaded = available.filter((skill) =>
-    toolCalls.some((call) => callLoadsSkill(call, skill)),
-  );
+  const loadedSkills = new Set<string>();
+  for (const { loadedSkill } of toolCalls) {
+    if (loadedSkill) loadedSkills.add(loadedSkill);
+  }
+  const loaded = available.filter((skill) => loadedSkills.has(skill));
 
   return {
     available,

--- a/packages/core/src/skill-results.ts
+++ b/packages/core/src/skill-results.ts
@@ -1,0 +1,49 @@
+import type { ToolCallRecord } from "./index.js";
+import type { SkillResult } from "./eval-metadata.js";
+
+const PATH_START_BOUNDARY = String.raw`(?:^|[\s"'` + "`" + String.raw`])`;
+const PATH_END_BOUNDARY = String.raw`(?:$|[\s"'` + "`" + String.raw`])`;
+
+/** Escapes configured skill names before interpolating them into path regexes. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Checks whether text mentions a loaded skill entrypoint in any installed skill directory. */
+function textReferencesSkillEntrypoint(text: string, skill: string): boolean {
+  return new RegExp(
+    `${PATH_START_BOUNDARY}\\S*skills/${escapeRegExp(skill)}/SKILL\\.md${PATH_END_BOUNDARY}`,
+  ).test(text);
+}
+
+/** Recognizes known agent transcript signatures for loading one configured skill. */
+function callLoadsSkill(call: ToolCallRecord, skill: string): boolean {
+  if (call.endpoint === "load_skill" && call.body.name === skill) return true;
+  if (call.endpoint === "Skill" && call.body.skill === skill) return true;
+
+  const path = call.path ?? call.body.file_path ?? call.body.path;
+  if (typeof path === "string" && textReferencesSkillEntrypoint(path, skill)) {
+    return true;
+  }
+
+  const command = call.command ?? call.body.command;
+  return (
+    typeof command === "string" &&
+    textReferencesSkillEntrypoint(command, skill)
+  );
+}
+
+/** Builds the persisted skill activation summary for one eval run. */
+export function buildSkillResult(
+  available: readonly string[],
+  toolCalls: readonly ToolCallRecord[],
+): SkillResult {
+  const loaded = available.filter((skill) =>
+    toolCalls.some((call) => callLoadsSkill(call, skill)),
+  );
+
+  return {
+    available: [...available],
+    loaded,
+  };
+}

--- a/packages/core/src/skill-results.ts
+++ b/packages/core/src/skill-results.ts
@@ -1,37 +1,9 @@
-import type { ToolCallRecord } from "./index.js";
 import type { SkillResult } from "./eval-metadata.js";
+import type { ToolCallRecord } from "./index.js";
 
-// Skill reads can appear as bare paths or quoted shell args in tool-call logs.
-const PATH_START_BOUNDARY = String.raw`(?:^|[\s"'` + "`" + String.raw`])`;
-const PATH_END_BOUNDARY = String.raw`(?:$|[\s"'` + "`" + String.raw`])`;
-
-/** Escapes configured skill names before interpolating them into path regexes. */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/** Checks whether text mentions a loaded skill entrypoint in any installed skill directory. */
-function textReferencesSkillEntrypoint(text: string, skill: string): boolean {
-  return new RegExp(
-    `${PATH_START_BOUNDARY}\\S*skills/${escapeRegExp(skill)}/SKILL\\.md${PATH_END_BOUNDARY}`,
-  ).test(text);
-}
-
-/** Recognizes known agent transcript signatures for loading one configured skill. */
+/** Checks whether a normalized tool call loaded one configured skill. */
 function callLoadsSkill(call: ToolCallRecord, skill: string): boolean {
-  if (call.endpoint === "load_skill" && call.body.name === skill) return true;
-  if (call.endpoint === "Skill" && call.body.skill === skill) return true;
-
-  const path = call.path ?? call.body.file_path ?? call.body.path;
-  if (typeof path === "string" && textReferencesSkillEntrypoint(path, skill)) {
-    return true;
-  }
-
-  const command = call.command ?? call.body.command;
-  return (
-    typeof command === "string" &&
-    textReferencesSkillEntrypoint(command, skill)
-  );
+  return call.loadedSkill === skill;
 }
 
 /** Builds the persisted skill activation summary for one eval run. */

--- a/packages/core/src/skill-results.ts
+++ b/packages/core/src/skill-results.ts
@@ -36,15 +36,15 @@ function callLoadsSkill(call: ToolCallRecord, skill: string): boolean {
 
 /** Builds the persisted skill activation summary for one eval run. */
 export function buildSkillResult(
-  available: readonly string[],
-  toolCalls: readonly ToolCallRecord[],
+  available: string[],
+  toolCalls: ToolCallRecord[],
 ): SkillResult {
   const loaded = available.filter((skill) =>
     toolCalls.some((call) => callLoadsSkill(call, skill)),
   );
 
   return {
-    available: [...available],
+    available,
     loaded,
   };
 }

--- a/packages/core/src/transcript/types.ts
+++ b/packages/core/src/transcript/types.ts
@@ -61,6 +61,8 @@ export interface TranscriptEvent {
     path?: string;
     command?: string;
     url?: string;
+    /** Skill name loaded by this call, when the parser can identify one. */
+    loadedSkill?: string;
     /** Tool result payload (for `tool_result`). */
     result?: unknown;
     /** Whether the tool call succeeded (for `tool_result`). */


### PR DESCRIPTION
**Changes**
- Adds `skills.available` and `skills.loaded` to eval result metadata, including result export, so new runs record which configured skills were exposed and which ones were actually loaded.
- Tracks loaded skills from the tools-mode `load_skill` tool, Claude Code `Skill` calls, and CLI tool calls that read `skills/<name>/SKILL.md`. Adds focused test coverage for the activation summary builder.

In testing, agents are pretty reliable loading the `supabase` skill, they don't often load `postgres-best-practices`.

Closes AI-874
