### PR TITLE
fix(evals): accept secure 401/403 in service-role-bypass scorer

### DIFF
--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -4,7 +4,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { bootPlatformBackend } from "../harness/platform-backend.js";
 import { viteBuild, vitestRun } from "../harness/project-runner.js";
-import type { ToolScorer, TranscriptPart } from "../harness/types.js";
+import type {
+  EdgeFunctionsInvokeResult,
+  ToolEvalContext,
+  ToolScorer,
+  TranscriptPart,
+} from "../harness/types.js";
 import type { PlatformBackend } from "../harness/platform-backend.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..", "..");
@@ -19,6 +24,7 @@ if (!DEBUG) console.error = () => undefined;
 const CLIENT_RLS_EVAL = "evals/build-rls-002-own-todos-client";
 const FUNCTIONS_EVAL = "evals/build-functions-001-order-total";
 const EDGE_AUTH_DB_EVAL = "evals/build-functions-002-edge-auth-db";
+const SERVICE_ROLE_BYPASS_EVAL = "evals/build-functions-004-service-role-bypass";
 const INVESTIGATE_LOGS_EVAL = "evals/investigate-logs-001-top-error-function";
 const INVESTIGATE_SECURITY_EVAL = "evals/investigate-security-001-public-table";
 const FRONTEND_EVAL = "evals/build-frontend-001-todos-app";
