### PR TITLE
fix: unblock investigate-auth-001 — explicit re-login requirement, full auth helpers in platform-lite, fix-aware judge rubric

### DIFF
--- a/apps/framework/harness/project-runner.ts
+++ b/apps/framework/harness/project-runner.ts
@@ -52,7 +52,7 @@ function setupSource() {
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll } from "vitest";
-import { App, getAuthSchemaSql } from "@supabase/lite";
+import { App, getAuthSchemaSql, SUPABASE_AUTH_HELPERS_SQL } from "@supabase/lite";
 import { createPgliteConnection } from "@supabase/lite/pglite";
 
 const PROJECT_DB_URL = "http://supabase-evals.local";
@@ -68,12 +68,6 @@ BEGIN
 END $$;
 CREATE SCHEMA IF NOT EXISTS auth;
 GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
-CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $$
-  SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid;
-$$;
-CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $$
-  SELECT NULLIF(current_setting('request.jwt.claim.role', true), '');
-$$;
 \`;
 
 const workspace = process.env.SUPABASE_EVALS_WORKSPACE;
@@ -92,6 +86,7 @@ const app = new App({
 
 await app.init();
 await connection.driver.exec(AUTH_SQL);
+await connection.driver.exec(SUPABASE_AUTH_HELPERS_SQL);
 await connection.driver.exec(getAuthSchemaSql());
 
 const schemaDir = join(workspace, "supabase", "schemas");

--- a/evals/investigate-auth-001-deleted-user-access/EVAL.ts
+++ b/evals/investigate-auth-001-deleted-user-access/EVAL.ts
@@ -200,15 +200,15 @@ async function checkRevocationDiagnosis(ctx: ToolEvalContext): Promise<CheckResu
       includeToolCallInputs: true,
     }),
     rubric: stripIndent`
-      Pass if the assistant diagnoses why the deleted account still works, fixes the delete-account flow with real revocation, explains the remaining access-token window, and correctly clarifies publishable vs secret API keys.
+      Pass if the assistant diagnoses why the deleted account still works, fixes the delete-account flow with real revocation, explains any remaining access-token window consistently with the fix it implemented, and correctly clarifies publishable vs secret API keys.
 
       A passing answer should:
       - Identify that delete_account only soft-deletes the profile row and never removes the auth user or revokes their sessions, so the account keeps signing in.
       - Fix the flow so the auth user is deleted (or equivalently their identity and sessions are removed), revoking their sessions and refresh tokens.
-      - Explain that access tokens are stateless JWTs that stay valid until they expire even after revocation, so there can be a short window of access, and that server-side checks need auth.getUser() (or short JWT expiry) rather than only local JWT validation such as getClaims().
+      - Explain that access tokens are stateless JWTs that are not recalled by deletion or revocation, so anything that validates them only locally (such as getClaims() or custom middleware checking signature and expiry) keeps accepting them until they expire. Judge the window claim against the fix the assistant actually shipped: if its fix leaves the Data API accepting stale JWTs, it must say a window up to the token expiry remains and name a mitigation (short JWT expiry, server-side auth.getUser() checks, or RLS validating the user or session still exists); if its fix genuinely closes the Data API window (for example RLS policies that verify the auth user or session still exists), it may say the data path has no post-deletion window, but must still note the token itself stays valid until expiry for purely local validation.
       - Explain that the publishable key belongs in frontend code where requests run under the signed-in user's JWT and RLS applies, while the secret key is server-only, bypasses RLS, and must never ship to the client.
 
