### PR TITLE
chore: tag `mcp` interface scenarios

### DIFF
--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -254,6 +254,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -311,6 +312,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -438,6 +440,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -662,6 +665,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -728,6 +732,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -789,6 +794,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -842,6 +848,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -968,6 +975,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1026,6 +1034,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1314,6 +1323,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1366,6 +1376,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1483,6 +1494,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1687,6 +1699,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1748,6 +1761,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1804,6 +1818,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1852,6 +1867,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -1968,6 +1984,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2021,6 +2038,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2324,6 +2342,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2381,6 +2400,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2508,6 +2528,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2732,6 +2753,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2798,6 +2820,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2859,6 +2882,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -2912,6 +2936,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3038,6 +3063,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3096,6 +3122,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3384,6 +3411,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3436,6 +3464,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3553,6 +3582,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3757,6 +3787,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -3819,6 +3850,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3875,6 +3907,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -3923,6 +3956,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4039,6 +4073,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4092,6 +4127,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4395,6 +4431,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4452,6 +4489,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4579,6 +4617,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4803,6 +4842,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -4872,6 +4912,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -4933,6 +4974,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -4986,6 +5028,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -5115,6 +5158,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -5173,6 +5217,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -5462,6 +5507,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -5514,6 +5560,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -5631,6 +5678,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -5835,6 +5883,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -5898,6 +5947,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -5954,6 +6004,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -6002,6 +6053,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -6118,6 +6170,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -6171,6 +6224,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -6475,6 +6529,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -6532,6 +6587,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -6660,6 +6716,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -6885,6 +6942,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -6951,6 +7009,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7012,6 +7071,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7065,6 +7125,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7192,6 +7253,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7251,6 +7313,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7539,6 +7602,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7591,6 +7655,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7708,6 +7773,7 @@
       "rls"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -7912,6 +7978,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": false,
     "checks": [
       {
@@ -7974,6 +8041,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -8030,6 +8098,7 @@
       "observability"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -8078,6 +8147,7 @@
       "sdk"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -8194,6 +8264,7 @@
       "sql"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {
@@ -8247,6 +8318,7 @@
       "security"
     ],
     "suite": "benchmark",
+    "interface": "mcp",
     "passed": true,
     "checks": [
       {

--- a/evals/build-functions-001-order-total/PROMPT.md
+++ b/evals/build-functions-001-order-total/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: other
+interface: mcp
 product:
   - edge-functions
   - data-api

--- a/evals/build-functions-002-edge-auth-db/PROMPT.md
+++ b/evals/build-functions-002-edge-auth-db/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: other
+interface: mcp
 product:
   - edge-functions
   - database

--- a/evals/build-functions-003-todos-crud-api/PROMPT.md
+++ b/evals/build-functions-003-todos-crud-api/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: other
+interface: mcp
 product:
   - edge-functions
   - database

--- a/evals/build-functions-004-service-role-bypass/PROMPT.md
+++ b/evals/build-functions-004-service-role-bypass/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+interface: mcp
 product:
   - edge-functions
   - auth

--- a/evals/build-realtime-001-live-chat-updates/PROMPT.md
+++ b/evals/build-realtime-001-live-chat-updates/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: regression
+interface: mcp
 product:
   - realtime
   - database

--- a/evals/build-rls-002-own-todos-client/PROMPT.md
+++ b/evals/build-rls-002-own-todos-client/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: other
+interface: mcp
 product:
   - database
   - auth

--- a/evals/build-rls-003-org-roles-permissions/PROMPT.md
+++ b/evals/build-rls-003-org-roles-permissions/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: other
+interface: mcp
 product:
   - database
   - auth

--- a/evals/build-storage-001-private-bucket-access/PROMPT.md
+++ b/evals/build-storage-001-private-bucket-access/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+interface: mcp
 product:
   - storage
   - database

--- a/evals/build-vectors-001-rag-with-permissions/PROMPT.md
+++ b/evals/build-vectors-001-rag-with-permissions/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+interface: mcp
 product:
   - database
   - vectors

--- a/evals/investigate-auth-001-deleted-user-access/PROMPT.md
+++ b/evals/investigate-auth-001-deleted-user-access/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: benchmark
+interface: mcp
 product:
   - auth
 topic:

--- a/evals/investigate-db-001-table-row-counts/PROMPT.md
+++ b/evals/investigate-db-001-table-row-counts/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: other
+interface: mcp
 product:
   - database
 topic:

--- a/evals/investigate-logs-001-top-error-function/PROMPT.md
+++ b/evals/investigate-logs-001-top-error-function/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: other
+interface: mcp
 product:
   - edge-functions
 topic:

--- a/evals/investigate-realtime-001-subscribed-no-events/PROMPT.md
+++ b/evals/investigate-realtime-001-subscribed-no-events/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: benchmark
+interface: mcp
 product:
   - realtime
   - database

--- a/evals/investigate-reliability-001-error-rate-spike/PROMPT.md
+++ b/evals/investigate-reliability-001-error-rate-spike/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: other
+interface: mcp
 product:
   - edge-functions
 topic:

--- a/evals/investigate-reliability-002-subtle-error-spike/PROMPT.md
+++ b/evals/investigate-reliability-002-subtle-error-spike/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: other
+interface: mcp
 product:
   - edge-functions
 topic:

--- a/evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md
+++ b/evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: benchmark
+interface: mcp
 product:
   - edge-functions
 topic:

--- a/evals/investigate-security-001-public-table/PROMPT.md
+++ b/evals/investigate-security-001-public-table/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: other
+interface: mcp
 product:
   - database
 topic:

--- a/evals/resolve-dataapi-001-empty-results/PROMPT.md
+++ b/evals/resolve-dataapi-001-empty-results/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: benchmark
+interface: mcp
 product:
   - data-api
   - database

--- a/evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md
+++ b/evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: benchmark
+interface: mcp
 product:
   - database
 topic:

--- a/evals/resolve-security-001-rls-cross-user-leak/PROMPT.md
+++ b/evals/resolve-security-001-rls-cross-user-leak/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: other
+interface: mcp
 product:
   - database
   - auth

--- a/evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md
+++ b/evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: benchmark
+interface: mcp
 product:
   - database
   - auth


### PR DESCRIPTION
Tags MCP-related scenarios with `interface: mcp` (i.e. most scenarios with `remote/` seed or those lacking `cli` interface).

Technically any scenario can use MCP for `search_docs` but I'm excluding the docs-only use cases for the purpose of this metadata. `deploy-database-001-prometheus-metrics` is sole scenario with neither interface specified, since it relies purely on docs / web tools.

In the migration history mismatch scenario, agents can theoretically use both CLI and MCP but the expectation is CLI only, so it remains tagged as `cli`.

`deploy-database-001-prometheus-metrics` is the one scenario with neither interface specified, since it relies solely on docs

Also downloaded the raw artifacts from [the latest broad eval refresh](https://github.com/supabase/evals/actions/runs/29113316748) and re-exported results so they're available in Hex.

Closes AI-913
