### PR TITLE
feat: run regression evals in CI

### DIFF
--- a/.github/workflows/append-gh-pages-history.yml
+++ b/.github/workflows/append-gh-pages-history.yml
@@ -38,7 +38,6 @@ jobs:
           append_if_changed() {
             local source="$1"
             local history="$2"
-            local wrap="$3"
 
             if [ "${{ github.event_name }}" != "workflow_dispatch" ] && \
               git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- "$source"; then
@@ -49,17 +48,14 @@ jobs:
               return
             fi
 
-            if [ "$wrap" = "true" ]; then
-              git show "${{ github.sha }}:$source" \
-                | jq -c --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '{ts: $ts, results: .}' \
-                >> "$history"
-            else
-              git show "${{ github.sha }}:$source" | jq -c . >> "$history"
-            fi
+            git show "${{ github.sha }}:$source" \
+              | jq -c --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --arg sha "${{ github.sha }}" \
+                '{ts: $ts, sha: $sha, results: .}' \
+              >> "$history"
           }
 
-          append_if_changed apps/web/src/data/eval-results.json results.jsonl true
-          append_if_changed apps/web/src/data/regression-eval-results.json regression-results.jsonl false
+          append_if_changed apps/web/src/data/eval-results.json results.jsonl
+          append_if_changed apps/web/src/data/regression-eval-results.json regression-results.jsonl
 
           for history in results.jsonl regression-results.jsonl; do
             [ -f "$history" ] && git add "$history"

--- a/.github/workflows/append-gh-pages-history.yml
+++ b/.github/workflows/append-gh-pages-history.yml
@@ -3,11 +3,17 @@ name: Append gh-pages history
 on:
   push:
     branches: [main]
-    paths: [apps/web/src/data/eval-results.json]
+    paths:
+      - apps/web/src/data/eval-results.json
+      - apps/web/src/data/regression-eval-results.json
   workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: append-gh-pages-history
+  cancel-in-progress: false
 
 jobs:
   append:
@@ -29,11 +35,39 @@ jobs:
           git fetch origin gh-pages:gh-pages
           git checkout gh-pages
 
-          git show ${{ github.sha }}:apps/web/src/data/eval-results.json \
-            | jq -c --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '{ts: $ts, results: .}' \
-            >> results.jsonl
+          append_if_changed() {
+            local source="$1"
+            local history="$2"
+            local wrap="$3"
 
-          git add results.jsonl
+            if [ "${{ github.event_name }}" != "workflow_dispatch" ] && \
+              git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- "$source"; then
+              return
+            fi
+
+            if ! git cat-file -e "${{ github.sha }}:$source" 2> /dev/null; then
+              return
+            fi
+
+            if [ "$wrap" = "true" ]; then
+              git show "${{ github.sha }}:$source" \
+                | jq -c --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '{ts: $ts, results: .}' \
+                >> "$history"
+            else
+              git show "${{ github.sha }}:$source" | jq -c . >> "$history"
+            fi
+          }
+
+          append_if_changed apps/web/src/data/eval-results.json results.jsonl true
+          append_if_changed apps/web/src/data/regression-eval-results.json regression-results.jsonl false
+
+          for history in results.jsonl regression-results.jsonl; do
+            [ -f "$history" ] && git add "$history"
+          done
+          if git diff --cached --quiet; then
+            echo "No result history changes to commit"
+            exit 0
+          fi
           git commit -m "chore: append eval results"
           git push origin gh-pages
           git checkout -

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -339,11 +339,14 @@ jobs:
           set -euo pipefail
 
           mkdir -p results
-          for artifact_dir in downloaded-results/raw-results-*/; do
-            [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. results/
-          done
-
           pairs='${{ needs.prepare.outputs.pairs }}'
+          while IFS= read -r experiment; do
+            mkdir -p "results/$experiment"
+            for artifact_dir in "downloaded-results/raw-results-${experiment}__"*/; do
+              [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. "results/$experiment"/
+            done
+          done < <(jq -r '.[].experiment' <<< "$pairs" | sort -u)
+
           if jq -e 'any(.[]; .eval_suite == "benchmark")' <<< "$pairs" > /dev/null; then
             export_args=(--suite benchmark --output apps/web/src/data/eval-results.json)
             if [ "${{ needs.prepare.outputs.do_merge }}" = "true" ]; then

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -71,7 +71,7 @@ jobs:
       pairs: ${{ steps.discover.outputs.pairs }}
       runs: ${{ steps.inputs.outputs.runs }}
       timeout_sec: ${{ steps.inputs.outputs.timeout_sec }}
-      scope: ${{ steps.inputs.outputs.scope }}
+      filter_changed: ${{ steps.inputs.outputs.filter_changed }}
       do_merge: ${{ steps.inputs.outputs.do_merge }}
     steps:
       - name: Prepare inputs
@@ -107,16 +107,17 @@ jobs:
           experiment_suite_json="$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))' <<< "$experiment_suite")"
 
           # run-evals takes priority; run-evals-changed only filters when run-evals is absent.
-          scope="all"
+          # filter_changed drives the changed-eval filter (PR-only, needs a PR diff).
+          filter_changed="false"
           if [ "${{ github.event_name }}" = "pull_request" ] && \
              [ "${{ contains(github.event.pull_request.labels.*.name, 'run-evals-changed') }}" = "true" ] && \
              [ "${{ contains(github.event.pull_request.labels.*.name, 'run-evals') }}" = "false" ]; then
-            scope="changed"
+            filter_changed="true"
           fi
 
           # do_merge drives the export --merge (graft into existing results). It's
           # always on for the changed path, and opt-in for manual dispatch.
-          do_merge="$([ "$scope" = "changed" ] && echo true || echo false)"
+          do_merge="$filter_changed"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.merge }}" = "true" ]; then
             do_merge="true"
           fi
@@ -128,7 +129,7 @@ jobs:
             echo "experiment_suite=$experiment_suite_json"
             echo "runs=$runs"
             echo "timeout_sec=$timeout_sec"
-            echo "scope=$scope"
+            echo "filter_changed=$filter_changed"
             echo "do_merge=$do_merge"
           } >> "$GITHUB_OUTPUT"
 
