### PR TITLE
feat: include `claude-code-sonnet-5-no-skills` experiment in regression results

### DIFF
--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -168,5 +168,160 @@
     "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
     "attempts": 1,
     "sourcePath": "claude-code-sonnet-5/resolve-reliability-001-unhealthy-project-recovery.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-realtime-001-live-chat-updates",
+    "stage": "build",
+    "product": [
+      "realtime",
+      "database"
+    ],
+    "topic": [
+      "sql"
+    ],
+    "suite": "regression",
+    "interface": "mcp",
+    "passed": true,
+    "checks": [
+      {
+        "name": "messages table added to supabase_realtime publication",
+        "passed": true
+      },
+      {
+        "name": "did not recommend read replicas for Realtime",
+        "passed": true,
+        "judgeNotes": "The answer correctly treats the task as Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, provides a postgres_changes subscription snippet, and does not recommend or confuse read replicas."
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "prompt": "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
+    "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/build-realtime-001-live-chat-updates.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-dataapi-002-secure-default-grants",
+    "stage": "resolve",
+    "product": [
+      "data-api",
+      "database",
+      "auth"
+    ],
+    "topic": [
+      "rls",
+      "sdk"
+    ],
+    "suite": "regression",
+    "interface": "cli",
+    "cliVersion": "2.109.1",
+    "passed": true,
+    "checks": [
+      {
+        "name": "auto_expose_new_tables is not enabled",
+        "passed": true
+      },
+      {
+        "name": "authenticated has explicit journal_entries SELECT and INSERT grants",
+        "passed": true,
+        "notes": "can_select=true, can_insert=true"
+      },
+      {
+        "name": "anon does not have journal_entries SELECT or INSERT grants",
+        "passed": true,
+        "notes": "can_select=false, can_insert=false"
+      },
+      {
+        "name": "RLS still enabled on journal_entries",
+        "passed": true
+      },
+      {
+        "name": "user A reads own journal entries",
+        "passed": true
+      },
+      {
+        "name": "user B cannot read user A journal entries",
+        "passed": true
+      },
+      {
+        "name": "anon reads no journal entries",
+        "passed": true,
+        "notes": "error 42501: permission denied for table journal_entries"
+      },
+      {
+        "name": "user A can save a new journal entry",
+        "passed": true
+      },
+      {
+        "name": "user B cannot insert a journal entry as user A",
+        "passed": true
+      },
+      {
+        "name": "diagnosed secure default grants without weakening RLS",
+        "passed": true,
+        "judgeNotes": "Diagnoses missing Data API/table grants under secure-default behavior, distinguishes grants from RLS, preserves owner-scoped RLS, grants SELECT/INSERT to authenticated, and does not grant anon/public or weaken RLS. Extra service_role grant is not disqualifying."
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "prompt": "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
+    "promptSourcePath": "evals/resolve-dataapi-002-secure-default-grants/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/resolve-dataapi-002-secure-default-grants.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-reliability-001-unhealthy-project-recovery",
+    "stage": "resolve",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "observability"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "answered unhealthy project recovery question safely",
+        "passed": true,
+        "judgeNotes": "The answer clearly advises against pause/restore as the first recovery step, distinguishes restart from pause/restore, recommends restart first plus checking status/logs/advisors, and suggests support if dashboard access is blocked. It is safe and does not conflate restore with restart."
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "prompt": "My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?",
+    "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/resolve-reliability-001-unhealthy-project-recovery.json"
   }
 ]

--- a/experiments/claude-code-sonnet-5-no-skills.ts
+++ b/experiments/claude-code-sonnet-5-no-skills.ts
@@ -8,7 +8,7 @@ import { localStackRuntime } from "@supabase-evals/sandbox";
 
 // Same as claude-code-sonnet-5 but with no skills, to measure skills' impact.
 export default defineExperiment({
-  suite: ["no-skills"],
+  suite: ["no-skills", "regression"],
   agent: claudeCodeAgent({
     model: "claude-sonnet-5",
     reasoningEffort: "high",


### PR DESCRIPTION
Pairs the no-skills sonnet-5 experiment with the `regression` experiment suite so regression evals also get a no-skills variant, to see whether skills help edge cases more than benchmark scenarios.

Closes AI-937