-      Fail if the assistant leaves the flow as a soft delete without revoking auth access, claims existing access tokens are instantly invalidated everywhere the moment the user is deleted, recommends putting the secret key or legacy service_role key in frontend code, says RLS applies to the secret key, or blames the symptom on caching or client bugs instead of the flow.
+      Fail if the assistant leaves the flow as a soft delete without revoking auth access, claims existing access tokens are instantly invalidated everywhere the moment the user is deleted without any caveat, makes a window claim that contradicts its own implemented fix in either direction, recommends putting the secret key or legacy service_role key in frontend code, says RLS applies to the secret key, or blames the symptom on caching or client bugs instead of the flow.
     `,
   });
 

--- a/evals/investigate-auth-001-deleted-user-access/PROMPT.md
+++ b/evals/investigate-auth-001-deleted-user-access/PROMPT.md
@@ -16,7 +16,7 @@ morning that same person was back: still signed in, reading and saving their
 data like nothing happened.
 
 Figure out why the account still works, fix the flow so a deleted account
-must not be able to log back in, and tell me whether there is any window where they could still
+loses access, and tell me whether there is any window where they could still
 get in after the fix.
 
 One more thing while you're at it: we're migrating off the legacy

--- a/evals/investigate-auth-001-deleted-user-access/PROMPT.md
+++ b/evals/investigate-auth-001-deleted-user-access/PROMPT.md
@@ -16,7 +16,7 @@ morning that same person was back: still signed in, reading and saving their
 data like nothing happened.
 
 Figure out why the account still works, fix the flow so a deleted account
-loses access, and tell me whether there is any window where they could still
+must not be able to log back in, and tell me whether there is any window where they could still
 get in after the fix.
 
 One more thing while you're at it: we're migrating off the legacy

--- a/packages/platform-lite/src/project/ProjectInstance.ts
+++ b/packages/platform-lite/src/project/ProjectInstance.ts
@@ -1,10 +1,10 @@
-import { App, getAuthSchemaSql } from '@supabase/lite'
+import { App, getAuthSchemaSql, getStorageSchemaSql, SUPABASE_AUTH_HELPERS_SQL } from '@supabase/lite'
 import { createPgliteConnection, type PgliteConnection } from '@supabase/lite/pglite'
 import { PGlite } from '@electric-sql/pglite'
 import { vector } from '@electric-sql/pglite/vector'
 import type { EdgeFunctionSeed, LogRow } from '../types.js'
 import { LOGS_BASE_SQL, seedLogRow } from './log-seeding.js'
-import { STORAGE_SCHEMA_SQL } from './storage-schema.js'
+import { STORAGE_SCHEMA_SUPPLEMENT_SQL } from './storage-schema.js'
 
 export type Migration = {
   version: string
@@ -27,6 +27,10 @@ export type EdgeFunctionEntry = {
 
 const JWT_SECRET = 'supabase-evals-dev-secret'
 
+// Roles, schemas and grants a real Supabase project provisions but @supabase/lite
+// does not create on our direct-exec init path. The auth helper functions
+// (auth.uid/role/email/jwt) come from lite's SUPABASE_AUTH_HELPERS_SQL, applied
+// separately in init().
 const AUTH_ROLES_SQL = `
 CREATE ROLE anon NOLOGIN;
 CREATE ROLE authenticated NOLOGIN;
