### PR TITLE
fix: declarative schema guidance and scoring

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ""
       eval:
-        description: "Optional single eval id to run"
+        description: "Optional comma-separated eval ids to run"
         required: false
         default: ""
       suite:
@@ -174,9 +174,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          eval_id="${{ steps.inputs.outputs.eval }}"
-          if [ -n "$eval_id" ]; then
-            echo "evals=$(jq -n --arg id "$eval_id" '[$id]')" >> "$GITHUB_OUTPUT"
+          eval_ids="${{ steps.inputs.outputs.eval }}"
+          if [ -n "$eval_ids" ]; then
+            evals_json="$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))' <<< "$eval_ids")"
+            echo "evals=$evals_json" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -1189,7 +1189,7 @@
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-opus-4.8-no-skills/build-cli-002-declarative-schema.json"
   },
   {
@@ -5319,8 +5319,7 @@
       },
       {
         "name": "a new migration was generated for the change",
-        "passed": false,
-        "notes": "found 1 migration file(s)"
+        "passed": true
       },
       {
         "name": "description column exists in the live database",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -1189,7 +1189,7 @@
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-opus-4.8-no-skills/build-cli-002-declarative-schema.json"
   },
   {
@@ -4232,11 +4232,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "supabase db diff used to generate the migration",
-        "passed": false
+        "passed": true
       },
       {
         "name": "schema file updated to include description column",
@@ -4262,7 +4262,7 @@
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema.json"
   },
   {
@@ -6304,11 +6304,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "supabase db diff used to generate the migration",
-        "passed": false
+        "passed": true
       },
       {
         "name": "schema file updated to include description column",
@@ -6334,7 +6334,7 @@
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.5/build-cli-002-declarative-schema.json"
   },
   {

--- a/evals/build-cli-002-declarative-schema/EVAL.ts
+++ b/evals/build-cli-002-declarative-schema/EVAL.ts
@@ -21,7 +21,7 @@ export default scorer;
 function checkDbDiffUsed(ctx: LocalStackEvalContext): CheckResult {
   const name = "supabase db diff used to generate the migration";
   const used = ctx.toolCalls.some((tc) =>
-    /supabase\s+db\s+diff/.test(String(tc.body.command ?? tc.command ?? "")),
+    /supabase\s+db\s+diff/.test(tc.command ?? ""),
   );
   return { name, passed: used };
 }

--- a/evals/build-cli-002-declarative-schema/EVAL.ts
+++ b/evals/build-cli-002-declarative-schema/EVAL.ts
@@ -20,12 +20,8 @@ export default scorer;
 /** Checks that the agent ran `supabase db diff` rather than hand-writing the migration. */
 function checkDbDiffUsed(ctx: LocalStackEvalContext): CheckResult {
   const name = "supabase db diff used to generate the migration";
-  const used = ctx.toolCalls.some(
-    // Case-insensitive: in-process agents emit the tool name `bash`, CLI agents
-    // (Claude Code) emit `Bash`.
-    (tc) =>
-      tc.endpoint.toLowerCase() === "bash" &&
-      /supabase\s+db\s+diff/.test(String(tc.body.command ?? "")),
+  const used = ctx.toolCalls.some((tc) =>
+    /supabase\s+db\s+diff/.test(String(tc.body.command ?? tc.command ?? "")),
   );
   return { name, passed: used };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -641,9 +641,15 @@ export function aiSdkAgent(options: {
               typeof input.name === "string"
                 ? input.name
                 : undefined;
+            const command =
+              event.toolCall.toolName.toLowerCase() === "bash" &&
+              typeof input.command === "string"
+                ? input.command
+                : undefined;
             toolCalls.push({
               endpoint: event.toolCall.toolName,
               body: input,
+              command,
               loadedSkill,
               result: event.output,
               ts: Date.now(),


### PR DESCRIPTION
Improvements for `build-cli-002-declarative-schema`

- Updates the agent-skills submodule to include declarative schema workflow guidance from https://github.com/supabase/agent-skills/pull/120.
- Fixes eval refresh single-eval handling (which caused [this failure](https://github.com/supabase/evals/actions/runs/29025007584)), and supports comma-separated eval IDs.
- Fixes `build-cli-002-declarative-schema` scoring to use normalized `.command` when testing if `supabase db diff` was called, and normalizes AI SDK agent's tool calls onto `ToolCallRecord.command`

See refresh run: https://github.com/supabase/evals/actions/runs/29025860898

Results now look more reasonable, where Codex stumbles without explicit declarative schema guidance (it tried editing the existing migration in-place + resetting db) but passes with the skill. Interestingly Claude gets it right even without skills.

| Without skills | With skills |
|--------|--------|
| <img width="2794" height="806" alt="CleanShot 2026-07-09 at 10 47 06@2x" src="https://github.com/user-attachments/assets/6e86195c-4936-4ee4-8b68-ebb296fcf965" /> | <img width="2794" height="806" alt="CleanShot 2026-07-09 at 10 47 04@2x" src="https://github.com/user-attachments/assets/a7b15347-3caf-4a9b-b6a9-e6bca3d1b057" /> | 

Before merging this, we should merge + release https://github.com/supabase/agent-skills/pull/120

Ref AI-875
