### PR TITLE
chore: mark debugging skill evals as regression suite

### DIFF
--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -140,6 +140,56 @@
       "modelId": "claude-sonnet-5",
       "reasoningEffort": "high"
     },
+    "eval": "investigate-functions-001-546-resource-limit",
+    "stage": "investigate",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "observability"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "identified video-thumbnails and the 546 resource-limit pattern",
+        "passed": true,
+        "judgeNotes": "Identified `video-thumbnails` as the affected function and explicitly recognized failures as HTTP 546 due to CPU/resource limit, not 500/503."
+      },
+      {
+        "name": "attributed the 546s to CPU time exhaustion",
+        "passed": true,
+        "judgeNotes": "The assistant specifically attributes the 546 failures to CPU time exhaustion, citing shutdown reason CPUTime and cpu_time_used=2000ms at cpu_time_limit=2000ms, and distinguishes it from wall-clock/network/code issues."
+      },
+      {
+        "name": "recommended reducing/offloading CPU work as the fix",
+        "passed": true,
+        "judgeNotes": "The assistant clearly recommends moving CPU-heavy video decoding/thumbnail extraction out of the Edge Function into an async/background worker or external/container service, and also suggests reducing inline CPU work by decoding only needed frames, downscaling, and routing oversized videos asynchronously. It explicitly says not to increase the CPU limit."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our `video-thumbnails` edge function has been failing intermittently since this morning. It generates a thumbnail from a user-uploaded video, and about half the calls are erroring out.\n\nCan you investigate the project logs and tell me what's going on and what we should do about it?",
+    "promptSourcePath": "evals/investigate-functions-001-546-resource-limit/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5/investigate-functions-001-546-resource-limit.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
     "eval": "resolve-dataapi-002-secure-default-grants",
     "stage": "resolve",
     "product": [
@@ -224,6 +274,60 @@
       "modelId": "claude-sonnet-5",
       "reasoningEffort": "high"
     },
+    "eval": "resolve-dataapi-002-update-zero-rows-affected",
+    "stage": "resolve",
+    "product": [
+      "data-api",
+      "database"
+    ],
+    "topic": [
+      "rls"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "RLS still enabled on tasks",
+        "passed": true
+      },
+      {
+        "name": "user A's update actually checks off their own task",
+        "passed": true,
+        "notes": "saw: [{\"id\":\"a5fd1475-664f-4723-9885-cd18d2aaa382\",\"is_done\":true}]"
+      },
+      {
+        "name": "user B cannot update user A's task",
+        "passed": true
+      },
+      {
+        "name": "diagnosed the missing USING clause and added it",
+        "passed": true,
+        "judgeNotes": "Diagnosed the missing USING clause on the UPDATE RLS policy, explained why WITH CHECK alone causes zero-row updates, and fixed it with a user_id = auth.uid() USING while preserving WITH CHECK and authenticated/owner scoping."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our app lets signed-in users manage a personal `tasks` list. Users can create tasks and check them off (`is_done`).\n\nCreating a task works fine, and I can see the row in the table. But when a user checks off a task, the app's update call succeeds with no error, yet `is_done` never actually changes, and the API doesn't return the updated row either.\n\nFind out why the update has no effect and fix it.",
+    "promptSourcePath": "evals/resolve-dataapi-002-update-zero-rows-affected/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5/resolve-dataapi-002-update-zero-rows-affected.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
     "eval": "resolve-reliability-001-unhealthy-project-recovery",
     "stage": "resolve",
     "product": [
@@ -254,6 +358,73 @@
     "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
     "attempts": 1,
     "sourcePath": "claude-code-sonnet-5/resolve-reliability-001-unhealthy-project-recovery.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-storage-001-upsert-missing-update-policy",
+    "stage": "resolve",
+    "product": [
+      "storage",
+      "database"
+    ],
+    "topic": [
+      "rls"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "bucket avatars exists",
+        "passed": true
+      },
+      {
+        "name": "bucket avatars stays public",
+        "passed": true,
+        "notes": "the bucket being public is intentional (avatars need a public URL); it is not the bug"
+      },
+      {
+        "name": "RLS still enabled on storage.objects",
+        "passed": true
+      },
+      {
+        "name": "anon can still read the public avatar",
+        "passed": true
+      },
+      {
+        "name": "user A can replace their own avatar via upsert",
+        "passed": true,
+        "notes": "saw: [{\"name\":\"019f6b4d-e03f-7180-87cb-a6467be87a16/avatar.png\",\"metadata\":{\"version\":\"replacement\"}}]"
+      },
+      {
+        "name": "user B cannot overwrite user A's avatar",
+        "passed": true
+      },
+      {
+        "name": "added an owner-scoped UPDATE policy without weakening public reads",
+        "passed": true,
+        "judgeNotes": "Diagnosed missing UPDATE policy for Supabase Storage upsert, distinguished public bucket/read from write/update permissions, added authenticated owner-scoped UPDATE policy with USING and WITH CHECK, and kept public read/RLS intact."
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "prompt": "Our app has a public `avatars` bucket so profile photos have a public URL. Each user's avatar is stored at `<user_id>/avatar.png`, and the app uploads it with `upsert: true` so a new photo replaces the old one at that same path.\n\nThe very first upload for a user always works, but replacing an existing avatar fails. Find out why and fix it.",
+    "promptSourcePath": "evals/resolve-storage-001-upsert-missing-update-policy/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5/resolve-storage-001-upsert-missing-update-policy.json"
   },
   {
     "experiment": "claude-code-sonnet-5-no-skills",
@@ -295,6 +466,51 @@
     "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
     "attempts": 1,
     "sourcePath": "claude-code-sonnet-5-no-skills/build-realtime-001-live-chat-updates.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "investigate-functions-001-546-resource-limit",
+    "stage": "investigate",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "observability"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "identified video-thumbnails and the 546 resource-limit pattern",
+        "passed": true,
+        "judgeNotes": "Identified `video-thumbnails` as the affected function and explicitly recognized HTTP 546 CPU/resource-limit shutdowns, not 500s/503s."
+      },
+      {
+        "name": "attributed the 546s to CPU time exhaustion",
+        "passed": true,
+        "judgeNotes": "The assistant explicitly attributes the 546 shutdowns to CPU time exhaustion, citing log evidence: `shutdown (reason: CPUTime, cpu_time_used: 2000ms, cpu_time_limit: 2000ms)`, and explains this as hitting the CPU cap rather than memory, wall-clock time, exceptions, or unrelated errors."
+      },
+      {
+        "name": "recommended reducing/offloading CPU work as the fix",
+        "passed": true,
+        "judgeNotes": "The assistant explicitly recommends reducing CPU cost per call and moving CPU-heavy thumbnail generation off the Edge Function hot path to a background worker/external processing service. It does not rely only on retries, timeouts, or raising limits."
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "prompt": "Our `video-thumbnails` edge function has been failing intermittently since this morning. It generates a thumbnail from a user-uploaded video, and about half the calls are erroring out.\n\nCan you investigate the project logs and tell me what's going on and what we should do about it?",
+    "promptSourcePath": "evals/investigate-functions-001-546-resource-limit/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/investigate-functions-001-546-resource-limit.json"
   },
   {
     "experiment": "claude-code-sonnet-5-no-skills",
@@ -384,6 +600,55 @@
       "modelId": "claude-sonnet-5",
       "reasoningEffort": "high"
     },
+    "eval": "resolve-dataapi-002-update-zero-rows-affected",
+    "stage": "resolve",
+    "product": [
+      "data-api",
+      "database"
+    ],
+    "topic": [
+      "rls"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "RLS still enabled on tasks",
+        "passed": true
+      },
+      {
+        "name": "user A's update actually checks off their own task",
+        "passed": true,
+        "notes": "saw: [{\"id\":\"6d830c6f-831f-421b-97b0-73d45aabc9f3\",\"is_done\":true}]"
+      },
+      {
+        "name": "user B cannot update user A's task",
+        "passed": true
+      },
+      {
+        "name": "diagnosed the missing USING clause and added it",
+        "passed": true,
+        "judgeNotes": "Diagnosed the silent zero-row UPDATE as the tasks UPDATE RLS policy missing a USING clause, explained WITH CHECK vs USING behavior, and fixed it by adding owner-scoped USING while preserving WITH CHECK and authenticated/user isolation."
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "prompt": "Our app lets signed-in users manage a personal `tasks` list. Users can create tasks and check them off (`is_done`).\n\nCreating a task works fine, and I can see the row in the table. But when a user checks off a task, the app's update call succeeds with no error, yet `is_done` never actually changes, and the API doesn't return the updated row either.\n\nFind out why the update has no effect and fix it.",
+    "promptSourcePath": "evals/resolve-dataapi-002-update-zero-rows-affected/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/resolve-dataapi-002-update-zero-rows-affected.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
     "eval": "resolve-reliability-001-unhealthy-project-recovery",
     "stage": "resolve",
     "product": [
@@ -409,5 +674,67 @@
     "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
     "attempts": 1,
     "sourcePath": "claude-code-sonnet-5-no-skills/resolve-reliability-001-unhealthy-project-recovery.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "resolve-storage-001-upsert-missing-update-policy",
+    "stage": "resolve",
+    "product": [
+      "storage",
+      "database"
+    ],
+    "topic": [
+      "rls"
+    ],
+    "suite": "regression",
+    "passed": true,
+    "checks": [
+      {
+        "name": "bucket avatars exists",
+        "passed": true
+      },
+      {
+        "name": "bucket avatars stays public",
+        "passed": true,
+        "notes": "the bucket being public is intentional (avatars need a public URL); it is not the bug"
+      },
+      {
+        "name": "RLS still enabled on storage.objects",
+        "passed": true
+      },
+      {
+        "name": "anon can still read the public avatar",
+        "passed": true
+      },
+      {
+        "name": "user A can replace their own avatar via upsert",
+        "passed": true,
+        "notes": "saw: [{\"name\":\"019f6b4d-a79d-7121-84f4-2001ba455934/avatar.png\",\"metadata\":{\"version\":\"replacement\"}}]"
+      },
+      {
+        "name": "user B cannot overwrite user A's avatar",
+        "passed": true
+      },
+      {
+        "name": "added an owner-scoped UPDATE policy without weakening public reads",
+        "passed": true,
+        "judgeNotes": "Diagnosed missing UPDATE RLS policy for upsert replacement, kept public read/RLS intact, and added authenticated owner-scoped UPDATE policy with USING and WITH CHECK."
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "prompt": "Our app has a public `avatars` bucket so profile photos have a public URL. Each user's avatar is stored at `<user_id>/avatar.png`, and the app uploads it with `upsert: true` so a new photo replaces the old one at that same path.\n\nThe very first upload for a user always works, but replacing an existing avatar fails. Find out why and fix it.",
+    "promptSourcePath": "evals/resolve-storage-001-upsert-missing-update-policy/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/resolve-storage-001-upsert-missing-update-policy.json"
   }
 ]

--- a/evals/investigate-functions-001-546-resource-limit/PROMPT.md
+++ b/evals/investigate-functions-001-546-resource-limit/PROMPT.md
@@ -1,6 +1,6 @@
 ---
 stage: investigate
-suite: benchmark
+suite: regression
 product:
   - edge-functions
 topic:

--- a/evals/resolve-dataapi-002-update-zero-rows-affected/PROMPT.md
+++ b/evals/resolve-dataapi-002-update-zero-rows-affected/PROMPT.md
@@ -1,6 +1,6 @@
 ---
 stage: resolve
-suite: benchmark
+suite: regression
 product:
   - data-api
   - database

--- a/evals/resolve-storage-001-upsert-missing-update-policy/PROMPT.md
+++ b/evals/resolve-storage-001-upsert-missing-update-policy/PROMPT.md
@@ -1,6 +1,6 @@
 ---
 stage: resolve
-suite: benchmark
+suite: regression
 product:
   - storage
   - database


### PR DESCRIPTION
Flips `suite` from `benchmark` to `regression` for the 3 debugging evals added in #79 based on tentative results from [this run](https://github.com/supabase/evals/actions/runs/29460030347) until we can review results more closely ([context](https://supabase.slack.com/archives/C051L8U2EJF/p1784162695187869?thread_ts=1783679169.518959&cid=C051L8U2EJF))

24/24 checks pass in refreshed results