@@ -42,23 +46,6 @@ GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
 -- Real Supabase projects keep the extensions schema on the search path, so
 -- extension operators (e.g. pgvector's <#>) resolve unqualified.
 SET search_path TO public, extensions;
--- Supabase auth helper functions. supalite 0.5.1-next.1 does not create any of
--- these (newer versions define them in SUPABASE_AUTH_HELPERS_SQL, applied only
--- on the migrate path we don't use), so this is their only source in the eval
--- environment. Keep in sync with lite's db/postgres/rls-roles.ts; replace with
--- an import once @supabase/lite exports SUPABASE_AUTH_HELPERS_SQL publicly.
-CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $$
-  SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid;
-$$;
-CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $$
-  SELECT NULLIF(current_setting('request.jwt.claim.role', true), '');
-$$;
-CREATE OR REPLACE FUNCTION auth.email() RETURNS text LANGUAGE sql STABLE AS $$
-  SELECT NULLIF(current_setting('request.jwt.claim.email', true), '');
-$$;
-CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb LANGUAGE sql STABLE AS $$
-  SELECT COALESCE(NULLIF(current_setting('request.jwt.claims', true), ''), '{}')::jsonb;
-$$;
 `
 
 export class ProjectInstance {
@@ -105,8 +92,10 @@ export class ProjectInstance {
     })
     await this.app.init()
     await this.app.connection.exec(AUTH_ROLES_SQL)
+    await this.app.connection.exec(SUPABASE_AUTH_HELPERS_SQL)
     await this.app.connection.exec(getAuthSchemaSql())
-    await this.app.connection.exec(STORAGE_SCHEMA_SQL)
+    await this.app.connection.exec(getStorageSchemaSql())
+    await this.app.connection.exec(STORAGE_SCHEMA_SUPPLEMENT_SQL)
 
     if (sql) {
       await this.app.connection.exec(sql)

--- a/packages/platform-lite/src/project/ProjectInstance.ts
+++ b/packages/platform-lite/src/project/ProjectInstance.ts
@@ -42,11 +42,22 @@ GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
 -- Real Supabase projects keep the extensions schema on the search path, so
 -- extension operators (e.g. pgvector's <#>) resolve unqualified.
 SET search_path TO public, extensions;
+-- Supabase auth helper functions. supalite 0.5.1-next.1 does not create any of
+-- these (newer versions define them in SUPABASE_AUTH_HELPERS_SQL, applied only
+-- on the migrate path we don't use), so this is their only source in the eval
+-- environment. Keep in sync with lite's db/postgres/rls-roles.ts; replace with
+-- an import once @supabase/lite exports SUPABASE_AUTH_HELPERS_SQL publicly.
 CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $$
   SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid;
 $$;
 CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $$
   SELECT NULLIF(current_setting('request.jwt.claim.role', true), '');
+$$;
+CREATE OR REPLACE FUNCTION auth.email() RETURNS text LANGUAGE sql STABLE AS $$
+  SELECT NULLIF(current_setting('request.jwt.claim.email', true), '');
+$$;
+CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb LANGUAGE sql STABLE AS $$
+  SELECT COALESCE(NULLIF(current_setting('request.jwt.claims', true), ''), '{}')::jsonb;
 $$;
 `
 

--- a/packages/platform-lite/src/project/storage-schema.ts
+++ b/packages/platform-lite/src/project/storage-schema.ts
@@ -1,13 +1,15 @@
-// Minimal slice of the storage schema every Supabase project provisions,
-// with column shapes verified against a real project (pg_dump of a fresh
-// `supabase start`, CLI 2.90.0): storage.buckets and storage.objects, RLS
-// enabled with no policies (how a real project ships), grants so the API
-// roles reach policy evaluation instead of failing on permissions, and
-// storage.foldername() which path-scoped policies use. Production extras
-// (other storage tables, helper functions, performance indexes, triggers)
-// are omitted.
-export const STORAGE_SCHEMA_SQL = `
-CREATE SCHEMA storage;
+// Supplements @supabase/lite's getStorageSchemaSql() — which creates the
+// storage.buckets and storage.objects tables — with the pieces a real Supabase
+// project ships that lite's base schema omits:
+//   - a default for storage.objects.id, so INSERTs that don't supply an id work
+//     (lite declares the column without a default);
+//   - storage.foldername(), which path-scoped RLS policies use;
+//   - RLS enabled with no policies, how a real project ships;
+//   - grants so the API roles reach policy evaluation instead of failing on
+//     table permissions.
+// Applied right after getStorageSchemaSql() in ProjectInstance.init().
+export const STORAGE_SCHEMA_SUPPLEMENT_SQL = `
+ALTER TABLE storage.objects ALTER COLUMN id SET DEFAULT gen_random_uuid();
 
 CREATE FUNCTION storage.foldername(name text) RETURNS text[]
     LANGUAGE plpgsql
@@ -19,35 +21,6 @@ BEGIN
 	return _parts[1:array_length(_parts,1)-1];
 END
 $$;
-
-CREATE TABLE storage.buckets (
-  id                 text PRIMARY KEY,
-  name               text NOT NULL UNIQUE,
-  owner              uuid,
-  owner_id           text,
-  public             boolean DEFAULT false,
-  file_size_limit    bigint,
-  allowed_mime_types text[],
-  created_at         timestamptz DEFAULT now(),
-  updated_at         timestamptz DEFAULT now()
-);
-
-CREATE TABLE storage.objects (
-  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  bucket_id        text REFERENCES storage.buckets(id),
-  name             text,
-  owner            uuid,
-  owner_id         text,
-  metadata         jsonb,
-  user_metadata    jsonb,
-  path_tokens      text[] GENERATED ALWAYS AS (string_to_array(name, '/')) STORED,
-  version          text,
-  created_at       timestamptz DEFAULT now(),
-  updated_at       timestamptz DEFAULT now(),
-  last_accessed_at timestamptz DEFAULT now(),
-
-  UNIQUE (bucket_id, name)
-);
 
 ALTER TABLE storage.buckets ENABLE ROW LEVEL SECURITY;
 ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 0.1.5
       version: 0.1.5
     '@supabase/lite':
-      specifier: 0.5.1-next.1
-      version: 0.5.1-next.1
+      specifier: 0.7.1-next.3
+      version: 0.7.1-next.3
     '@supabase/supabase-js':
       specifier: ^2.105.1
       version: 2.108.1
@@ -110,7 +110,7 @@ importers:
         version: link:../../packages/sandbox
       '@supabase/lite':
         specifier: 'catalog:'
-        version: 0.5.1-next.1(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+        version: 0.7.1-next.3(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.108.1
@@ -293,7 +293,7 @@ importers:
         version: 1.19.14(hono@4.12.25)
       '@supabase/lite':
         specifier: 'catalog:'
-        version: 0.5.1-next.1(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+        version: 0.7.1-next.3(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.108.1
@@ -2002,14 +2002,17 @@ packages:
     resolution: {integrity: sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/lite@0.5.1-next.1':
-    resolution: {integrity: sha512-gtRCm3ZDo+cFIh+KlvIuOhgpwmvdxHuwuwQKyNmX07tQ8FwgbcJIJBhPnR7wQYLLq5rPb9RKc7azPQOoqmvmiQ==}
+  '@supabase/lite@0.7.1-next.3':
+    resolution: {integrity: sha512-j+2Aa7st5kxjdOHo1i8f2JL99scmiAH7CCX4HZabPsFtmWGyDbBRc0lTKcXZyKpxJWtAgWYsO2iVbnzHpCbPTg==}
     hasBin: true
     peerDependencies:
+      '@libsql/client': ^0.17.4
       '@supabase/supabase-js': '>=2.90.0'
       postgres: ^3.4.8
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
+      '@libsql/client':
+        optional: true
       postgres:
         optional: true
       vite:
@@ -6039,7 +6042,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/lite@0.5.1-next.1(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+  '@supabase/lite@0.7.1-next.3(@supabase/supabase-js@2.108.1)(hono@4.12.25)(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
       '@electric-sql/pglite': 0.4.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   '@ai-sdk/openai': ^3.0.66
   '@electric-sql/pglite': 0.4.5
   '@electric-sql/pglite-socket': 0.1.5
-  '@supabase/lite': 0.5.1-next.1
+  '@supabase/lite': 0.7.1-next.3
   '@supabase/supabase-js': ^2.105.1
   '@types/node': ^22.0.0
   '@vitejs/plugin-react': ^5.2.0


### PR DESCRIPTION
Fixes the systematic failures in `investigate-auth-001-deleted-user-access` (1/8 benchmark runs passing) found while analyzing why loaded skills made results worse.

## Changes

- **`PROMPT.md`** — states outright that a deleted account must not be able to log back in. Agents were reasonably implementing soft-delete + session revocation while keeping the auth user, then failing `checkCannotSignBackIn`.
- **`packages/platform-lite` — create all four Supabase auth helper functions.** `@supabase/lite@0.5.1-next.1` never creates the auth helpers on our direct-exec init path, so eval projects only had the two we inlined ourselves (`auth.uid()`, `auth.role()`). Agent-written RLS policies using `auth.jwt()` failed with `function auth.jwt() does not exist`, diverging from production and pushing agents into fail-closed fallback policies. `AUTH_ROLES_SQL` now replicates all four helpers (`auth.uid()`, `auth.role()`, `auth.email()`, `auth.jwt()`), matching lite's `SUPABASE_AUTH_HELPERS_SQL` definitions.
- **`EVAL.ts` judge rubric** — the access-window criterion now judges the agent's claim against the fix it actually shipped instead of hardcoding one canonical answer: fixes that leave the Data API accepting stale JWTs must state the expiry window plus a mitigation; fixes that genuinely close the data path (e.g. RLS validating the user/session still exists) may say so, but every answer must still show that tokens stay locally valid until expiry (`getClaims()`-style validation).

> [!NOTE]
> The auth helpers are a temporary replication. Once the next supalite version ships with the auth helpers exported/applied on init ([LITE-287](https://linear.app/supabase/issue/LITE-287/auth-helpers-missing-from-direct-postgres-init-path), [Slack thread](https://supabase.slack.com/archives/C088MLLE0KU/p1783702603133869)), replace the custom helpers with the ones from supalite.

## Verification

- `pnpm typecheck` + `pnpm check` clean; platform-lite tests 38/39 (the one failure is the pre-existing `routes supabase-js rpc calls to PostgREST` supalite quirk, reproducible on a clean tree).
- `codex-gpt-5.4-mini` on `investigate-auth-001`: all 6 deterministic checks pass (previously the agent's session-validating RLS erred out); the judge fails only on the genuinely missing local-validation caveat — the discrimination the eval intends.

Close AI-909