@@ -47,6 +53,15 @@ function scorerCtx(
 
 function checksMessage(result: { checks?: unknown[] }) {
   return JSON.stringify(result.checks ?? []);
+}
+
+function failedCheckNames(result: {
+  checks?: { name: string; passed: boolean }[];
+}) {
+  return (
+    result.checks?.filter((check) => !check.passed).map((check) => check.name) ??
+    []
+  );
 }
 
 async function withBackend<T>(
@@ -113,6 +128,155 @@ async function smokeFunctionsEval() {
   });
 
   console.log("PASS functions scorer + edge-functions dispatcher");
+}
+
+function functionResponse(
+  status: number,
+  body = "",
+  outboundBearerTokens: string[] = [],
+): EdgeFunctionsInvokeResult {
+  return { type: "response", status, headers: {}, body, outboundBearerTokens };
+}
+
+function serviceRoleBypassCtx(
+  responses: EdgeFunctionsInvokeResult[],
+): ToolEvalContext {
+  const authResult = (id: string, accessToken: string) => ({
+    data: { user: { id }, session: { access_token: accessToken } },
+    error: null,
+  });
+  const clientA = {
+    auth: { signUp: async () => authResult("user-a", "token-a") },
+  } as unknown as ToolEvalContext["client"];
+  const clientB = {
+    auth: { signUp: async () => authResult("user-b", "token-b") },
+  } as unknown as ToolEvalContext["client"];
+
+  return {
+    mgmt: {} as ToolEvalContext["mgmt"],
+    ref: "test-ref",
+    client: clientA,
+    getClient: () => clientB,
+    query: async () => ({ rows: [] }),
+    invokeFunction: async () => {
+      const response = responses.shift();
+      if (!response) throw new Error("missing fake function response");
+      return response;
+    },
+    toolCalls: [],
+    transcript: [],
+  };
+}
+
+function serviceRoleResponses(
+  overrides: Partial<
+    Record<
+      "missingAuth" | "ownNotes" | "aRequestsB" | "bRequestsA",
+      EdgeFunctionsInvokeResult
+    >
+  > = {},
+): EdgeFunctionsInvokeResult[] {
+  return [
+    overrides.missingAuth ?? functionResponse(401),
+    overrides.ownNotes ??
+      functionResponse(200, "user A private note", ["token-a"]),
+    overrides.aRequestsB ?? functionResponse(401, "unauthorized"),
+    overrides.bRequestsA ?? functionResponse(403, "forbidden"),
+  ];
+}
+
+async function smokeServiceRoleBypassEval() {
+  const scorer = await loadScorer(SERVICE_ROLE_BYPASS_EVAL);
+
+  const secure = await scorer(
+    serviceRoleBypassCtx(serviceRoleResponses()),
+  );
+  assert.equal(secure.passed, true, checksMessage(secure));
+  assert.match(checksMessage(secure), /"notes":"status=401"/);
+  assert.match(checksMessage(secure), /"notes":"status=200"/);
+  assert.match(checksMessage(secure), /"notes":"status=403"/);
+  assert.match(
+    checksMessage(secure),
+    /"notes":"bearer_tokens=1, all_match=true"/,
+  );
+
+  const callerScoped = await scorer(
+    serviceRoleBypassCtx(
+      serviceRoleResponses({
+        aRequestsB: functionResponse(
+          200,
+          "user A private note",
+          ["token-a"],
+        ),
+        bRequestsA: functionResponse(
+          200,
+          "user B private note",
+          ["token-b"],
+        ),
+      }),
+    ),
+  );
+  assert.equal(callerScoped.passed, true, checksMessage(callerScoped));
+
+  const leaky = await scorer(
+    serviceRoleBypassCtx(
+      serviceRoleResponses({
+        aRequestsB: functionResponse(200, "user B private note"),
+        bRequestsA: functionResponse(403, "user A private note"),
+      }),
+    ),
+  );
+  assert.equal(leaky.passed, false, checksMessage(leaky));
+  assert.deepEqual(failedCheckNames(leaky), [
+    "user A cannot force-read user B note",
+    "user B cannot force-read user A note",
+  ]);
+  assert.match(checksMessage(leaky), /"notes":"status=200"/);
+  assert.match(checksMessage(leaky), /"notes":"status=403"/);
+
+  const ignoredAuth = await scorer(
+    serviceRoleBypassCtx(
+      serviceRoleResponses({
+        missingAuth: functionResponse(200),
+      }),
+    ),
+  );
+  assert.equal(ignoredAuth.passed, false, checksMessage(ignoredAuth));
+  assert.deepEqual(failedCheckNames(ignoredAuth), ["rejects missing auth"]);
+
+  const unauthenticatedLeak = await scorer(
+    serviceRoleBypassCtx(
+      serviceRoleResponses({
+        missingAuth: functionResponse(401, "user A private note"),
+      }),
+    ),
+  );
+  assert.equal(
+    unauthenticatedLeak.passed,
+    false,
+    checksMessage(unauthenticatedLeak),
+  );
+  assert.deepEqual(failedCheckNames(unauthenticatedLeak), [
+    "rejects missing auth",
+  ]);
+
+  const serviceRoleRead = await scorer(
+    serviceRoleBypassCtx(
+      serviceRoleResponses({
+        ownNotes: functionResponse(
+          200,
+          "user A private note",
+          ["service-role-key"],
+        ),
+      }),
+    ),
+  );
+  assert.equal(serviceRoleRead.passed, false, checksMessage(serviceRoleRead));
+  assert.deepEqual(failedCheckNames(serviceRoleRead), [
+    "reads only with the caller's JWT",
+  ]);
+
+  console.log("PASS service-role bypass scorer security contract");
 }
 
 async function smokeSupaliteClient() {
@@ -285,8 +449,13 @@ async function smokeFrontendBuildTooling() {
 }
 
 async function main() {
+  if (process.argv.includes("--service-role-bypass")) {
+    await smokeServiceRoleBypassEval();
+    return;
+  }
   await smokeClientRlsEval();
   await smokeFunctionsEval();
+  await smokeServiceRoleBypassEval();
   await smokeSupaliteClient();
   await smokePlatformBackendClose();
   await smokeEdgeAuthDbEval();

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -138,6 +138,12 @@ function functionResponse(
   return { type: "response", status, headers: {}, body, outboundBearerTokens };
 }
 
+// Unlike the other smokes, this one fakes the ToolEvalContext instead of
+// booting a real backend: the scorer's *decision logic* (which statuses and
+// bodies pass) is what we want to pin, and driving that through a real stack
+// would mean deploying six edge-function variants. `responses` are consumed in
+// the scorer's invocation order (missingAuth, ownNotes, aRequestsB, bRequestsA);
+// `serviceRoleResponses` builds them in that same order.
 function serviceRoleBypassCtx(
   responses: EdgeFunctionsInvokeResult[],
 ): ToolEvalContext {
@@ -168,6 +174,7 @@ function serviceRoleBypassCtx(
   };
 }
 
+// Order matches the scorer's invocation sequence; overrides are keyed by role.
 function serviceRoleResponses(
   overrides: Partial<
     Record<
@@ -187,10 +194,12 @@ function serviceRoleResponses(
 
 async function smokeServiceRoleBypassEval() {
   const scorer = await loadScorer(SERVICE_ROLE_BYPASS_EVAL);
+  const runScorer = (overrides?: Parameters<typeof serviceRoleResponses>[0]) =>
+    scorer(serviceRoleBypassCtx(serviceRoleResponses(overrides)));
 
-  const secure = await scorer(
-    serviceRoleBypassCtx(serviceRoleResponses()),
-  );
+  // The recommended secure fix: reject anonymous access, serve the caller their
+  // own note over their JWT, and deny forced cross-user reads.
+  const secure = await runScorer();
   assert.equal(secure.passed, true, checksMessage(secure));
   assert.match(checksMessage(secure), /"notes":"status=401"/);
   assert.match(checksMessage(secure), /"notes":"status=200"/);
@@ -200,32 +209,27 @@ async function smokeServiceRoleBypassEval() {
     /"notes":"bearer_tokens=1, all_match=true"/,
   );
 
-  const callerScoped = await scorer(
-    serviceRoleBypassCtx(
-      serviceRoleResponses({
-        aRequestsB: functionResponse(
-          200,
-          "user A private note",
-          ["token-a"],
-        ),
-        bRequestsA: functionResponse(
-          200,
-          "user B private note",
-          ["token-b"],
-        ),
-      }),
-    ),
-  );
+  // Ignoring the spoofed user_id and returning the caller's own note is the
+  // other secure shape the scorer must accept.
+  const callerScoped = await runScorer({
+    aRequestsB: functionResponse(200, "user A private note", ["token-a"]),
+    bRequestsA: functionResponse(200, "user B private note", ["token-b"]),
+  });
   assert.equal(callerScoped.passed, true, checksMessage(callerScoped));
 
-  const leaky = await scorer(
-    serviceRoleBypassCtx(
-      serviceRoleResponses({
-        aRequestsB: functionResponse(200, "user B private note"),
-        bRequestsA: functionResponse(403, "user A private note"),
-      }),
-    ),
-  );
+  // An RLS-scoped read of another user's note returns no rows, which a function
+  // may surface as 404. That is still a non-leaking denial.
+  const notFound = await runScorer({
+    aRequestsB: functionResponse(404, "not found"),
+    bRequestsA: functionResponse(404, "not found"),
+  });
+  assert.equal(notFound.passed, true, checksMessage(notFound));
+
+  // A leaked note fails regardless of status (200 or 403).
+  const leaky = await runScorer({
+    aRequestsB: functionResponse(200, "user B private note"),
+    bRequestsA: functionResponse(403, "user A private note"),
+  });
   assert.equal(leaky.passed, false, checksMessage(leaky));
   assert.deepEqual(failedCheckNames(leaky), [
     "user A cannot force-read user B note",
@@ -234,23 +238,15 @@ async function smokeServiceRoleBypassEval() {
   assert.match(checksMessage(leaky), /"notes":"status=200"/);
   assert.match(checksMessage(leaky), /"notes":"status=403"/);
 
-  const ignoredAuth = await scorer(
-    serviceRoleBypassCtx(
-      serviceRoleResponses({
-        missingAuth: functionResponse(200),
-      }),
-    ),
-  );
+  // Serving data to an unauthenticated caller fails, even with no leaked note.
+  const ignoredAuth = await runScorer({ missingAuth: functionResponse(200) });
   assert.equal(ignoredAuth.passed, false, checksMessage(ignoredAuth));
   assert.deepEqual(failedCheckNames(ignoredAuth), ["rejects missing auth"]);
 
-  const unauthenticatedLeak = await scorer(
-    serviceRoleBypassCtx(
-      serviceRoleResponses({
-        missingAuth: functionResponse(401, "user A private note"),
-      }),
-    ),
-  );
+  // A 401 that still echoes a note is a leak, not a denial.
+  const unauthenticatedLeak = await runScorer({
+    missingAuth: functionResponse(401, "user A private note"),
+  });
   assert.equal(
     unauthenticatedLeak.passed,
     false,
@@ -260,17 +256,10 @@ async function smokeServiceRoleBypassEval() {
     "rejects missing auth",
   ]);
 
-  const serviceRoleRead = await scorer(
-    serviceRoleBypassCtx(
-      serviceRoleResponses({
-        ownNotes: functionResponse(
-          200,
-          "user A private note",
-          ["service-role-key"],
-        ),
-      }),
-    ),
-  );
+  // Reading via the service-role key instead of the caller's JWT fails.
+  const serviceRoleRead = await runScorer({
+    ownNotes: functionResponse(200, "user A private note", ["service-role-key"]),
+  });
   assert.equal(serviceRoleRead.passed, false, checksMessage(serviceRoleRead));
   assert.deepEqual(failedCheckNames(serviceRoleRead), [
     "reads only with the caller's JWT",
@@ -449,10 +438,6 @@ async function smokeFrontendBuildTooling() {
 }
 
 async function main() {
-  if (process.argv.includes("--service-role-bypass")) {
-    await smokeServiceRoleBypassEval();
-    return;
-  }
   await smokeClientRlsEval();
   await smokeFunctionsEval();
   await smokeServiceRoleBypassEval();

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -259,23 +259,28 @@
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       }
     ],
     "skills": {
@@ -1328,23 +1333,28 @@
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       }
     ],
     "skills": {
@@ -2347,23 +2357,28 @@
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       }
     ],
     "skills": {
@@ -2371,13 +2386,11 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": [
-        "supabase"
-      ]
+      "loaded": []
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-sonnet-5/build-functions-004-service-role-bypass.json"
   },
   {
@@ -3416,23 +3429,28 @@
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       }
     ],
     "skills": {
@@ -3441,7 +3459,7 @@
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-sonnet-5-no-skills/build-functions-004-service-role-bypass.json"
   },
   {
@@ -4436,23 +4454,28 @@
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": true,
+        "notes": "status=403"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": true,
+        "notes": "status=403"
       }
     ],
     "skills": {
@@ -4461,7 +4484,8 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
       ]
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
@@ -5508,27 +5532,32 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": false
+        "passed": true,
+        "notes": "status=403"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": false
+        "passed": true,
+        "notes": "status=403"
       }
     ],
     "skills": {
@@ -5537,7 +5566,7 @@
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini-no-skills/build-functions-004-service-role-bypass.json"
   },
   {
@@ -6530,27 +6559,32 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": false
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": false
+        "passed": true,
+        "notes": "status=200"
       }
     ],
     "skills": {
@@ -6564,7 +6598,7 @@
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.5/build-functions-004-service-role-bypass.json"
   },
   {
@@ -7607,23 +7641,28 @@
     "checks": [
       {
         "name": "rejects missing auth",
-        "passed": true
+        "passed": true,
+        "notes": "status=401"
       },
       {
         "name": "user A reads own note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "reads only with the caller's JWT",
-        "passed": true
+        "passed": true,
+        "notes": "bearer_tokens=2, all_match=true"
       },
       {
         "name": "user A cannot force-read user B note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
-        "passed": true
+        "passed": true,
+        "notes": "status=200"
       }
     ],
     "skills": {

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -2386,11 +2386,13 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-sonnet-5/build-functions-004-service-role-bypass.json"
   },
   {
@@ -4470,12 +4472,12 @@
       {
         "name": "user A cannot force-read user B note",
         "passed": true,
-        "notes": "status=403"
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
         "passed": true,
-        "notes": "status=403"
+        "notes": "status=200"
       }
     ],
     "skills": {
@@ -4484,13 +4486,12 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
       ]
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini/build-functions-004-service-role-bypass.json"
   },
   {

--- a/evals/build-functions-004-service-role-bypass/EVAL.ts
+++ b/evals/build-functions-004-service-role-bypass/EVAL.ts
@@ -63,13 +63,23 @@ INSERT INTO private_notes (user_id, body) VALUES
     headers: authHeadersB,
   });
 