@@ -179,7 +180,7 @@ jobs:
             done
           fi
 
-          if [ "${{ steps.inputs.outputs.scope }}" = "changed" ]; then
+          if [ "${{ steps.inputs.outputs.filter_changed }}" = "true" ]; then
             changed_evals=$(gh pr diff ${{ github.event.pull_request.number }} --name-only \
               | grep '^evals/' | cut -d/ -f2 | sort -u || true)
 

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -370,9 +370,11 @@ jobs:
           fi
 
           if jq -e 'any(.[]; .eval_suite == "regression")' <<< "$pairs" > /dev/null; then
-            pnpm --filter @supabase-evals/framework export-results -- \
-              --suite regression \
-              --output apps/web/src/data/regression-eval-results.json
+            export_args=(--suite regression --output apps/web/src/data/regression-eval-results.json)
+            if [ "${{ needs.prepare.outputs.do_merge }}" = "true" ]; then
+              export_args+=(--merge)
+            fi
+            pnpm --filter @supabase-evals/framework export-results -- "${export_args[@]}"
           fi
 
       - name: Upload exported results

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -310,11 +310,25 @@ jobs:
     if: needs.prepare.outputs.pairs != '[]'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        # A GitHub App token is needed so the push below can trigger the
+        # gh-pages workflow: GITHUB_TOKEN pushes don't trigger other workflows.
+        # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+        if: >-
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch)
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           submodules: recursive
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -379,16 +393,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Generate GitHub App token
-        id: generate-token
-        if: >-
-          github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch)
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - name: Commit exported results to branch
         # PR runs commit to the PR head branch. Manual dispatch commits to the
         # selected branch only when commit_to_branch is enabled.
@@ -414,14 +418,7 @@ jobs:
           fi
 
           git commit -m "chore: refresh eval results"
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            # GITHUB_TOKEN pushes do not trigger the gh-pages push workflow:
-            # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
-            git remote set-url origin https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}
-            git push origin HEAD:main
-          else
-            git push
-          fi
+          git push
 
       - name: Create results pull request
         if: github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -364,9 +364,8 @@ jobs:
             jq -n \
               --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
               --arg evaluated_sha "$(git rev-parse HEAD)" \
-              --arg scope "${{ needs.prepare.outputs.scope }}" \
               --slurpfile results "$output" \
-              '{generatedAt: $generated_at, evaluatedSha: $evaluated_sha, scope: $scope, results: $results[0]}' \
+              '{generatedAt: $generated_at, evaluatedSha: $evaluated_sha, results: $results[0]}' \
               > "$output.tmp"
             mv "$output.tmp" "$output"
           fi

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -370,18 +370,9 @@ jobs:
           fi
 
           if jq -e 'any(.[]; .eval_suite == "regression")' <<< "$pairs" > /dev/null; then
-            output=apps/web/src/data/regression-eval-results.json
             pnpm --filter @supabase-evals/framework export-results -- \
               --suite regression \
-              --output "$output"
-
-            jq -n \
-              --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-              --arg evaluated_sha "$(git rev-parse HEAD)" \
-              --slurpfile results "$output" \
-              '{generatedAt: $generated_at, evaluatedSha: $evaluated_sha, results: $results[0]}' \
-              > "$output.tmp"
-            mv "$output.tmp" "$output"
+              --output apps/web/src/data/regression-eval-results.json
           fi
 
       - name: Upload exported results

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -37,6 +37,8 @@ on:
         type: boolean
         required: false
         default: false
+  schedule:
+    - cron: '15 6 * * *'
   pull_request:
     # Run whenever a PR carrying the run-evals label is opened, pushed to, or
     # receives the run-evals label. The job-level `if` gates on those cases.
@@ -56,6 +58,7 @@ jobs:
   prepare:
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'pull_request' &&
         (contains(github.event.pull_request.labels.*.name, 'run-evals') ||
          contains(github.event.pull_request.labels.*.name, 'run-evals-changed')) &&
@@ -65,14 +68,10 @@ jobs:
          github.event.label.name == 'run-evals-changed'))
     runs-on: ubuntu-latest
     outputs:
-      experiments: ${{ steps.discover-experiments.outputs.experiments }}
-      eval: ${{ steps.inputs.outputs.eval }}
-      evals: ${{ steps.discover.outputs.evals }}
-      suite: ${{ steps.inputs.outputs.suite }}
-      experiment_suite: ${{ steps.inputs.outputs.experiment_suite }}
+      pairs: ${{ steps.discover.outputs.pairs }}
       runs: ${{ steps.inputs.outputs.runs }}
       timeout_sec: ${{ steps.inputs.outputs.timeout_sec }}
-      filter_changed: ${{ steps.inputs.outputs.filter_changed }}
+      scope: ${{ steps.inputs.outputs.scope }}
       do_merge: ${{ steps.inputs.outputs.do_merge }}
     steps:
       - name: Prepare inputs
@@ -88,11 +87,18 @@ jobs:
             experiment_suite="${{ inputs.experiment_suite }}"
             runs="${{ inputs.runs }}"
             timeout_sec="${{ inputs.timeout_sec }}"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            experiments_override=""
+            eval_id=""
+            suite="regression"
+            experiment_suite="regression"
+            runs="2"
+            timeout_sec="720"
           else
             experiments_override=""
             eval_id=""
-            suite="benchmark"
-            experiment_suite="benchmark,no-skills"
+            suite="benchmark,regression"
+            experiment_suite="benchmark,no-skills,regression"
             runs="2"
             timeout_sec="720"
           fi
@@ -101,17 +107,16 @@ jobs:
           experiment_suite_json="$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))' <<< "$experiment_suite")"
 
           # run-evals takes priority; run-evals-changed only filters when run-evals is absent.
-          # filter_changed drives the changed-eval filter (PR-only, needs a PR diff).
-          filter_changed="false"
+          scope="all"
           if [ "${{ github.event_name }}" = "pull_request" ] && \
              [ "${{ contains(github.event.pull_request.labels.*.name, 'run-evals-changed') }}" = "true" ] && \
              [ "${{ contains(github.event.pull_request.labels.*.name, 'run-evals') }}" = "false" ]; then
