### PR TITLE
docs: `CONTRIBUTING.md` guide for adding scenarios and experiments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Read [README.md](README.md) for repo concepts and instructions for running evals locally.
+
+## Adding an eval
+
+First, determine the eval suite for your scenario:
+
+- **Regression** evals are suitable for most scenarios. If we notice agents make a narrow mistake, we track it here to reproduce the issue, verify a fix, and monitor for regression. These scenarios are not included in the benchmark so they don't inflate scores.
+- **Benchmark** evals are scenarios we've intentionally selected for the published benchmark report. These should be representative of the user journey on Supabase to cover a breadth of dimensions.
+
+Then add a folder under `evals/` containing:
+
+1. `PROMPT.md` with frontmatter metadata and the task the agent sees.
+2. `EVAL.ts` with the scorer.
+3. Optional `remote/` data when the scenario needs to seed hosted project state, such as database, logs, or functions.
+4. Optional `local/` files when the scenario needs to seed a local filesystem, such as a local `supabase/` project.
+
+If your scenario contains anything not self-explanatory, consider adding a `README.md` to the folder with a brief explanation of how it's set up and what it's testing.
+
+## Eval criteria
+
+Every new scenario needs a `motivation:` defined in `PROMPT.md` frontmatter that cites some evidence for the scenario being a part of the Supabase user journey, ideally a pain point. Examples include support tickets, GitHub issues, Linear issues, or social media threads.
+
+For new **benchmark** scenarios, we need to see at least one agent, ideally more, failing the new scenario to ensure we're getting signal from results. If agents are already acing your scenario, consider hardening it with a more ambiguous or misleading prompt, unusual seed data, or subtle footgun. Run locally and review agent failures to ensure they're legitimate reasoning mistakes, not eval framework limitations. We also want to keep benchmarks representative of the user journey. Review the [Evals coverage table](https://app.hex.tech/supabase/app/Evals-033abDlwqlTbW5ktgwFffU/latest) and make sure you're not over-indexing on a niche use case.
+
+## Writing good prompts
+
+Prompts should reflect what a real user would type into their agent. Prompts should NOT reflect deep familiarity with Supabase nor specify every detail of a request, as users should expect agents to fill in the gaps themselves.
+
+Instead of spoonfeeding agents in the prompt, move details into seed data to let agents discover context and infer user intent. For example, a seeded database table can help agents resolve the true names of columns or preferred naming conventions for a project, seeded edge functions can provide a template for desired functionality, and inline comments can help explain a project's structure beyond what the code shows.
+
+## Adding an experiment
+
+Add a file under `experiments/` for the agent, model, and runtime setup you want to compare. Set `suite: ["benchmark"]` or another experiment suite value so the runner and results UI can group comparable experiments.
+
+## Submitting evals for review
+
+Before submitting an eval for review, try running it locally to sanity check that it can complete without errors. It's okay if agents fail the eval, we just don't want them to be scored unfairly for framework limitations.
+
+When you create a PR, use GitHub Actions to refresh the results in CI so we can verify the results in a trusted environment. Currently, results are tracked in Git and committed to the repo, so the refresh results workflow can either commit result changes directly to a branch or generate a PR to propose the change.
+
+You have a few options to run evals in CI:
+
+- Add the `run-evals-changed` label to your PR to refresh only the `evals/` changed in that PR and commit merged results directly to your branch.
+- Add the `run-evals` label to run every benchmark eval across the `benchmark` and `no-skills` experiment suites. Use this when a change can affect results broadly, such as framework changes.
+- Dispatch the [Refresh eval results](https://github.com/supabase/evals/actions/workflows/eval-refresh.yml) workflow manually to target any branch and choose specific evals, experiments, or other options. It can commit results directly to the selected branch or open a separate results PR.
+
+Include refreshed results for PRs with new/changed evals so a reviewer can see results directly from your PR or Vercel preview build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ Instead of spoonfeeding agents in the prompt, move details into seed data to let
 
 ## Writing scorers
 
-Prefer determinstic checks where possible for stability and efficiency. Avoid being overly presriptive with the process an agent takes to reach a solution (unless critical to the scenario), prefer checking the end state by inspecting the project or filesystem.
+Prefer deterministic checks where possible for stability and efficiency. Avoid being overly prescriptive with the process an agent takes to reach a solution (unless critical to the scenario), prefer checking the end state by inspecting the project or filesystem.
 
-If determinstic checks are too inflexible or convoluted, use an LLM-as-a-judge check via `judge()` to check semantic correctness.
+If deterministic checks are too inflexible or convoluted, use an LLM-as-a-judge check via `judge()` to check semantic correctness.
 
 Prefer building checks declaratively and returning the list in one place instead of accumulating checks within branching logic, so the list remains stable if one path fails.
 
@@ -42,7 +42,7 @@ Prefer building checks declaratively and returning the list in one place instead
 
 Add a file under `experiments/` for the agent, model, and runtime setup you want to compare. Here you can configure which skills and MCP servers are available.
 
-Select the experiment's `suite:` depending on your use case. If this experiment should be part of our published benchmark, assign `suite: ["benchmark"]` and add include a corresponding `*-no-skills` variant to compare results with and without skills. You can also assign custom experiment suites for grouping related experiments for other head-to-head comparisons as desired.
+Select the experiment's `suite:` depending on your use case. If this experiment should be part of our published benchmark, assign `suite: ["benchmark"]` and include a corresponding `*-no-skills` variant to compare results with and without skills. You can also assign custom experiment suites for grouping related experiments for other head-to-head comparisons as desired.
 
 ## Submitting evals for review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,19 @@ Every new scenario needs a `motivation:` defined in `PROMPT.md` frontmatter that
 
 For new **benchmark** scenarios, we need to see at least one agent, ideally more, failing the new scenario to ensure we're getting signal from results. If agents are already acing your scenario, consider hardening it with a more ambiguous or misleading prompt, unusual seed data, or subtle footgun. Run locally and review agent failures to ensure they're legitimate reasoning mistakes, not eval framework limitations. We also want to keep benchmarks representative of the user journey. Review the [Evals coverage table](https://app.hex.tech/supabase/app/Evals-033abDlwqlTbW5ktgwFffU/latest) and make sure you're not over-indexing on a niche use case.
 
-## Writing good prompts
+## Writing prompts
 
-Prompts should reflect what a real user would type into their agent. Prompts should NOT reflect deep familiarity with Supabase nor specify every detail of a request, as users should expect agents to fill in the gaps themselves.
+Prompts should reflect what a real user would send to an agent. Prompts should NOT reflect deep familiarity with Supabase nor specify every detail of a request, as users should expect agents to fill in the gaps themselves. They should be short and casual messages, not highly formatted specs.
 
 Instead of spoonfeeding agents in the prompt, move details into seed data to let agents discover context and infer user intent. For example, a seeded database table can help agents resolve the true names of columns or preferred naming conventions for a project, seeded edge functions can provide a template for desired functionality, and inline comments can help explain a project's structure beyond what the code shows.
+
+## Writing scorers
+
+Prefer determinstic checks where possible for stability and efficiency. Avoid being overly presriptive with the process an agent takes to reach a solution (unless critical to the scenario), prefer checking the end state by inspecting the project or filesystem.
+
+If determinstic checks are too inflexible or convoluted, use an LLM-as-a-judge check via `judge()` to check semantic correctness.
+
+Prefer building checks declaratively and returning the list in one place instead of accumulating checks within branching logic, so the list remains stable if one path fails.
 
 ## Adding an experiment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,9 @@ Prefer building checks declaratively and returning the list in one place instead
 
 ## Adding an experiment
 
-Add a file under `experiments/` for the agent, model, and runtime setup you want to compare. Set `suite: ["benchmark"]` or another experiment suite value so the runner and results UI can group comparable experiments.
+Add a file under `experiments/` for the agent, model, and runtime setup you want to compare. Here you can configure which skills and MCP servers are available.
+
+Select the experiment's `suite:` depending on your use case. If this experiment should be part of our published benchmark, assign `suite: ["benchmark"]` and add include a corresponding `*-no-skills` variant to compare results with and without skills. You can also assign custom experiment suites for grouping related experiments for other head-to-head comparisons as desired.
 
 ## Submitting evals for review
 

--- a/README.md
+++ b/README.md
@@ -25,18 +25,6 @@ cp .env.example .env
 
 Agent-backed runs require the relevant provider key in `.env` (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
 
-Run one eval:
-
-```bash
-pnpm eval -- --eval resolve-dataapi-001-empty-results --experiment claude-code-sonnet-5
-```
-
-View results in the web app at `http://localhost:5173`:
-
-```bash
-pnpm web
-```
-
 ## Concepts
 
 - An **eval** is one scenario under `evals/<id>/`. It contains the prompt, scorer, and optional starting state for the two environments: `remote/` (the hosted project) and `local/` (the agent's working files).
@@ -47,23 +35,28 @@ pnpm web
 - A **runtime** is the local Supabase-like environment and tool surface an experiment gives to the agent.
 - `platform-lite` exposes a Supabase Management API-compatible HTTP surface backed by [`@supabase/lite`](https://github.com/supabase/supabase-lite), so real tools like `@supabase/mcp-server-supabase` can run against a lightweight project.
 
-## Common Workflows
-
-### Add an eval
-
-1. Add a folder under `evals/`.
-2. Add `PROMPT.md` with frontmatter metadata and the task the agent sees.
-3. Add `EVAL.ts` with the scorer.
-4. Add `remote/` data if the scenario needs hosted-project state (database, logs, functions).
-5. Add `local/` files if the agent starts from an existing workspace (the app or repo it edits).
-
-### Add an experiment
-
-Add a file under `experiments/` for the agent/model/runtime setup you want to compare. Set `suite: ["benchmark"]` or another experiment suite value so the runner and results UI can group comparable experiments.
-
-### Run evals
+## Running evals
 
 Running evals executes experiment x eval pairs and writes local result files under `results/`.
+
+Run a single eval with one experiment:
+
+```bash
+pnpm eval -- --eval resolve-dataapi-001-empty-results --experiment claude-code-sonnet-5
+```
+
+
+Run selected evals across multiple experiments:
+
+```bash
+pnpm eval -- \
+  --experiment claude-code-sonnet-5 \
+  --experiment claude-code-opus-4.8 \
+  --eval resolve-dataapi-001-empty-results \
+  --eval investigate-auth-001-deleted-user-access
+```
+
+`--suite`, `--experiment-suite`, `--experiment`, and `--eval` accept multiple inputs via repeated flags as well as comma-separated values.
 
 Run all benchmark and no-skills experiments across all benchmark evals:
 
@@ -71,22 +64,18 @@ Run all benchmark and no-skills experiments across all benchmark evals:
 pnpm eval -- --suite benchmark --experiment-suite benchmark,no-skills
 ```
 
-Narrow to specific evals or experiments (flags are repeatable):
+### View results in the web app
+
+After running evals locally, export their results to `eval-results.json` for the web app:
 
 ```bash
-pnpm eval -- \
-  --suite benchmark \
-  --experiment-suite benchmark \
-  --experiment claude-code-sonnet-5 \
-  --experiment claude-code-opus-4.8 \
-  --eval resolve-dataapi-001-empty-results \
-  --eval investigate-auth-001-deleted-user-access
+pnpm export-results
 ```
 
-Or run everything:
+Start the web app development server:
 
 ```bash
-pnpm eval
+pnpm web
 ```
 
 ## Eval Shape
@@ -118,7 +107,6 @@ motivation: AI-123
 
 Allowed metadata values are defined in `packages/core/src/eval-metadata.ts`.
 `suite` is required on every eval (`benchmark`, `regression`, or `other`). Run an eval suite with `--suite regression` / `--suite other`. Select experiment suites separately with `--experiment-suite benchmark` or `--experiment-suite no-skills`.
-Benchmark evals should include `motivation` with the issue or other reference that explains why the scenario belongs in the suite.
 
 ## Eval Modes
 
@@ -165,3 +153,7 @@ pnpm check
 ```
 
 Runs typechecks plus local smoke tests.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidance on adding evals and experiments, and submitting changes.


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` and moves/tweaks content in `README.md`

The split is:
- `README.md`: general repo structure, concepts, and instructions to set up and run evals locally
- `CONTRIBUTING.md`: how to add and submit new scenarios or experiments

My thinking is there are two kinds of developers who might come to this repo. Some just want to inspect and verify eval results, others want to contribute scenarios and experiments.

The new `CONTRIBUTING.md` includes our criteria for what's an acceptable scenario, how to write prompts and scorers, and how to refresh results in CI.

Closes AI-918, AI-916