+  const ownNotesUsesCallerJwt =
+    ownNotes.type === "response" &&
+    ownNotes.outboundBearerTokens.length > 0 &&
+    ownNotes.outboundBearerTokens.every((token) => token === callerToken);
+
   const checks: CheckResult[] = [
     {
       name: "rejects missing auth",
       passed:
         missingAuth.type === "response" &&
-        (missingAuth.status === 401 || missingAuth.status === 403),
-      notes: missingAuth.type === "error" ? missingAuth.error : undefined,
+        (missingAuth.status === 401 || missingAuth.status === 403) &&
+        !missingAuth.body.includes(NOTE_A) &&
+        !missingAuth.body.includes(NOTE_B),
+      notes:
+        missingAuth.type === "response"
+          ? `status=${missingAuth.status}`
+          : missingAuth.error,
     },
     {
       name: "user A reads own note",
@@ -78,32 +88,45 @@ INSERT INTO private_notes (user_id, body) VALUES
         ownNotes.status === 200 &&
         ownNotes.body.includes(NOTE_A) &&
         !ownNotes.body.includes(NOTE_B),
-      notes: ownNotes.type === "error" ? ownNotes.error : undefined,
+      notes:
+        ownNotes.type === "response"
+          ? `status=${ownNotes.status}`
+          : ownNotes.error,
     },
     {
       // Reads should run as the signed-in user, never the service-role key.
       name: "reads only with the caller's JWT",
-      passed:
-        ownNotes.type === "response" &&
-        ownNotes.outboundBearerTokens.length > 0 &&
-        ownNotes.outboundBearerTokens.every((token) => token === callerToken),
-      notes: ownNotes.type === "error" ? ownNotes.error : undefined,
+      passed: ownNotesUsesCallerJwt,
+      notes:
+        ownNotes.type === "response"
+          ? `bearer_tokens=${ownNotes.outboundBearerTokens.length}, all_match=${ownNotesUsesCallerJwt}`
+          : ownNotes.error,
     },
     {
       name: "user A cannot force-read user B note",
       passed:
         aRequestsB.type === "response" &&
-        aRequestsB.status === 200 &&
+        (aRequestsB.status === 200 ||
+          aRequestsB.status === 401 ||
+          aRequestsB.status === 403) &&
         !aRequestsB.body.includes(NOTE_B),
-      notes: aRequestsB.type === "error" ? aRequestsB.error : undefined,
+      notes:
+        aRequestsB.type === "response"
+          ? `status=${aRequestsB.status}`
+          : aRequestsB.error,
     },
     {
       name: "user B cannot force-read user A note",
       passed:
         bRequestsA.type === "response" &&
-        bRequestsA.status === 200 &&
+        (bRequestsA.status === 200 ||
+          bRequestsA.status === 401 ||
+          bRequestsA.status === 403) &&
         !bRequestsA.body.includes(NOTE_A),
-      notes: bRequestsA.type === "error" ? bRequestsA.error : undefined,
+      notes:
+        bRequestsA.type === "response"
+          ? `status=${bRequestsA.status}`
+          : bRequestsA.error,
     },
   ];
 