-            filter_changed="true"
+            scope="changed"
           fi
 
           # do_merge drives the export --merge (graft into existing results). It's
           # always on for the changed path, and opt-in for manual dispatch.
-          do_merge="$filter_changed"
+          do_merge="$([ "$scope" = "changed" ] && echo true || echo false)"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.merge }}" = "true" ]; then
             do_merge="true"
           fi
@@ -123,7 +128,7 @@ jobs:
             echo "experiment_suite=$experiment_suite_json"
             echo "runs=$runs"
             echo "timeout_sec=$timeout_sec"
-            echo "filter_changed=$filter_changed"
+            echo "scope=$scope"
             echo "do_merge=$do_merge"
           } >> "$GITHUB_OUTPUT"
 
@@ -144,29 +149,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Discover experiments
-        id: discover-experiments
-        shell: bash
-        run: |
-          set -euo pipefail
-          touch .env
-          experiments_override="${{ steps.inputs.outputs.experiments_override }}"
-          if [ -n "$experiments_override" ]; then
-            experiments_json="$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))' <<< "$experiments_override")"
-          else
-            experiment_suite_args=()
-            while IFS= read -r s; do
-              experiment_suite_args+=("--experiment-suite" "$s")
-            done < <(jq -r '.[]' <<< '${{ steps.inputs.outputs.experiment_suite }}')
-            experiments_json="$(pnpm --silent eval -- list "${experiment_suite_args[@]}")"
-          fi
-          if [ "$(echo "$experiments_json" | jq 'length')" -eq 0 ]; then
-            echo "No experiments found for experiment suites: ${{ steps.inputs.outputs.experiment_suite }}" >&2
-            exit 1
-          fi
-          echo "experiments=$experiments_json" >> "$GITHUB_OUTPUT"
-
-      - name: Discover evals
+      - name: Discover eval pairs
         id: discover
         env:
           GH_TOKEN: ${{ github.token }}
@@ -174,40 +157,35 @@ jobs:
         run: |
           set -euo pipefail
 
+          touch .env
+          suite_json='${{ steps.inputs.outputs.suite }}'
           eval_ids="${{ steps.inputs.outputs.eval }}"
           if [ -n "$eval_ids" ]; then
-            evals_json="$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))' <<< "$eval_ids")"
-            echo "evals=$evals_json" >> "$GITHUB_OUTPUT"
-            exit 0
+            matching=()
+            while IFS= read -r id; do
+              [ -d "evals/$id" ] && matching+=("$id")
+            done < <(jq -r 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | .[]' <<< "$eval_ids")
+          else
+            matching=()
+            for dir in evals/*/; do
+              [ -d "$dir" ] || continue
+              id=$(basename "$dir")
+              prompt="$dir/PROMPT.md"
+              [ -f "$prompt" ] || continue
+              suite_val=$(sed -n 's/^suite:[[:space:]]*//p' "$prompt" | head -n 1)
+              if jq -e --arg s "$suite_val" 'index($s) != null' <<< "$suite_json" > /dev/null 2>&1; then
+                matching+=("$id")
+              fi
+            done
           fi
 
-          suite_json='${{ steps.inputs.outputs.suite }}'
-          matching=()
-          for dir in evals/*/; do
-            [ -d "$dir" ] || continue
-            id=$(basename "$dir")
-            prompt="$dir/PROMPT.md"
-            [ -f "$prompt" ] || continue
-            suite_val=$(sed -n 's/^suite:[[:space:]]*//p' "$prompt" | head -n 1)
-            suite_val="${suite_val:-regression}"
-            if jq -e --arg s "$suite_val" 'index($s) != null' <<< "$suite_json" > /dev/null 2>&1; then
-              matching+=("$id")
-            fi
-          done
-
-          if [ "${#matching[@]}" -eq 0 ]; then
-            echo "No evals found for suites: $suite_json" >&2
-            exit 1
-          fi
-
-          # Filter to only changed eval dirs when run-evals-changed label is active
-          if [ "${{ steps.inputs.outputs.filter_changed }}" = "true" ]; then
+          if [ "${{ steps.inputs.outputs.scope }}" = "changed" ]; then
             changed_evals=$(gh pr diff ${{ github.event.pull_request.number }} --name-only \
               | grep '^evals/' | cut -d/ -f2 | sort -u || true)
 
             if [ -z "$changed_evals" ]; then
               echo "No eval directories changed in this PR — nothing to run"
-              echo "evals=[]" >> "$GITHUB_OUTPUT"
+              echo "pairs=[]" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -223,22 +201,59 @@ jobs:
 
           if [ "${#matching[@]}" -eq 0 ]; then
             echo "Changed evals don't match requested suites: $suite_json"
-            echo "evals=[]" >> "$GITHUB_OUTPUT"
+            echo "pairs=[]" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          evals_json=$(printf '%s\n' "${matching[@]}" | jq -Rcs 'split("\n") | map(select(length > 0))')
-          echo "evals=$evals_json" >> "$GITHUB_OUTPUT"
+          pairs='[]'
+          experiments_override="${{ steps.inputs.outputs.experiments_override }}"
+          for id in "${matching[@]}"; do
+            eval_suite=$(sed -n 's/^suite:[[:space:]]*//p' "evals/$id/PROMPT.md" | head -n 1)
+            case "$eval_suite" in
+              benchmark) experiment_suites=(benchmark no-skills) ;;
+              regression) experiment_suites=(regression) ;;
+              *) continue ;;
+            esac
+
+            for experiment_suite in "${experiment_suites[@]}"; do
+              if ! jq -e --arg suite "$experiment_suite" 'index($suite) != null' \
+                <<< '${{ steps.inputs.outputs.experiment_suite }}' > /dev/null; then
+                continue
+              fi
+
+              if [ -n "$experiments_override" ]; then
+                experiments_json="$(jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))' <<< "$experiments_override")"
+              else
+                experiments_json="$(pnpm --silent eval -- list --experiment-suite "$experiment_suite")"
+              fi
+
+              while IFS= read -r experiment; do
+                pairs="$(jq -c \
+                  --arg eval_id "$id" \
+                  --arg experiment "$experiment" \
+                  --arg experiment_suite "$experiment_suite" \
+                  --arg eval_suite "$eval_suite" \
+                  '. + [{eval_id: $eval_id, experiment: $experiment, experiment_suite: $experiment_suite, eval_suite: $eval_suite}]' \
+                  <<< "$pairs")"
+              done < <(jq -r '.[]' <<< "$experiments_json")
+            done
+          done
+
+          if [ "$(jq 'length' <<< "$pairs")" -eq 0 ]; then
+            echo "No experiment and eval pairs matched" >&2
+            exit 1
+          fi
+
+          echo "pairs=$pairs" >> "$GITHUB_OUTPUT"
 
   run-evals:
     needs: prepare