--- a/evals/build-functions-004-service-role-bypass/EVAL.ts
+++ b/evals/build-functions-004-service-role-bypass/EVAL.ts
@@ -1,9 +1,37 @@
-import type { CheckResult, ToolScorer } from "@supabase-evals/core";
+import type {
+  CheckResult,
+  EdgeFunctionsInvokeResult,
+  ToolScorer,
+} from "@supabase-evals/core";
 
 const FUNCTION_NAME = "private-notes";
 const PASSWORD = "secret123";
 const NOTE_A = "user A private note";
 const NOTE_B = "user B private note";
+
+function responseNote(res: EdgeFunctionsInvokeResult): string | undefined {
+  return res.type === "response" ? `status=${res.status}` : res.error;
+}
+
+// A cross-user or unauthenticated request is secure as long as it returns a
+// graceful HTTP denial (or caller-scoped 200) and never echoes a forbidden
+// note. The exact status is left to the implementation; the no-leak invariant
+// is the real contract.
+function secureResponse(
+  name: string,
+  res: EdgeFunctionsInvokeResult,
+  acceptedStatuses: number[],
+  forbiddenNotes: string[],
+): CheckResult {
+  return {
+    name,
+    passed:
+      res.type === "response" &&
+      acceptedStatuses.includes(res.status) &&
+      forbiddenNotes.every((note) => !res.body.includes(note)),
+    notes: responseNote(res),
+  };
+}
 
 const scorer: ToolScorer = async (ctx) => {
   const clientA = ctx.client;
@@ -69,18 +97,12 @@ INSERT INTO private_notes (user_id, body) VALUES
     ownNotes.outboundBearerTokens.every((token) => token === callerToken);
 
   const checks: CheckResult[] = [
-    {
-      name: "rejects missing auth",
-      passed:
-        missingAuth.type === "response" &&
-        (missingAuth.status === 401 || missingAuth.status === 403) &&
-        !missingAuth.body.includes(NOTE_A) &&
-        !missingAuth.body.includes(NOTE_B),
-      notes:
-        missingAuth.type === "response"
-          ? `status=${missingAuth.status}`
-          : missingAuth.error,
-    },
+    secureResponse(
+      "rejects missing auth",
+      missingAuth,
+      [401, 403],
+      [NOTE_A, NOTE_B],
+    ),
     {
       name: "user A reads own note",
       passed:
@@ -88,10 +110,7 @@ INSERT INTO private_notes (user_id, body) VALUES
         ownNotes.status === 200 &&
         ownNotes.body.includes(NOTE_A) &&
         !ownNotes.body.includes(NOTE_B),
-      notes:
-        ownNotes.type === "response"
-          ? `status=${ownNotes.status}`
-          : ownNotes.error,
+      notes: responseNote(ownNotes),
     },
     {
       // Reads should run as the signed-in user, never the service-role key.
@@ -102,32 +121,18 @@ INSERT INTO private_notes (user_id, body) VALUES
           ? `bearer_tokens=${ownNotes.outboundBearerTokens.length}, all_match=${ownNotesUsesCallerJwt}`
           : ownNotes.error,
     },
-    {
-      name: "user A cannot force-read user B note",
-      passed:
-        aRequestsB.type === "response" &&
-        (aRequestsB.status === 200 ||
-          aRequestsB.status === 401 ||
-          aRequestsB.status === 403) &&
-        !aRequestsB.body.includes(NOTE_B),
-      notes:
-        aRequestsB.type === "response"
-          ? `status=${aRequestsB.status}`
-          : aRequestsB.error,
-    },
-    {
-      name: "user B cannot force-read user A note",
-      passed:
-        bRequestsA.type === "response" &&
-        (bRequestsA.status === 200 ||
-          bRequestsA.status === 401 ||
-          bRequestsA.status === 403) &&
-        !bRequestsA.body.includes(NOTE_A),
-      notes:
-        bRequestsA.type === "response"
-          ? `status=${bRequestsA.status}`
-          : bRequestsA.error,
-    },
+    secureResponse(
+      "user A cannot force-read user B note",
+      aRequestsB,
+      [200, 401, 403, 404],
+      [NOTE_B],
+    ),
+    secureResponse(
+      "user B cannot force-read user A note",
+      bRequestsA,
+      [200, 401, 403, 404],
+      [NOTE_A],
+    ),
   ];
 
   return { passed: checks.every((check) => check.passed), checks };


### PR DESCRIPTION
## Summary

- Accept any graceful, non-leaking response to a forced cross-user read: `200` scoped to the caller, or a `401`/`403`/`404` denial. The exact status is left to the implementation; the no-leak invariant is the real contract.
- Keep the no-leak invariant for every response and retain the caller-JWT requirement for reads.
- Add response-path diagnostics (`status=...`, bearer-token count) without logging bearer token values.
- Dedupe the denial checks behind a single `secureResponse` helper so the accepted-status policy and note format are single-sourced (previously the two force-read checks were copy-paste twins).
- Add focused scorer smoke coverage for every accepted and rejected shape (AI-918 falsifiability).

## Original run evidence

The [committed result export at `12b223d`](https://github.com/supabase/evals/blob/12b223dd96315a418c40d8f9ab9e6306ff81fb72/apps/web/src/data/eval-results.json) for [run 28895076929](https://github.com/supabase/evals/actions/runs/28895076929) records the with-skills run at 3/5, with exactly these checks failing:

- `user A cannot force-read user B note`
- `user B cannot force-read user A note`

The no-skills result finished at 5/5. Its job log shows attempt 1 at 3/5 before retrying to 5/5, while both with-skills attempts remained at 3/5. This matches the issue's documented difference: the secure skills implementation returned `403`, while the passing no-skills implementation returned caller-scoped `200` responses.

Retries previously masked this scorer bug in the no-skills condition. With this fix, both secure behaviors are accepted deterministically, so retry masking no longer applies to this scenario.

## Falsifiability

The smoke regression proves both accepted behaviors (secure `401`/`403`/`404` denials and caller-scoped `200` reads) and still fails implementations that:

- return another user's note in either a `200` or a denial response,
- ignore missing authentication,
- return a `401` that leaks note data,
- use a service-role bearer token for the user-facing read.

## Verification

- `pnpm test:framework`: reaches `PASS service-role bypass scorer security contract` (all secure/insecure scenarios), 15.63s. The run then hits the pre-existing frontend smoke failure (missing `node_modules/vite/bin/vite.js`), which reproduces on clean `main`.
- `pnpm --filter @supabase-evals/framework typecheck`: PASS (1.94s)
- [Changed-eval run 29333039515](https://github.com/supabase/evals/actions/runs/29333039515) on the first commit: all matrix jobs PASS; refreshed export in [`d234af9`](https://github.com/supabase/evals/commit/d234af96f31b282acdfcb88cf14ec244dcc8ceb0) shows `codex-gpt-5.4-mini` and `codex-gpt-5.4-mini-no-skills` both PASS with no failed checks. A fresh run re-validates the 404/restructure commit.
- No local compile or test step exceeded one minute.

Closes AI-910