-    if: needs.prepare.outputs.evals != '[]'
+    if: needs.prepare.outputs.pairs != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        experiment: ${{ fromJSON(needs.prepare.outputs.experiments) }}
-        eval_id: ${{ fromJSON(needs.prepare.outputs.evals) }}
+        include: ${{ fromJSON(needs.prepare.outputs.pairs) }}
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -278,6 +293,7 @@ jobs:
 
           pnpm eval -- \
             --experiment "${{ matrix.experiment }}" \
+            --experiment-suite "${{ matrix.experiment_suite }}" \
             --eval "${{ matrix.eval_id }}" \
             --runs "${{ needs.prepare.outputs.runs }}" \
             --timeout-sec "${{ needs.prepare.outputs.timeout_sec }}"
@@ -291,7 +307,7 @@ jobs:
 
   publish-results:
     needs: [prepare, run-evals]
-    if: needs.prepare.outputs.evals != '[]'
+    if: needs.prepare.outputs.pairs != '[]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -317,52 +333,66 @@ jobs:
         with:
           path: downloaded-results
 
-      - name: Export web results
+      - name: Export results
         shell: bash
         run: |
           set -euo pipefail
 
           mkdir -p results
-          export_args=()
-          while IFS= read -r experiment; do
-            mkdir -p "results/$experiment"
-            for artifact_dir in "downloaded-results/raw-results-${experiment}__"*/; do
-              [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. "results/$experiment"/
-            done
-            export_args+=("--experiment" "$experiment")
-          done < <(jq -r '.[]' <<< '${{ needs.prepare.outputs.experiments }}')
+          for artifact_dir in downloaded-results/raw-results-*/; do
+            [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. results/
+          done
 
-          while IFS= read -r suite; do
-            export_args+=("--suite" "$suite")
-          done < <(jq -r '.[]' <<< '${{ needs.prepare.outputs.suite }}')
-
-          while IFS= read -r experiment_suite; do
-            export_args+=("--experiment-suite" "$experiment_suite")
-          done < <(jq -r '.[]' <<< '${{ needs.prepare.outputs.experiment_suite }}')
-
-          if [ -n "${{ needs.prepare.outputs.eval }}" ]; then
-            export_args+=("--eval" "${{ needs.prepare.outputs.eval }}")
+          pairs='${{ needs.prepare.outputs.pairs }}'
+          if jq -e 'any(.[]; .eval_suite == "benchmark")' <<< "$pairs" > /dev/null; then
+            export_args=(--suite benchmark --output apps/web/src/data/eval-results.json)
+            if [ "${{ needs.prepare.outputs.do_merge }}" = "true" ]; then
+              export_args+=(--merge)
+            fi
+            pnpm --filter @supabase-evals/framework export-results -- "${export_args[@]}"
           fi
 
-          if [ "${{ needs.prepare.outputs.do_merge }}" = "true" ]; then
-            export_args+=("--merge")
-          fi
+          if jq -e 'any(.[]; .eval_suite == "regression")' <<< "$pairs" > /dev/null; then
+            output=apps/web/src/data/regression-eval-results.json
+            pnpm --filter @supabase-evals/framework export-results -- \
+              --suite regression \
+              --output "$output"
 
-          pnpm --filter @supabase-evals/framework export-results -- "${export_args[@]}"
+            jq -n \
+              --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+              --arg evaluated_sha "$(git rev-parse HEAD)" \
+              --arg scope "${{ needs.prepare.outputs.scope }}" \
+              --slurpfile results "$output" \
+              '{generatedAt: $generated_at, evaluatedSha: $evaluated_sha, scope: $scope, results: $results[0]}' \
+              > "$output.tmp"
+            mv "$output.tmp" "$output"
+          fi
 
       - name: Upload exported results
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: eval-results-json
-          path: apps/web/src/data/eval-results.json
+          path: apps/web/src/data/*eval-results.json
+          if-no-files-found: error
           retention-days: 7
+
+      - name: Generate GitHub App token
+        id: generate-token
+        if: >-
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch)
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Commit exported results to branch
         # PR runs commit to the PR head branch. Manual dispatch commits to the
         # selected branch only when commit_to_branch is enabled.
         if: >-
           github.event_name == 'pull_request' ||
+          github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.commit_to_branch)
         shell: bash
         run: |
@@ -372,7 +402,9 @@ jobs:
           # github-actions[bot]'s noreply email uses its public user ID: https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add apps/web/src/data/eval-results.json
+          for result_file in apps/web/src/data/*eval-results.json; do
+            [ -f "$result_file" ] && git add "$result_file"
+          done
 
           if git diff --cached --quiet; then
             echo "No eval result changes to commit"
@@ -380,22 +412,21 @@ jobs:
           fi
 
           git commit -m "chore: refresh eval results"
-          git push
-
-      - name: Generate GitHub App token
-        id: generate-token
-        if: github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            # GITHUB_TOKEN pushes do not trigger the gh-pages push workflow:
+            # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+            git remote set-url origin https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}
+            git push origin HEAD:main
+          else
+            git push
+          fi
 
       - name: Create results pull request
         if: github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          add-paths: apps/web/src/data/eval-results.json
+          add-paths: apps/web/src/data/*eval-results.json
           # Per-base head branch so a branch refresh PR can't collide with main's.
           branch: chore/refresh-eval-results-${{ github.ref_name }}
           base: ${{ github.ref_name }}

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -65,6 +65,10 @@ const EXPERIMENT_FILTERS = readRepeatedFlag(rawArgs, "experiment").map(
 const EVAL_FILTERS = readRepeatedFlag(rawArgs, "eval");
 const SUITE_FILTERS = readSuiteFilters(rawArgs);
 const EXPERIMENT_SUITE_FILTERS = readExperimentSuiteFilters(rawArgs);
+const SELECTED_EXPERIMENT_SUITE =
+  EXPERIMENT_SUITE_FILTERS.length === 1
+    ? EXPERIMENT_SUITE_FILTERS[0]
+    : undefined;
 const RUNS = Number(readFlag("runs") ?? 1);
 const TIMEOUT_SEC = Number(readFlag("timeout-sec") ?? 720);
 const CONCURRENCY = Number(readFlag("concurrency") ?? 1);
@@ -757,7 +761,7 @@ async function main() {
           JSON.stringify(
             {
               experiment: name,
-              experimentSuite: config.suite?.[0],
+              experimentSuite: SELECTED_EXPERIMENT_SUITE ?? config.suite?.[0],
               experimentDisplay,
               eval: ev.id,
               ...ev.metadata,

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -67,6 +67,16 @@ const SUITE_FILTERS = readSuiteFilters(rawArgs);
 const EXPERIMENT_SUITE_FILTERS = readExperimentSuiteFilters(rawArgs);
 const MERGE = rawArgs.includes("--merge");
 
+/** Reads an optional export destination relative to the repository root. */
+function readOutputPath(): string {
+  const inline = rawArgs.find((arg) => arg.startsWith("--output="));
+  const value =
+    inline?.slice("--output=".length) ?? readRepeatedFlag(rawArgs, "output")[0];
+  return value ? resolve(ROOT, value) : OUTPUT_PATH;
+}
+
+const outputPath = readOutputPath();
+
 async function readPrompt(evalId: string) {
   const promptPath = resolve(EVALS_DIR, evalId, "PROMPT.md");
   const normalizedEvalsDir = resolve(EVALS_DIR);
@@ -267,9 +277,9 @@ async function main() {
   }
 
   let results = newResults;
-  if (MERGE && existsSync(OUTPUT_PATH)) {
+  if (MERGE && existsSync(outputPath)) {
     const existing: EvalResult[] = JSON.parse(
-      await readFile(OUTPUT_PATH, "utf8"),
+      await readFile(outputPath, "utf8"),
     );
     const replaced = new Set(
       newResults.map((r) => `${r.experiment}::${r.eval}`),
@@ -284,12 +294,12 @@ async function main() {
     );
   }
 
-  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
-  await writeFile(OUTPUT_PATH, `${JSON.stringify(results, null, 2)}\n`);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(results, null, 2)}\n`);
 
   const passed = results.filter((result) => result.passed).length;
   console.log(
-    `Exported ${results.length} result(s) to ${relative(ROOT, OUTPUT_PATH)} ` +
+    `Exported ${results.length} result(s) to ${relative(ROOT, outputPath)} ` +
       `(${passed} pass, ${results.length - passed} fail)`,
   );
 }

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -67,15 +67,8 @@ const SUITE_FILTERS = readSuiteFilters(rawArgs);
 const EXPERIMENT_SUITE_FILTERS = readExperimentSuiteFilters(rawArgs);
 const MERGE = rawArgs.includes("--merge");
 
-/** Reads an optional export destination relative to the repository root. */
-function readOutputPath(): string {
-  const inline = rawArgs.find((arg) => arg.startsWith("--output="));
-  const value =
-    inline?.slice("--output=".length) ?? readRepeatedFlag(rawArgs, "output")[0];
-  return value ? resolve(ROOT, value) : OUTPUT_PATH;
-}
-
-const outputPath = readOutputPath();
+const OUTPUT_FLAG = readRepeatedFlag(rawArgs, "output")[0];
+const outputPath = OUTPUT_FLAG ? resolve(ROOT, OUTPUT_FLAG) : OUTPUT_PATH;
 
 async function readPrompt(evalId: string) {
   const promptPath = resolve(EVALS_DIR, evalId, "PROMPT.md");

--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-13T21:45:45Z",
-  "evaluatedSha": "f83d51d44f9f86b856fcc1925ad1ca34dd4f903b",
+  "generatedAt": "2026-07-13T23:31:12Z",
+  "evaluatedSha": "499586e64e24b771b38ffcca9af26f9d6673617e",
   "results": [
     {
       "experiment": "claude-code-sonnet-5",
@@ -31,7 +31,7 @@
         {
           "name": "did not recommend read replicas for Realtime",
           "passed": true,
-          "judgeNotes": "The answer correctly treats the request as a Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, provides postgres_changes client code, and does not recommend or imply read replicas are needed or useful."
+          "judgeNotes": "The answer treats the request as Supabase Realtime/Postgres Changes setup, adds public.messages to the supabase_realtime publication, provides a postgres_changes client snippet, and does not recommend read replicas or confuse them with logical replication/publications."
         }
       ],
       "skills": {
@@ -115,7 +115,7 @@
         {
           "name": "diagnosed secure default grants without weakening RLS",
           "passed": true,
-          "judgeNotes": "The answer correctly identifies secure-by-default Data API/table grant behavior as the root cause, distinguishes grants from RLS, notes existing owner-scoped RLS policies are correct, grants SELECT and INSERT only to authenticated, avoids anon/public, and keeps RLS intact."
+          "judgeNotes": "The answer correctly diagnoses missing table-level grants/Data API exposure separate from RLS, preserves existing owner-scoped RLS, grants only SELECT and INSERT on public.journal_entries to authenticated, does not grant anon/public, and keeps RLS enabled with verification."
         }
       ],
       "skills": {
@@ -155,7 +155,7 @@
         {
           "name": "answered unhealthy project recovery question safely",
           "passed": true,
-          "judgeNotes": "The answer correctly rejects pause/restore as the first recovery step, distinguishes restart from restore/pause, recommends restart as the immediate concrete step, and suggests follow-up checks like logs/advisors and scaling/performance tuning if recurring."
+          "judgeNotes": "The answer clearly says not to use pause/restore first, recommends restart as the first recovery step, distinguishes restart from pause/restore, mentions resource constraints/tuning and support, and points to Supabase troubleshooting docs. It could more explicitly define restore as backup/data recovery and include logs/waiting steps, but it provides concrete safe recovery guidance."
         }
       ],
       "skills": {

--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -1,0 +1,177 @@
+{
+  "generatedAt": "2026-07-13T21:11:39Z",
+  "evaluatedSha": "7068e743b58668b0beca92d2812363e8013df542",
+  "scope": "all",
+  "results": [
+    {
+      "experiment": "claude-code-sonnet-5",
+      "experimentSuite": "regression",
+      "experimentDisplay": {
+        "agent": "claude-code",
+        "modelProvider": "anthropic",
+        "modelId": "claude-sonnet-5",
+        "reasoningEffort": "high"
+      },
+      "eval": "build-realtime-001-live-chat-updates",
+      "stage": "build",
+      "product": [
+        "realtime",
+        "database"
+      ],
+      "topic": [
+        "sql"
+      ],
+      "suite": "regression",
+      "interface": "mcp",
+      "passed": true,
+      "checks": [
+        {
+          "name": "messages table added to supabase_realtime publication",
+          "passed": true
+        },
+        {
+          "name": "did not recommend read replicas for Realtime",
+          "passed": true,
+          "judgeNotes": "The assistant correctly treated the request as a Supabase Realtime/Postgres Changes setup, added tables to the supabase_realtime publication, provided postgres_changes client subscription code, and did not recommend or mention read replicas."
+        }
+      ],
+      "skills": {
+        "available": [
+          "supabase",
+          "supabase-postgres-best-practices"
+        ],
+        "loaded": [
+          "supabase"
+        ]
+      },
+      "prompt": "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
+      "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
+      "attempts": 1,
+      "sourcePath": "claude-code-sonnet-5/build-realtime-001-live-chat-updates.json"
+    },
+    {
+      "experiment": "claude-code-sonnet-5",
+      "experimentSuite": "regression",
+      "experimentDisplay": {
+        "agent": "claude-code",
+        "modelProvider": "anthropic",
+        "modelId": "claude-sonnet-5",
+        "reasoningEffort": "high"
+      },
+      "eval": "resolve-dataapi-002-secure-default-grants",
+      "stage": "resolve",
+      "product": [
+        "data-api",
+        "database",
+        "auth"
+      ],
+      "topic": [
+        "rls",
+        "sdk"
+      ],
+      "suite": "regression",
+      "interface": "cli",
+      "cliVersion": "2.109.1",
+      "passed": true,
+      "checks": [
+        {
+          "name": "auto_expose_new_tables is not enabled",
+          "passed": true
+        },
+        {
+          "name": "authenticated has explicit journal_entries SELECT and INSERT grants",
+          "passed": true,
+          "notes": "can_select=true, can_insert=true"
+        },
+        {
+          "name": "anon does not have journal_entries SELECT or INSERT grants",
+          "passed": true,
+          "notes": "can_select=false, can_insert=false"
+        },
+        {
+          "name": "RLS still enabled on journal_entries",
+          "passed": true
+        },
+        {
+          "name": "user A reads own journal entries",
+          "passed": true
+        },
+        {
+          "name": "user B cannot read user A journal entries",
+          "passed": true
+        },
+        {
+          "name": "anon reads no journal entries",
+          "passed": true,
+          "notes": "error 42501: permission denied for table journal_entries"
+        },
+        {
+          "name": "user A can save a new journal entry",
+          "passed": true
+        },
+        {
+          "name": "user B cannot insert a journal entry as user A",
+          "passed": true
+        },
+        {
+          "name": "diagnosed secure default grants without weakening RLS",
+          "passed": true,
+          "judgeNotes": "Diagnoses secure-by-default/restrictive Data API grants, distinguishes grants from RLS, preserves owner-scoped RLS, grants only SELECT/INSERT to authenticated, and does not grant anon/public or disable/weaken RLS."
+        }
+      ],
+      "skills": {
+        "available": [
+          "supabase",
+          "supabase-postgres-best-practices"
+        ],
+        "loaded": [
+          "supabase"
+        ]
+      },
+      "prompt": "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
+      "promptSourcePath": "evals/resolve-dataapi-002-secure-default-grants/PROMPT.md",
+      "attempts": 1,
+      "sourcePath": "claude-code-sonnet-5/resolve-dataapi-002-secure-default-grants.json"
+    },
+    {
+      "experiment": "claude-code-sonnet-5",
+      "experimentSuite": "regression",
+      "experimentDisplay": {
+        "agent": "claude-code",
+        "modelProvider": "anthropic",
+        "modelId": "claude-sonnet-5",
+        "reasoningEffort": "high"
+      },
+      "eval": "resolve-reliability-001-unhealthy-project-recovery",
+      "stage": "resolve",
+      "product": [
+        "database"
+      ],
+      "topic": [
+        "observability"
+      ],
+      "suite": "regression",
+      "passed": true,
+      "checks": [
+        {
+          "name": "answered unhealthy project recovery question safely",
+          "passed": true,
+          "judgeNotes": "The answer safely rejects pause/restore as the first recovery step, distinguishes restart from restore/backup recovery, and recommends concrete steps: restart, check logs/advisors, investigate overload, scale/tune, and contact support if unresolved."
+        }
+      ],
+      "skills": {
+        "available": [
+          "supabase",
+          "supabase-postgres-best-practices"
+        ],
+        "loaded": [
+          "supabase"
+        ]
+      },
+      "prompt": "My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?",
+      "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
+      "attempts": 1,
+      "sourcePath": "claude-code-sonnet-5/resolve-reliability-001-unhealthy-project-recovery.json"
+    }
+  ]
+}

--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -1,7 +1,6 @@
 {
-  "generatedAt": "2026-07-13T21:11:39Z",
-  "evaluatedSha": "7068e743b58668b0beca92d2812363e8013df542",
-  "scope": "all",
+  "generatedAt": "2026-07-13T21:45:45Z",
+  "evaluatedSha": "f83d51d44f9f86b856fcc1925ad1ca34dd4f903b",
   "results": [
     {
       "experiment": "claude-code-sonnet-5",
@@ -32,7 +31,7 @@
         {
           "name": "did not recommend read replicas for Realtime",
           "passed": true,
-          "judgeNotes": "The assistant correctly treated the request as a Supabase Realtime/Postgres Changes setup, added tables to the supabase_realtime publication, provided postgres_changes client subscription code, and did not recommend or mention read replicas."
+          "judgeNotes": "The answer correctly treats the request as a Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, provides postgres_changes client code, and does not recommend or imply read replicas are needed or useful."
         }
       ],
       "skills": {
@@ -116,7 +115,7 @@
         {
           "name": "diagnosed secure default grants without weakening RLS",
           "passed": true,
-          "judgeNotes": "Diagnoses secure-by-default/restrictive Data API grants, distinguishes grants from RLS, preserves owner-scoped RLS, grants only SELECT/INSERT to authenticated, and does not grant anon/public or disable/weaken RLS."
+          "judgeNotes": "The answer correctly identifies secure-by-default Data API/table grant behavior as the root cause, distinguishes grants from RLS, notes existing owner-scoped RLS policies are correct, grants SELECT and INSERT only to authenticated, avoids anon/public, and keeps RLS intact."
         }
       ],
       "skills": {
@@ -156,7 +155,7 @@
         {
           "name": "answered unhealthy project recovery question safely",
           "passed": true,
-          "judgeNotes": "The answer safely rejects pause/restore as the first recovery step, distinguishes restart from restore/backup recovery, and recommends concrete steps: restart, check logs/advisors, investigate overload, scale/tune, and contact support if unresolved."
+          "judgeNotes": "The answer correctly rejects pause/restore as the first recovery step, distinguishes restart from restore/pause, recommends restart as the immediate concrete step, and suggests follow-up checks like logs/advisors and scaling/performance tuning if recurring."
         }
       ],
       "skills": {

--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -1,176 +1,172 @@
-{
-  "generatedAt": "2026-07-13T21:45:45Z",
-  "evaluatedSha": "f83d51d44f9f86b856fcc1925ad1ca34dd4f903b",
-  "results": [
-    {
-      "experiment": "claude-code-sonnet-5",
-      "experimentSuite": "regression",
-      "experimentDisplay": {
-        "agent": "claude-code",
-        "modelProvider": "anthropic",
-        "modelId": "claude-sonnet-5",
-        "reasoningEffort": "high"
-      },
-      "eval": "build-realtime-001-live-chat-updates",
-      "stage": "build",
-      "product": [
-        "realtime",
-        "database"
-      ],
-      "topic": [
-        "sql"
-      ],
-      "suite": "regression",
-      "interface": "mcp",
-      "passed": true,
-      "checks": [
-        {
-          "name": "messages table added to supabase_realtime publication",
-          "passed": true
-        },
-        {
-          "name": "did not recommend read replicas for Realtime",
-          "passed": true,
-          "judgeNotes": "The answer correctly treats the request as a Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, provides postgres_changes client code, and does not recommend or imply read replicas are needed or useful."
-        }
-      ],
-      "skills": {
-        "available": [
-          "supabase",
-          "supabase-postgres-best-practices"
-        ],
-        "loaded": [
-          "supabase"
-        ]
-      },
-      "prompt": "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
-      "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
-      "attempts": 1,
-      "sourcePath": "claude-code-sonnet-5/build-realtime-001-live-chat-updates.json"
+[
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
     },
-    {
-      "experiment": "claude-code-sonnet-5",
-      "experimentSuite": "regression",
-      "experimentDisplay": {
-        "agent": "claude-code",
-        "modelProvider": "anthropic",
-        "modelId": "claude-sonnet-5",
-        "reasoningEffort": "high"
+    "eval": "build-realtime-001-live-chat-updates",
+    "stage": "build",
+    "product": [
+      "realtime",
+      "database"
+    ],
+    "topic": [
+      "sql"
+    ],
+    "suite": "regression",
+    "interface": "mcp",
+    "passed": true,
+    "checks": [
+      {
+        "name": "messages table added to supabase_realtime publication",
+        "passed": true
       },
-      "eval": "resolve-dataapi-002-secure-default-grants",
-      "stage": "resolve",
-      "product": [
-        "data-api",
-        "database",
-        "auth"
+      {
+        "name": "did not recommend read replicas for Realtime",
+        "passed": true,
+        "judgeNotes": "The answer correctly treats the request as a Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, provides postgres_changes client code, and does not recommend or imply read replicas are needed or useful."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
       ],
-      "topic": [
-        "rls",
-        "sdk"
-      ],
-      "suite": "regression",
-      "interface": "cli",
-      "cliVersion": "2.109.1",
-      "passed": true,
-      "checks": [
-        {
-          "name": "auto_expose_new_tables is not enabled",
-          "passed": true
-        },
-        {
-          "name": "authenticated has explicit journal_entries SELECT and INSERT grants",
-          "passed": true,
-          "notes": "can_select=true, can_insert=true"
-        },
-        {
-          "name": "anon does not have journal_entries SELECT or INSERT grants",
-          "passed": true,
-          "notes": "can_select=false, can_insert=false"
-        },
-        {
-          "name": "RLS still enabled on journal_entries",
-          "passed": true
-        },
-        {
-          "name": "user A reads own journal entries",
-          "passed": true
-        },
-        {
-          "name": "user B cannot read user A journal entries",
-          "passed": true
-        },
-        {
-          "name": "anon reads no journal entries",
-          "passed": true,
-          "notes": "error 42501: permission denied for table journal_entries"
-        },
-        {
-          "name": "user A can save a new journal entry",
-          "passed": true
-        },
-        {
-          "name": "user B cannot insert a journal entry as user A",
-          "passed": true
-        },
-        {
-          "name": "diagnosed secure default grants without weakening RLS",
-          "passed": true,
-          "judgeNotes": "The answer correctly identifies secure-by-default Data API/table grant behavior as the root cause, distinguishes grants from RLS, notes existing owner-scoped RLS policies are correct, grants SELECT and INSERT only to authenticated, avoids anon/public, and keeps RLS intact."
-        }
-      ],
-      "skills": {
-        "available": [
-          "supabase",
-          "supabase-postgres-best-practices"
-        ],
-        "loaded": [
-          "supabase"
-        ]
-      },
-      "prompt": "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
-      "promptSourcePath": "evals/resolve-dataapi-002-secure-default-grants/PROMPT.md",
-      "attempts": 1,
-      "sourcePath": "claude-code-sonnet-5/resolve-dataapi-002-secure-default-grants.json"
+      "loaded": [
+        "supabase"
+      ]
     },
-    {
-      "experiment": "claude-code-sonnet-5",
-      "experimentSuite": "regression",
-      "experimentDisplay": {
-        "agent": "claude-code",
-        "modelProvider": "anthropic",
-        "modelId": "claude-sonnet-5",
-        "reasoningEffort": "high"
+    "prompt": "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
+    "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5/build-realtime-001-live-chat-updates.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-dataapi-002-secure-default-grants",
+    "stage": "resolve",
+    "product": [
+      "data-api",
+      "database",
+      "auth"
+    ],
+    "topic": [
+      "rls",
+      "sdk"
+    ],
+    "suite": "regression",
+    "interface": "cli",
+    "cliVersion": "2.109.1",
+    "passed": true,
+    "checks": [
+      {
+        "name": "auto_expose_new_tables is not enabled",
+        "passed": true
       },
-      "eval": "resolve-reliability-001-unhealthy-project-recovery",
-      "stage": "resolve",
-      "product": [
-        "database"
-      ],
-      "topic": [
-        "observability"
-      ],
-      "suite": "regression",
-      "passed": true,
-      "checks": [
-        {
-          "name": "answered unhealthy project recovery question safely",
-          "passed": true,
-          "judgeNotes": "The answer correctly rejects pause/restore as the first recovery step, distinguishes restart from restore/pause, recommends restart as the immediate concrete step, and suggests follow-up checks like logs/advisors and scaling/performance tuning if recurring."
-        }
-      ],
-      "skills": {
-        "available": [
-          "supabase",
-          "supabase-postgres-best-practices"
-        ],
-        "loaded": [
-          "supabase"
-        ]
+      {
+        "name": "authenticated has explicit journal_entries SELECT and INSERT grants",
+        "passed": true,
+        "notes": "can_select=true, can_insert=true"
       },
-      "prompt": "My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?",
-      "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
-      "attempts": 1,
-      "sourcePath": "claude-code-sonnet-5/resolve-reliability-001-unhealthy-project-recovery.json"
-    }
-  ]
-}
+      {
+        "name": "anon does not have journal_entries SELECT or INSERT grants",
+        "passed": true,
+        "notes": "can_select=false, can_insert=false"
+      },
+      {
+        "name": "RLS still enabled on journal_entries",
+        "passed": true
+      },
+      {
+        "name": "user A reads own journal entries",
+        "passed": true
+      },
+      {
+        "name": "user B cannot read user A journal entries",
+        "passed": true
+      },
+      {
+        "name": "anon reads no journal entries",
+        "passed": true,
+        "notes": "error 42501: permission denied for table journal_entries"
+      },
+      {
+        "name": "user A can save a new journal entry",
+        "passed": true
+      },
+      {
+        "name": "user B cannot insert a journal entry as user A",
+        "passed": true
+      },
+      {
+        "name": "diagnosed secure default grants without weakening RLS",
+        "passed": true,
+        "judgeNotes": "The answer correctly identifies secure-by-default Data API/table grant behavior as the root cause, distinguishes grants from RLS, notes existing owner-scoped RLS policies are correct, grants SELECT and INSERT only to authenticated, avoids anon/public, and keeps RLS intact."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
+    "promptSourcePath": "evals/resolve-dataapi-002-secure-default-grants/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5/resolve-dataapi-002-secure-default-grants.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-reliability-001-unhealthy-project-recovery",
+    "stage": "resolve",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "observability"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "answered unhealthy project recovery question safely",
+        "passed": true,
+        "judgeNotes": "The answer correctly rejects pause/restore as the first recovery step, distinguishes restart from restore/pause, recommends restart as the immediate concrete step, and suggests follow-up checks like logs/advisors and scaling/performance tuning if recurring."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?",
+    "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5/resolve-reliability-001-unhealthy-project-recovery.json"
+  }
+]

--- a/experiments/claude-code-sonnet-5.ts
+++ b/experiments/claude-code-sonnet-5.ts
@@ -7,7 +7,7 @@ import {
 import { localStackRuntime } from "@supabase-evals/sandbox";
 
 export default defineExperiment({
-  suite: ["benchmark"],
+  suite: ["benchmark", "regression"],
   agent: claudeCodeAgent({
     model: "claude-sonnet-5",
     reasoningEffort: "high",

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -44,7 +44,11 @@ export const evalSuiteSchema = z.enum(["benchmark", "regression", "other"]);
 export const EVAL_SUITES = evalSuiteSchema.options;
 export type EvalSuite = z.infer<typeof evalSuiteSchema>;
 
-export const experimentSuiteSchema = z.enum(["benchmark", "no-skills"]);
+export const experimentSuiteSchema = z.enum([
+  "benchmark",
+  "no-skills",
+  "regression",
+]);
 export const EXPERIMENT_SUITES = experimentSuiteSchema.options;
 export type ExperimentSuite = z.infer<typeof experimentSuiteSchema>;
 


### PR DESCRIPTION
- Runs regression evals daily with Claude Sonnet 5 and commits reviewable snapshots.
- Runs benchmark evals against `benchmark,no-skills` and regression evals only against `regression` experiment suite
- Adds configurable `--output` destination for exported results file
- Includes commit `sha` in accumulated results file so we can correlate charts to source code more easily
- Appends scheduled regression snapshots to `gh-pages/regression-results.jsonl`.

I dispatched the workflow against this PR to show the generated regression eval results (all passing).

Closes AI-888
