### PR TITLE
feat: track docs activation in eval results

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -344,14 +344,27 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download raw results
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: downloaded-results
+        # actions/download-artifact only nests a downloaded artifact under a
+        # directory named after it when there's more than one to disambiguate;
+        # with exactly one matching pair it dumps the contents flat into
+        # `path`, silently breaking the per-experiment glob below. Naming the
+        # destination directory ourselves side-steps that inconsistency.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p downloaded-results
+          pairs='${{ needs.prepare.outputs.pairs }}'
+          while IFS= read -r name; do
+            gh run download ${{ github.run_id }} --name "$name" --dir "downloaded-results/$name"
+          done < <(jq -r '.[] | "raw-results-\(.experiment)__\(.eval_id)"' <<< "$pairs" | sort -u)
 
       - name: Export results
         shell: bash
         run: |
-          set -euxo pipefail
+          set -euo pipefail
 
           mkdir -p results
           pairs='${{ needs.prepare.outputs.pairs }}'
@@ -361,11 +374,6 @@ jobs:
               [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. "results/$experiment"/
             done
           done < <(jq -r '.[].experiment' <<< "$pairs" | sort -u)
-
-          echo "::group::DEBUG tree"
-          find downloaded-results -maxdepth 4
-          find results -maxdepth 4
-          echo "::endgroup::"
 
           if jq -e 'any(.[]; .eval_suite == "benchmark")' <<< "$pairs" > /dev/null; then
             export_args=(--suite benchmark --output apps/web/src/data/eval-results.json)

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -47,6 +47,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 concurrency:
   group: eval-refresh-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -351,7 +351,7 @@ jobs:
       - name: Export results
         shell: bash
         run: |
-          set -euo pipefail
+          set -euxo pipefail
 
           mkdir -p results
           pairs='${{ needs.prepare.outputs.pairs }}'
@@ -361,6 +361,11 @@ jobs:
               [ -d "$artifact_dir" ] && cp -R "$artifact_dir"/. "results/$experiment"/
             done
           done < <(jq -r '.[].experiment' <<< "$pairs" | sort -u)
+
+          echo "::group::DEBUG tree"
+          find downloaded-results -maxdepth 4
+          find results -maxdepth 4
+          echo "::endgroup::"
 
           if jq -e 'any(.[]; .eval_suite == "benchmark")' <<< "$pairs" > /dev/null; then
             export_args=(--suite benchmark --output apps/web/src/data/eval-results.json)

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -165,7 +165,7 @@ jobs:
             matching=()
             while IFS= read -r id; do
               [ -d "evals/$id" ] && matching+=("$id")
-            done < <(jq -r 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | .[]' <<< "$eval_ids")
+            done < <(jq -Rr 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | .[]' <<< "$eval_ids")
           else
             matching=()
             for dir in evals/*/; do

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -28,6 +28,7 @@ import {
 import { bootPlatformBackend } from "./platform-backend.js";
 import { viteBuild, vitestRun } from "./project-runner.js";
 import {
+  buildDocsResult,
   buildSkillResult,
   getExperimentDisplayMetadata,
 } from "@supabase-evals/core";
@@ -41,6 +42,7 @@ import type {
   LocalStackScorer,
   ScoreResult,
   SkillResult,
+  DocsResult,
   ToolCallRecord,
   TranscriptPart,
 } from "./types.js";
@@ -352,6 +354,7 @@ async function runOne(
   ScoreResult & {
     attempts: number;
     skills: SkillResult;
+    docs: DocsResult;
     toolCalls: ToolCallRecord[];
     transcript: TranscriptPart[];
     agentReport: string;
@@ -484,6 +487,7 @@ async function runOne(
           ...last,
           attempts: attempt,
           skills: buildSkillResult(availableSkills, run.toolCalls),
+          docs: buildDocsResult(run.toolCalls),
           toolCalls: run.toolCalls,
           transcript: run.transcript,
           agentReport: run.agentReport,
@@ -546,6 +550,7 @@ async function runOne(
         ...last,
         attempts: attempt,
         skills: buildSkillResult(availableSkills, run.toolCalls),
+        docs: buildDocsResult(run.toolCalls),
         toolCalls: run.toolCalls,
         transcript: run.transcript,
         agentReport: run.agentReport,
@@ -559,6 +564,7 @@ async function runOne(
     ...last,
     attempts: RUNS,
     skills: buildSkillResult(availableSkills, lastToolCalls),
+    docs: buildDocsResult(lastToolCalls),
     toolCalls: lastToolCalls,
     transcript: lastTranscript,
     agentReport: lastAgentReport,

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -30,6 +30,7 @@ import { viteBuild, vitestRun } from "./project-runner.js";
 import {
   buildDocsResult,
   buildSkillResult,
+  rehydrateTruncatedDocsResults,
   getExperimentDisplayMetadata,
 } from "@supabase-evals/core";
 import type {
@@ -449,6 +450,9 @@ async function runOne(
         mcpServers: session.mcpServers,
         timeoutSec: TIMEOUT_SEC,
       });
+      // Must happen before `session` disposes below: a truncated docs result
+      // is persisted inside the sandbox container, unreachable once it's torn down.
+      await rehydrateTruncatedDocsResults(session.sandbox, run.toolCalls);
 
       lastToolCalls = run.toolCalls;
       lastTranscript = run.transcript;
@@ -533,6 +537,9 @@ async function runOne(
       sandbox: cliSandbox?.sandbox,
       timeoutSec: TIMEOUT_SEC,
     });
+    // Must happen before `cliSandbox` disposes below: a truncated docs result
+    // is persisted inside the sandbox container, unreachable once it's torn down.
+    if (cliSandbox) await rehydrateTruncatedDocsResults(cliSandbox.sandbox, run.toolCalls);
 
     lastToolCalls = run.toolCalls;
     lastTranscript = run.transcript;

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -450,8 +450,7 @@ async function runOne(
         mcpServers: session.mcpServers,
         timeoutSec: TIMEOUT_SEC,
       });
-      // Must happen before `session` disposes below: a truncated docs result
-      // is persisted inside the sandbox container, unreachable once it's torn down.
+      // Must run before session disposes below, see rehydrateTruncatedDocsResults.
       await rehydrateTruncatedDocsResults(session.sandbox, run.toolCalls);
 
       lastToolCalls = run.toolCalls;
@@ -537,8 +536,7 @@ async function runOne(
       sandbox: cliSandbox?.sandbox,
       timeoutSec: TIMEOUT_SEC,
     });
-    // Must happen before `cliSandbox` disposes below: a truncated docs result
-    // is persisted inside the sandbox container, unreachable once it's torn down.
+    // Must run before cliSandbox disposes below, see rehydrateTruncatedDocsResults.
     if (cliSandbox) await rehydrateTruncatedDocsResults(cliSandbox.sandbox, run.toolCalls);
 
     lastToolCalls = run.toolCalls;

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -15,6 +15,7 @@ export type {
   JudgeResult,
   CommandResult,
   SkillResult,
+  DocsResult,
   VitestResult,
   ProjectResult,
   EdgeFunctionsInvokeInput,

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -128,6 +128,7 @@ async function readResultFile(
     passed: parsedResult.passed === true,
     checks: parsedResult.checks,
     skills: parsedResult.skills,
+    docs: parsedResult.docs,
     prompt: promptData?.prompt,
     promptSourcePath: promptData?.promptSourcePath,
     attempts: parsedResult.attempts,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
-import { BotIcon, CheckIcon, CopyIcon, XIcon } from "lucide-react"
+import { BotIcon, CheckIcon, CopyIcon, FileTextIcon, SearchIcon, XIcon } from "lucide-react"
 import { z } from "zod"
 import {
   evalResultSchema,
@@ -70,6 +70,46 @@ type ParsedResult = Omit<EvalResult, "product" | "topic"> & {
 }
 
 type CheckResult = NonNullable<ParsedResult["checks"]>[number]
+type DocsResult = NonNullable<ParsedResult["docs"]>
+type DocsCall = DocsResult["calls"][number]
+
+const DOCS_CALL_SOURCE_LABEL: Record<DocsCall["source"], string> = {
+  search_docs: "MCP",
+  web_fetch: "Web Fetch",
+  web_search: "Web Search",
+}
+
+// A cool color for MCP (our own docs tool) vs a warm one for the agent going
+// around it onto the open web, so both read clearly and stand apart.
+const DOCS_CALL_SOURCE_CHIP_CLASS: Record<DocsCall["source"], string> = {
+  search_docs: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-400",
+  web_fetch: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  web_search: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+}
+
+/**
+ * Search icon (muted) for a bare hit, a file icon for a call that actually
+ * pulled in page text, so the read-state lives on the icon rather than on
+ * the source chip, which is a different kind of information (which tool,
+ * not how much it read).
+ */
+function docsCallIcon(call: DocsCall) {
+  return call.hasContent === false ? SearchIcon : FileTextIcon
+}
+
+/**
+ * search_docs's `query` is a raw GraphQL document; pull out just the quoted
+ * search term for display, the rest is our own tool's plumbing, not
+ * something a reader needs to see at a glance. Falls back to the raw query
+ * (already plain text for web_fetch/web_search) if the shape is unexpected.
+ */
+function docsCallQueryLabel(call: DocsCall): string {
+  if (call.source === "search_docs") {
+    const match = call.query.match(/query:\s*"((?:[^"\\]|\\.)*)"/)
+    if (match) return match[1]
+  }
+  return call.query
+}
 
 type ExperimentStageSummary = {
   experiment: string
@@ -515,6 +555,61 @@ function ResultChecks({ checks }: { checks: CheckResult[] }) {
               </details>
             ) : null}
           </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * One row per tool call an agent made toward the docs (not one per page):
+ * the query it used, collapsed by default, expanding to the pages that call
+ * actually returned. Matches how the agent itself acts, issue one call, get
+ * a batch of results back together, rather than flattening every result
+ * into an undifferentiated list of pages.
+ */
+function ResultDocsCalls({ calls }: { calls: DocsCall[] }) {
+  return (
+    <div className="flex flex-col gap-1.5 leading-relaxed text-foreground">
+      {calls.map((call, index) => {
+        const searchOnly = call.hasContent === false
+        const Icon = docsCallIcon(call)
+        return (
+          <details key={index}>
+            <summary className="cursor-pointer">
+              <span className="inline-flex w-[calc(100%-1rem)] items-start gap-2 align-top">
+                <Icon
+                  className={cn("mt-0.5 size-4 shrink-0", searchOnly ? "text-muted-foreground/60" : "text-muted-foreground")}
+                  aria-hidden
+                />
+                <span className={cn("min-w-0 truncate", searchOnly ? "text-muted-foreground" : "text-foreground")}>
+                  {docsCallQueryLabel(call)}
+                </span>
+                <span className={cn(subgroupLabelClassName, "shrink-0", DOCS_CALL_SOURCE_CHIP_CLASS[call.source])}>
+                  {DOCS_CALL_SOURCE_LABEL[call.source]}
+                </span>
+              </span>
+            </summary>
+            <div className="mt-1 ml-6 flex flex-col gap-1">
+              {call.pages.length > 0 ? (
+                call.pages.map((page) => (
+                  <a
+                    key={page.url}
+                    href={page.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="truncate text-foreground hover:underline"
+                  >
+                    {page.title ?? page.url}
+                  </a>
+                ))
+              ) : (
+                <span className="text-muted-foreground">
+                  No results recovered (the tool's output may have been truncated).
+                </span>
+              )}
+            </div>
+          </details>
         )
       })}
     </div>
@@ -1002,6 +1097,12 @@ function ExperimentSheet({
                                       </pre>
                                     </div>
                                   }
+                                />
+                              ) : null}
+                              {result.docs?.calls.length ? (
+                                <EvalMetadataRow
+                                  label="Docs activity"
+                                  value={<ResultDocsCalls calls={result.docs.calls} />}
                                 />
                               ) : null}
                             </dl>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
-import { BotIcon, CheckIcon, CopyIcon, FileTextIcon, SearchIcon, XIcon } from "lucide-react"
+import { BotIcon, CheckIcon, ChevronRightIcon, CopyIcon, FileTextIcon, SearchIcon, XIcon } from "lucide-react"
 import { z } from "zod"
 import {
   evalResultSchema,
@@ -582,11 +582,15 @@ function ResultDocsCalls({ calls }: { calls: DocsCall[] }) {
         const searchOnly = call.hasContent === false
         const Icon = docsCallIcon(call)
         return (
-          <details key={index}>
-            <summary className="cursor-pointer">
-              <span className="inline-flex w-[calc(100%-1rem)] items-start gap-2 align-top">
+          <details key={index} className="group">
+            <summary className="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
+              <span className="inline-flex w-full items-center gap-2">
+                <ChevronRightIcon
+                  className="size-4 shrink-0 text-muted-foreground/50 transition-transform group-open:rotate-90"
+                  aria-hidden
+                />
                 <Icon
-                  className={cn("mt-0.5 size-4 shrink-0", searchOnly ? "text-muted-foreground/60" : "text-muted-foreground")}
+                  className={cn("size-4 shrink-0", searchOnly ? "text-muted-foreground/60" : "text-muted-foreground")}
                   aria-hidden
                 />
                 <span
@@ -605,7 +609,7 @@ function ResultDocsCalls({ calls }: { calls: DocsCall[] }) {
                 </span>
               </span>
             </summary>
-            <div className="mt-1 ml-6 flex flex-col gap-1">
+            <div className="mt-1 ml-12 flex flex-col gap-1">
               {call.pages.length > 0 ? (
                 call.pages.map((page) => (
                   <a
@@ -613,7 +617,7 @@ function ResultDocsCalls({ calls }: { calls: DocsCall[] }) {
                     href={page.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="truncate text-foreground hover:underline"
+                    className="truncate text-muted-foreground hover:text-foreground hover:underline"
                   >
                     {page.title ?? page.url}
                   </a>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -79,30 +79,19 @@ const DOCS_CALL_SOURCE_LABEL: Record<DocsCall["source"], string> = {
   web_search: "Web Search",
 }
 
-// A cool color for MCP (our own docs tool) vs a warm one for the agent going
-// around it onto the open web, so both read clearly and stand apart.
+// Cool color for MCP (our own docs tool), warm for the agent going around it onto the open web.
 const DOCS_CALL_SOURCE_CHIP_CLASS: Record<DocsCall["source"], string> = {
   search_docs: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-400",
   web_fetch: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
   web_search: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
 }
 
-/**
- * Search icon (muted) for a bare hit, a file icon for a call that actually
- * pulled in page text, so the read-state lives on the icon rather than on
- * the source chip, which is a different kind of information (which tool,
- * not how much it read).
- */
+/** Search icon for a bare hit, file icon for a call that actually pulled in page text. */
 function docsCallIcon(call: DocsCall) {
   return call.hasContent === false ? SearchIcon : FileTextIcon
 }
 
-/**
- * search_docs's `query` is a raw GraphQL document; pull out just the quoted
- * search term for display, the rest is our own tool's plumbing, not
- * something a reader needs to see at a glance. Falls back to the raw query
- * (already plain text for web_fetch/web_search) if the shape is unexpected.
- */
+/** Pulls the quoted search term out of search_docs's raw GraphQL query for display, else returns the query as-is. */
 function docsCallQueryLabel(call: DocsCall): string {
   if (call.source === "search_docs") {
     const match = call.query.match(/query:\s*"((?:[^"\\]|\\.)*)"/)
@@ -568,13 +557,7 @@ function ResultChecks({ checks }: { checks: CheckResult[] }) {
   )
 }
 
-/**
- * One row per tool call an agent made toward the docs (not one per page):
- * the query it used, collapsed by default, expanding to the pages that call
- * actually returned. Matches how the agent itself acts, issue one call, get
- * a batch of results back together, rather than flattening every result
- * into an undifferentiated list of pages.
- */
+/** One collapsible row per docs call (see DocsCall), expanding to the pages that call returned. */
 function ResultDocsCalls({ calls }: { calls: DocsCall[] }) {
   return (
     <div className="flex flex-col gap-1.5 leading-relaxed text-foreground">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -111,6 +111,13 @@ function docsCallQueryLabel(call: DocsCall): string {
   return call.query
 }
 
+/** Rough token estimate (chars/4, the standard quick heuristic) for how much text a call pulled into context. */
+function docsCallSizeLabel(call: DocsCall): string | undefined {
+  if (call.resultChars === undefined) return undefined
+  const tokens = Math.round(call.resultChars / 4)
+  return tokens < 1000 ? `~${tokens} tokens` : `~${(tokens / 1000).toFixed(1)}k tokens`
+}
+
 type ExperimentStageSummary = {
   experiment: string
   category: JourneyStage | "overall"
@@ -582,9 +589,17 @@ function ResultDocsCalls({ calls }: { calls: DocsCall[] }) {
                   className={cn("mt-0.5 size-4 shrink-0", searchOnly ? "text-muted-foreground/60" : "text-muted-foreground")}
                   aria-hidden
                 />
-                <span className={cn("min-w-0 truncate", searchOnly ? "text-muted-foreground" : "text-foreground")}>
+                <span
+                  title={docsCallQueryLabel(call)}
+                  className={cn("min-w-0 truncate", searchOnly ? "text-muted-foreground" : "text-foreground")}
+                >
                   {docsCallQueryLabel(call)}
                 </span>
+                {docsCallSizeLabel(call) ? (
+                  <span className="shrink-0 font-mono text-xs tracking-wide text-muted-foreground">
+                    {docsCallSizeLabel(call)}
+                  </span>
+                ) : null}
                 <span className={cn(subgroupLabelClassName, "shrink-0", DOCS_CALL_SOURCE_CHIP_CLASS[call.source])}>
                   {DOCS_CALL_SOURCE_LABEL[call.source]}
                 </span>

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -2969,12 +2969,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": false,
-        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
+        "passed": true
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -2982,13 +2981,11 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": false,
-        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
+        "passed": true
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": false,
-        "notes": "JWT_SECRET missing"
+        "passed": true
       }
     ],
     "skills": {
@@ -2996,10 +2993,94 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "docs": {
-      "calls": []
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"self-hosting with Docker docker-compose setup\", limit: 10) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker",
+              "title": "Self-Hosting with Docker"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting",
+              "title": "Self-Hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/postgres-upgrade-17",
+              "title": "Upgrade to Postgres 17"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
+              "title": "Envoy API Gateway"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth",
+              "title": "Configure Social Login (OAuth) Providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/custom-email-templates",
+              "title": "Custom Email Templates"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development",
+              "title": "Local Development & CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-proxy-https",
+              "title": "Configure Reverse Proxy and HTTPS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/restore-from-platform",
+              "title": "Restore a Platform Project to Self-Hosted"
+            }
+          ],
+          "resultChars": 144083
+        },
+        {
+          "source": "web_fetch",
+          "query": "List any breaking-change tagged entries related to self-hosting, docker-compose, or the self-hosting docker setup.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ],
+          "resultChars": 1093
+        },
+        {
+          "source": "web_fetch",
+          "query": "Return the raw list of entries verbatim, especially any tagged breaking-change, from the last 12 months, with their dates and links.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ],
+          "resultChars": 3617
+        },
+        {
+          "source": "web_fetch",
+          "query": "Return the full setup instructions for self-hosting Supabase with Docker, including the exact git clone / download steps, .env setup, and how to generate secrets (JWT secret, ANON_KEY, SERVICE_ROLE_KEY, dashboard credentials, POSTGRES_PASSWORD).",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker.md"
+            }
+          ],
+          "resultChars": 3222
+        }
+      ]
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -2969,11 +2969,12 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": true
+        "passed": false,
+        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -2981,11 +2982,13 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": true
+        "passed": false,
+        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": true
+        "passed": false,
+        "notes": "JWT_SECRET missing"
       }
     ],
     "skills": {
@@ -2993,9 +2996,10 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": [
-        "supabase"
-      ]
+      "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -2969,12 +2969,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": false,
-        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
+        "passed": true
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -2982,13 +2981,11 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": false,
-        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
+        "passed": true
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": false,
-        "notes": "JWT_SECRET missing"
+        "passed": true
       }
     ],
     "skills": {
@@ -2996,10 +2993,41 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "docs": {
-      "calls": []
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"self-hosting with docker compose\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker",
+              "title": "Self-Hosting with Docker"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting",
+              "title": "Self-Hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth",
+              "title": "Configure Social Login (OAuth) Providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/postgres-upgrade-17",
+              "title": "Upgrade to Postgres 17"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-proxy-https",
+              "title": "Configure Reverse Proxy and HTTPS"
+            }
+          ],
+          "resultChars": 81653
+        }
+      ]
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -63,6 +63,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -115,6 +118,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
@@ -169,6 +175,66 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"pg_cron schedule job invoke edge function net.http_post queue\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings",
+              "title": "Automatic embeddings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions",
+              "title": "Scheduling Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/webhook-debugging-guide-M8sk47",
+              "title": "Webhook debugging guide"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron",
+              "title": "Cron"
+            }
+          ],
+          "resultChars": 62880
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"queues read pop delete messages consume edge function pgmq_public rpc\", limit: 4) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues/consuming-messages-with-edge-functions",
+              "title": "Consuming Supabase Queue Messages with Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/pgmq",
+              "title": "PGMQ Extension"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings",
+              "title": "Automatic embeddings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/api",
+              "title": "API"
+            }
+          ],
+          "resultChars": 60050
+        }
       ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
@@ -226,6 +292,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
@@ -292,6 +361,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -336,17 +408,17 @@
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"b818b29b-85b5-4e82-b9ac-eb103e8739cb\",\"metric\":\"steps_a_mrnhal0w\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"d6d5fe0c-99bd-4131-bf20-272b4ea4e9fd\",\"metric\":\"steps_a_mro0usf9\",\"value\":111}]"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"b818b29b-85b5-4e82-b9ac-eb103e8739cb\",\"metric\":\"steps_a_mrnhal0w\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"d6d5fe0c-99bd-4131-bf20-272b4ea4e9fd\",\"metric\":\"steps_a_mro0usf9\",\"value\":111}]"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"686a9d9a-fc4a-47c4-81b3-55075e79fc1b\",\"metric\":\"steps_b_mrnhal0w\",\"value\":222}]"
+        "notes": "status 200: [{\"user_id\":\"dca2d817-6fa6-47ce-9655-c733eb8a7c63\",\"metric\":\"steps_b_mro0usf9\",\"value\":222}]"
       },
       {
         "name": "non-service key is not granted service access",
@@ -376,6 +448,67 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"edge function service role key apikey header authenticate user getUser\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-deleteuser"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
+              "title": "Envoy API Gateway"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-listusers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            }
+          ],
+          "resultChars": 34937
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"withSupabase @supabase/server edge function auth publishable secret authMode ctx supabaseAdmin getUser\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/choosing-a-server-package",
+              "title": "Which package to use"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-getuser"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            }
+          ],
+          "resultChars": 46083
+        }
       ]
     },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
@@ -421,7 +554,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-d487-72ec-aaf0-ef9d6e3aa776/receipt-alpha.pdf, 019f4d37-d487-72ec-aaf0-ef9d6e3aa776/receipt-beta.pdf"
+        "notes": "saw: 019f6c9d-f613-743e-92ba-d858089774ab/receipt-alpha.pdf, 019f6c9d-f613-743e-92ba-d858089774ab/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -442,7 +575,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "The answer creates a private user-files bucket, keeps RLS enabled, defines authenticated SELECT and INSERT policies scoped to bucket and owner via the first path segment/auth.uid(), and provides supabase-js createSignedUrl code with an expiry for temporary sharing. It does not make the bucket public, use permissive policies, anon/public roles, getPublicUrl, or client-side service role keys."
+        "judgeNotes": "Creates private user-files bucket, owner-scoped SELECT and INSERT policies on storage.objects for authenticated users using first folder = auth.uid(), keeps RLS enabled (does not disable it), and provides supabase-js createSignedUrl code with expiry. No public bucket/getPublicUrl/service-role misuse."
       }
     ],
     "skills": {
@@ -452,6 +585,51 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ storage: searchDocs(query: \"storage bucket RLS policy user folder path auth.uid\", limit: 5) { nodes { title href content } } signed: searchDocs(query: \"createSignedUrl temporary link expires storage\", limit: 4) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/helper-functions",
+              "title": "Storage Helper Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs",
+              "title": "Build a User Management App with Next.js"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/buckets/fundamentals",
+              "title": "Storage Buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurl"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads",
+              "title": "Serving assets from Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurls"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/dart/file-buckets-createsignedurl"
+            }
+          ],
+          "resultChars": 68372
+        }
       ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -489,12 +667,12 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "6 passed, 2 failed"
+        "notes": "3 passed, 2 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "Identifies `posts` as the broken tenant isolation policy, explains authenticated members can read posts from other orgs, and grounds the conclusion in pgTAP failures while noting `notes` passes."
+        "judgeNotes": "Correctly identifies `posts` as having a broken tenant isolation SELECT policy, grounded in pgTAP failure showing org1 member can read org2 posts. Does not blame `notes` and treats test results as authoritative."
       }
     ],
     "skills": {
@@ -505,6 +683,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
@@ -542,12 +723,12 @@
       {
         "name": "HNSW index on the embedding column",
         "passed": true,
-        "notes": "CREATE INDEX document_sections_embedding_hnsw ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
+        "notes": "CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
       },
       {
         "name": "index operator class matches the search operator",
         "passed": true,
-        "notes": "function operators: <=>\nindexes: CREATE INDEX document_sections_embedding_hnsw ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
+        "notes": "function operators: <=>\nindexes: CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
       },
       {
         "name": "user A search returns only own sections, best match first",
@@ -575,9 +756,41 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"semantic search gte-small embeddings match_document_sections RLS\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/rag-with-permissions",
+              "title": "RAG with Permissions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pgvector",
+              "title": "pgvector: Embeddings and vector similarity"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/choosing-compute-addon",
+              "title": "Choosing your Compute Add-on"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/semantic-search",
+              "title": "Semantic Search"
+            }
+          ],
+          "resultChars": 57915
+        }
+      ]
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-opus-4.8/build-vectors-001-rag-with-permissions.json"
   },
   {
@@ -607,12 +820,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Prometheus preserves the app job and adds an HTTPS Supabase scrape using /customer/v1/privileged/metrics with basic_auth password_file. docker-compose mounts the secrets directory containing that password file. No bearer auth or hardcoded key present."
+        "judgeNotes": "Meets requirements: preserves app scrape, adds Supabase HTTPS scrape with correct metrics_path, Basic Auth using password_file, project target on <project-ref>.supabase.co:443, and docker-compose mounts the secrets directory containing the password file read-only."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes concrete steps to replace project ref, create a Supabase Secret API key, place it in the matching gitignored secret file read by Prometheus, restart or reload the Compose stack, and verify via curl, Prometheus targets, PromQL, and Grafana."
+        "judgeNotes": "README includes concrete live setup steps: replace project ref, create a Supabase Secret API key, write it to the expected secret file mounted by Compose, and reload/start the Compose stack. It also provides verification via curl, Prometheus targets, and PromQL/Grafana guidance. No hardcoded real secret or mismatched setup detected."
       }
     ],
     "skills": {
@@ -622,6 +835,49 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Prometheus metrics endpoint observability Grafana integration\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
+            }
+          ],
+          "resultChars": 24393
+        },
+        {
+          "source": "web_fetch",
+          "query": "What is the exact Supabase project metrics endpoint URL, what authentication does it use (username/password), what is the recommended Prometheus scrape config (job, scrape_interval, metrics_path, basic_auth, scheme), and any Grafana dashboard details? Quote exact config snippets.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics.md"
+            }
+          ],
+          "resultChars": 1190
+        }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -678,6 +934,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -732,6 +991,32 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_fetch",
+          "query": "List the exact steps to self-host Supabase with Docker. Include: which files/directories to copy (docker-compose.yml, .env.example, volumes/), the exact commands to obtain them, the full list of secrets/env vars that must be set in .env (POSTGRES_PASSWORD, JWT_SECRET, ANON_KEY, SERVICE_ROLE_KEY, DASHBOARD_USERNAME, DASHBOARD_PASSWORD, SECRET_KEY_BASE, VAULT_ENC_KEY, pooler tenant/keys, etc.), how to generate JWT anon and service_role keys, and any security notes about changing default credentials.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker"
+            }
+          ],
+          "resultChars": 4558
+        },
+        {
+          "source": "web_fetch",
+          "query": "List any recent breaking-change entries related to self-hosting, Docker, docker-compose, env vars, JWT keys, API keys (anon/service_role/publishable/secret), or the analytics/logflare/vector/pooler services.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ],
+          "resultChars": 1453
+        }
+      ]
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -757,7 +1042,7 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "victim session active before delete-account",
@@ -778,7 +1063,8 @@
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
@@ -787,7 +1073,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": true,
-        "judgeNotes": "The answer identifies the soft-delete-only flaw, fixes deletion by removing auth.sessions and auth.users, explains JWT access-token expiry windows and session validation/short expiry, and correctly distinguishes frontend publishable keys with RLS from server-only secret/service keys that bypass RLS."
+        "judgeNotes": "Identifies soft-delete-only cause and lack of session revocation; implements meaningful revocation by banning auth user and deleting sessions/refresh tokens plus RLS enforcement of deleted flag. Explains JWTs remain valid until expiry for local validation, while DB path is closed immediately due to RLS checking active account, which is consistent with the implemented fix. Correctly distinguishes publishable/frontend/RLS-enforced keys from secret/server-only/RLS-bypassing keys."
       }
     ],
     "skills": {
@@ -798,6 +1084,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -850,7 +1139,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel can be SUBSCRIBED while INSERT events do not arrive because public.orders was missing from the supabase_realtime publication. It applied exactly the appropriate fix with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verified publication membership, and explicitly left RLS/policies and courier_locations intact. It did not blame client code, networking, grants, or weaken RLS."
+        "judgeNotes": "The assistant correctly diagnosed that the channel can be SUBSCRIBED while orders INSERT events are silent because public.orders was missing from the supabase_realtime publication. It fixed exactly that with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verified publication membership, and did not alter RLS, policies, courier_locations, or client code."
       }
     ],
     "skills": {
@@ -861,6 +1150,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
@@ -886,22 +1178,22 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as affected and described the recurring 503 gateway pattern across the morning of 2026-04-28, covering the 8 failures from ~07:00Z to 12:00Z. Also distinguished unrelated billing-webhook errors."
+        "judgeNotes": "Identified image-transform as the affected function and explicitly listed the recurring 503 gateway failures across the morning of 2026-04-28, covering all 8 failures from 07:00Z–12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "Although it notes the 503s appear only in gateway/API logs with no function invocation rows, it then attributes the likely cause to function boot/runtime/dependency issues and recommends changing the function dependency, which violates the rubric."
+        "passed": true,
+        "judgeNotes": "Attributes the 503s to the gateway/platform layer before function execution, grounded in the mismatch between API/gateway 503s and clean edge-function runtime 200 logs, and distinguishes them from avatar-upload's function-level 500."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps: inspect Edge Function logs for the exact 503 boot/runtime errors in a defined time window, pin/vendor the dependency, check function resource limits/concurrency, and inspect function config."
+        "judgeNotes": "The assistant recommended concrete next steps, including pulling detailed edge-function metrics/boot logs around specific 503 timestamps, checking for worker/resource limit errors, reducing invocation resource use, adding retries, and increasing compute/limits if capacity-related."
       }
     ],
     "skills": {
@@ -913,9 +1205,12 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-opus-4.8/investigate-reliability-003-edge-function-5xx-correlation.json"
   },
   {
@@ -969,7 +1264,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API results, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed deny-all RLS due to no policies and added authenticated SELECT and INSERT owner-scoped policies using auth.uid(), without disabling RLS."
       }
     ],
     "skills": {
@@ -980,6 +1275,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -1030,7 +1328,7 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Avatar migration was applied through `supabase db push` in #11, with output `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration was reconciled by adding the missing local migration file `20240115000000_add_profile_bio.sql` in #9, after which `supabase migration list` showed local/remote alignment and `supabase db push` succeeded. No prohibited workaround or direct SQL mutation was used; the psql commands were read-only inspection."
+        "judgeNotes": "Avatar migration was applied through `supabase db push` (#14), which shows `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration history was reconciled by adding the missing local file `supabase/migrations/20240115000000_add_profile_bio.sql` (#12), after which `supabase migration list` showed local and remote aligned (#13) and the successful push proceeded. No disallowed workaround or direct mutation was used; psql commands were read-only inspection."
       }
     ],
     "skills": {
@@ -1041,6 +1339,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
@@ -1084,7 +1385,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -1099,6 +1400,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -1174,6 +1478,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -1238,6 +1545,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -1286,6 +1596,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -1324,17 +1637,45 @@
       {
         "name": "cron command enqueues to the 'tasks' queue",
         "passed": true,
-        "notes": "queue depth 0 -> 1"
+        "notes": "queue depth 1 -> 2"
       },
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 5) from the queue"
+        "notes": "function removed the seeded message (id 7) from the queue"
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"pg_cron schedule job send message to queue pgmq\", limit: 4) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues/pgmq",
+              "title": "PGMQ Extension"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings",
+              "title": "Automatic embeddings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/quickstart",
+              "title": "Quickstart"
+            }
+          ],
+          "resultChars": 75189
+        }
+      ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
@@ -1387,9 +1728,12 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-opus-4.8-no-skills/build-database-001-migrate-postgres-to-supabase.json"
   },
   {
@@ -1447,6 +1791,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -1486,37 +1833,37 @@
       {
         "name": "rejects request with no credentials",
         "passed": true,
-        "notes": "status 401: {\"error\":\"authentication required\"}"
+        "notes": "status 401: {\"error\":\"unauthorized\"}"
       },
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"08620f24-1c0e-4eab-b9c3-ddc485ff22be\",\"metric\":\"steps_a_mrnhshgj\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"14f44167-7395-4098-9ee4-65835041dd08\",\"metric\":\"steps_a_mrnzcw4x\",\"value\":111}]"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"08620f24-1c0e-4eab-b9c3-ddc485ff22be\",\"metric\":\"steps_a_mrnhshgj\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"14f44167-7395-4098-9ee4-65835041dd08\",\"metric\":\"steps_a_mrnzcw4x\",\"value\":111}]"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"88c46b0f-784a-45b3-8777-95b80e79e52d\",\"metric\":\"steps_b_mrnhshgj\",\"value\":222}]"
+        "notes": "status 200: [{\"user_id\":\"1b50150f-6ab2-42bd-8008-f0c40d3404f9\",\"metric\":\"steps_b_mrnzcw4x\",\"value\":222}]"
       },
       {
         "name": "non-service key is not granted service access",
         "passed": true,
-        "notes": "status 401: {\"error\":\"authentication required\"}"
+        "notes": "status 401: {\"error\":\"unauthorized\"}"
       },
       {
         "name": "rejects an unverified (forged) user token",
         "passed": true,
-        "notes": "status 401: {\"error\":\"invalid or expired token\"}"
+        "notes": "status 401: {\"error\":\"unauthorized\"}"
       },
       {
         "name": "a user token in the apikey slot is not treated as the service key",
         "passed": true,
-        "notes": "status 401: {\"error\":\"authentication required\"}"
+        "notes": "status 401: {\"error\":\"unauthorized\"}"
       },
       {
         "name": "implementation uses @supabase/server",
@@ -1527,6 +1874,74 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"edge function dual authentication service role key user token verify jwt\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/error-codes",
+              "title": "Error codes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/jwt-fields",
+              "title": "JWT Claims Reference"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
+              "title": "Envoy API Gateway"
+            }
+          ],
+          "resultChars": 65709
+        },
+        {
+          "source": "search_docs",
+          "query": "{ securing: searchDocs(query: \"Securing Edge Functions service role bypass RLS API key apikey header pattern\", limit: 3) { nodes { title href content } } server: searchDocs(query: \"@supabase/server createClient edge function new API keys secret publishable\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/why-is-my-service-role-key-client-getting-rls-errors-or-not-returning-data-7_1K9z",
+              "title": "Why is my service role key client getting RLS errors or not returning data?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/choosing-a-server-package",
+              "title": "Which package to use"
+            }
+          ],
+          "resultChars": 46583
+        }
+      ]
     },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
     "promptSourcePath": "evals/build-functions-005-dual-auth-user-secret/PROMPT.md",
@@ -1571,7 +1986,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-1861-743f-9354-c90caeba6274/receipt-alpha.pdf, 019f4d37-1861-743f-9354-c90caeba6274/receipt-beta.pdf"
+        "notes": "saw: 019f6c9d-4b62-7791-8378-3d0bd8ab5048/receipt-alpha.pdf, 019f6c9d-4b62-7791-8378-3d0bd8ab5048/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -1592,12 +2007,48 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Configures a private user-files bucket, authenticated owner-scoped SELECT and INSERT RLS policies on storage.objects using the user id path prefix, does not disable RLS or make public access permissive, and uses supabase-js createSignedUrl with an expiry for temporary sharing."
+        "judgeNotes": "Meets all requirements: private user-files bucket, authenticated owner-scoped SELECT and INSERT policies with WITH CHECK, no RLS disabling or public access, and uses createSignedUrl with expiry for sharing."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"storage RLS policy private bucket user folder owner access control\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/buckets/fundamentals",
+              "title": "Storage Buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/security/product-security",
+              "title": "Secure configuration of Supabase products"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/ownership",
+              "title": "Ownership"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/design",
+              "title": "The Storage Schema"
+            }
+          ],
+          "resultChars": 22916
+        }
+      ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
@@ -1634,17 +2085,20 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "5 passed, 3 failed"
+        "notes": "6 passed, 2 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as the table with the broken tenant isolation policy, grounds the conclusion in pgTAP failures showing cross-org post visibility, and distinguishes it from `notes`, which passes isolation tests."
+        "judgeNotes": "The agent correctly identifies `posts` as the table with the broken tenant isolation policy, explains that authenticated members can read posts from organizations they are not members of, and grounds the conclusion in the pgTAP failures. It also distinguishes `notes` as correctly isolated."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
@@ -1710,6 +2164,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -1742,17 +2199,45 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Meets requirements: preserves app scrape; adds Supabase HTTPS scrape with correct metrics_path, basic_auth using password_file, and target under supabase.co; docker-compose mounts the secrets directory containing the password_file. No bearer auth or hardcoded key."
+        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase metrics scrape with correct path, Basic Auth using password_file, project target on supabase.co, and docker-compose mounts the secrets directory containing the password file."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes go-live steps for project ref substitution, Secret API key creation, writing the matching mounted secret file, Compose restart/reload, and concrete verification via curl, Prometheus targets, and a PromQL query."
+        "judgeNotes": "README includes concrete steps to replace project ref, create a Supabase Secret API key, place it in the mounted secrets/supabase_metrics_key file, reload/start the Compose stack, and verify via curl plus Prometheus targets."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Prometheus metrics endpoint scrape project monitoring\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            }
+          ],
+          "resultChars": 23542
+        }
+      ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
@@ -1803,6 +2288,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -1851,6 +2339,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
@@ -1907,12 +2398,44 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": true,
-        "judgeNotes": "Covers the root cause, implements real auth-user/session/refresh-token revocation, explains stateless JWT expiry window and mitigation via RLS/short TTL, and correctly distinguishes publishable frontend keys from server-only secret keys that bypass RLS."
+        "judgeNotes": "Meets all rubric requirements: identifies soft-delete-only bug, implements real auth user deletion/session revocation, correctly explains stateless JWT residual window and aligns it with added RLS live-profile mitigation while caveating local validation, and accurately distinguishes publishable vs secret keys including RLS behavior and frontend/server placement."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"publishable key secret key API keys migration anon service_role RLS\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-redwoodjs",
+              "title": "Build a User Management App with RedwoodJS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/quickstarts/with-expo-react-native-social-auth",
+              "title": "Build a Social Auth App with Expo React Native"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit",
+              "title": "Build a User Management App with SvelteKit"
+            }
+          ],
+          "resultChars": 169611
+        }
+      ]
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -1965,12 +2488,15 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel reaches SUBSCRIBED but no INSERT events arrive because public.orders was missing from the supabase_realtime publication, and fixed it with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders. It preserved courier_locations and did not disable RLS or weaken policies. The final note mentions RLS only as a secondary check, not the root cause or applied fix."
+        "judgeNotes": "The assistant correctly identifies that the channel reaches SUBSCRIBED but INSERT events do not arrive because public.orders is missing from the supabase_realtime publication. It applies exactly the required fix via ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verifies the publication, and explicitly leaves RLS/policies and courier_locations intact without blaming or weakening them."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
@@ -2001,26 +2527,29 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, including most/all 8 gateway failures from 07:00Z-12:00Z. Also correctly distinguished unrelated billing-webhook 503s."
+        "judgeNotes": "Identified image-transform as affected and described the recurring HTTP 503 gateway failures throughout the morning of 2026-04-28, covering the 8 failures from ~07:00Z to 12:00Z, while ruling out billing-webhook noise."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "Attributes recurring 503s to the gateway/platform layer, not function code, and grounds this in valid observations: 503s appear only in gateway logs with no function-internal rows, successful nearby invocations, and distinction from avatar-upload's function-level 500."
+        "judgeNotes": "Attributes recurring image-transform 503s to the gateway/platform layer before the function, grounded in valid observations: 503s appear in gateway logs with no corresponding function execution 503s, executions that reached the function were 200s, and distinguishes the avatar-upload 500 as a separate function-level error."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended specific actionable next steps: identify the scheduled burst source, add jitter, raise concurrency/rate limits, implement retry-with-backoff, and track the related 500."
+        "judgeNotes": "The assistant recommended concrete next steps including checking Edge Function resource limits/concurrency, correlating 503 timestamps with traffic spikes, and opening a Supabase support ticket referencing gateway 503s."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-opus-4.8-no-skills/investigate-reliability-003-edge-function-5xx-correlation.json"
   },
   {
@@ -2074,12 +2603,15 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies as deny-all causing Data API empty results; kept RLS enabled and created authenticated owner-scoped SELECT and INSERT policies using auth.uid() = user_id with WITH CHECK for inserts. Extra update/delete policies are acceptable."
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API results, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -2130,12 +2662,15 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Avatar migration was applied through the Supabase CLI with `supabase db push` in action #18, which output `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration was reconciled by adding the missing local migration file `20240115000000_add_profile_bio.sql` in action #16, after which `supabase migration list` showed local and remote aligned in action #17. Read-only `psql` inspection was used, but no disallowed direct SQL mutation or prepared-statement workaround was seen."
+        "judgeNotes": "Applied the pending avatar_url migration with `supabase db push` in step #18; output shows `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled the orphan bio migration by adding the local file `supabase/migrations/20240115000000_add_bio.sql` in step #16, after which migration list matched local/remote in step #17 and db push succeeded. No disallowed workaround observed."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
@@ -2189,6 +2724,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -2259,6 +2797,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -2298,7 +2839,7 @@
       {
         "name": "todos table exists with at least 2 seeded rows",
         "passed": true,
-        "notes": "found 3 rows"
+        "notes": "found 2 rows"
       },
       {
         "name": "row level security is enabled on todos",
@@ -2316,7 +2857,7 @@
       {
         "name": "REST API returns the todos to authenticated requests",
         "passed": true,
-        "notes": "3 rows"
+        "notes": "2 rows"
       }
     ],
     "skills": {
@@ -2327,6 +2868,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
@@ -2381,6 +2925,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -2419,12 +2966,12 @@
       {
         "name": "cron command enqueues to the 'tasks' queue",
         "passed": true,
-        "notes": "queue depth 0 -> 1"
+        "notes": "queue depth 1 -> 2"
       },
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 37) from the queue"
+        "notes": "function removed the seeded message (id 5) from the queue"
       }
     ],
     "skills": {
@@ -2434,6 +2981,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"pg_cron schedule pgmq send queue example\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues/pgmq",
+              "title": "PGMQ Extension"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/pgcron-debugging-guide-n1KTaz",
+              "title": "pg_cron debugging guide"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions",
+              "title": "Scheduling Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron",
+              "title": "Cron"
+            }
+          ],
+          "resultChars": 46500
+        }
       ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
@@ -2492,9 +3071,12 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-sonnet-5/build-database-001-migrate-postgres-to-supabase.json"
   },
   {
@@ -2557,6 +3139,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -2601,17 +3186,17 @@
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: {\"data\":[{\"user_id\":\"1240eab4-63fc-4d3d-ac3a-b3d8466469e5\",\"metric\":\"steps_a_mrnh6nr4\",\"value\":111}]}"
+        "notes": "status 200: {\"data\":[{\"user_id\":\"6f3de9df-d36e-4fe3-afa6-585831ee3ab6\",\"metric\":\"steps_a_mrnza8oa\",\"value\":111}]}"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: {\"data\":[{\"user_id\":\"1240eab4-63fc-4d3d-ac3a-b3d8466469e5\",\"metric\":\"steps_a_mrnh6nr4\",\"value\":111}]}"
+        "notes": "status 200: {\"data\":[{\"user_id\":\"6f3de9df-d36e-4fe3-afa6-585831ee3ab6\",\"metric\":\"steps_a_mrnza8oa\",\"value\":111}]}"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: {\"data\":[{\"user_id\":\"59450f92-b66c-432c-a8b8-81f30ef47277\",\"metric\":\"steps_b_mrnh6nr4\",\"value\":222}]}"
+        "notes": "status 200: {\"data\":[{\"user_id\":\"547d02a8-3075-460e-b74b-3566ca328be3\",\"metric\":\"steps_b_mrnza8oa\",\"value\":222}]}"
       },
       {
         "name": "non-service key is not granted service access",
@@ -2621,7 +3206,7 @@
       {
         "name": "rejects an unverified (forged) user token",
         "passed": true,
-        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+        "notes": "status 504: { \"message\":\"The upstream server is timing out\" }"
       },
       {
         "name": "a user token in the apikey slot is not treated as the service key",
@@ -2643,9 +3228,97 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Edge Functions environment variables SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY secret key default secrets\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/storage-caching",
+              "title": "Integrating with Supabase Storage"
+            }
+          ],
+          "resultChars": 36932
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"verify_jwt config.toml edge functions per function\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/mcp-server-mcp-lite",
+              "title": "Building an MCP Server with mcp-lite"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/deploy",
+              "title": "Deploy to Production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            }
+          ],
+          "resultChars": 27882
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Securing Edge Functions auth modes user secret combine multiple auth same function\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            }
+          ],
+          "resultChars": 33453
+        }
+      ]
+    },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
     "promptSourcePath": "evals/build-functions-005-dual-auth-user-secret/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-sonnet-5/build-functions-005-dual-auth-user-secret.json"
   },
   {
@@ -2686,7 +3359,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-866d-77bb-b699-7ec59a068785/receipt-alpha.pdf, 019f4d37-866d-77bb-b699-7ec59a068785/receipt-beta.pdf"
+        "notes": "saw: 019f6c9d-2621-71dc-bf54-b0321882d158/receipt-alpha.pdf, 019f6c9d-2621-71dc-bf54-b0321882d158/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -2707,7 +3380,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets rubric: private user-files bucket, authenticated owner-scoped SELECT and INSERT storage.objects policies with WITH CHECK for uploads, RLS not disabled, and supabase-js createSignedUrl with expiry for temporary sharing."
+        "judgeNotes": "Creates a private user-files bucket, owner-scoped SELECT and INSERT policies on storage.objects for authenticated users using the user-id path prefix, does not disable RLS or make the bucket public, and provides supabase-js createSignedUrl code with an expiry for temporary sharing."
       }
     ],
     "skills": {
@@ -2717,6 +3390,62 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"storage RLS policy folder path user id owner\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/helper-functions",
+              "title": "Storage Helper Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs",
+              "title": "Build a User Management App with Next.js"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/third-party/clerk",
+              "title": "Clerk"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/ownership",
+              "title": "Ownership"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary",
+              "title": "Glossary"
+            }
+          ],
+          "resultChars": 64123
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"createSignedUrl expiring link\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurl"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurls"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/dart/file-buckets-createsignedurl"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads",
+              "title": "Serving assets from Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsigneduploadurl"
+            }
+          ],
+          "resultChars": 7426
+        }
       ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -2749,17 +3478,17 @@
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
+        "notes": "4 file(s): supabase/tests/database/memberships_exposure.test.sql, supabase/tests/database/posts_tenant_isolation.test.sql, supabase/tests/database/00_rls_enabled.test.sql, supabase/tests/database/notes_tenant_isolation.test.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "7 passed, 4 failed"
+        "notes": "2 passed, 1 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as having a broken tenant isolation policy, states that authenticated members of any org can read other orgs’ posts, and grounds this in pgTAP failures (#6 and #7). It also correctly distinguishes `notes` as isolated and treats the test results as authoritative."
+        "judgeNotes": "The agent correctly identifies `posts` as having the broken tenant isolation policy, explains that authenticated members can read posts from other organizations due to the missing `org_id` match, and grounds the conclusion in the pgTAP failures while noting `notes` passed."
       }
     ],
     "skills": {
@@ -2769,6 +3498,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"pgTAP testing RLS policies auth.uid() local development\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/overview",
+              "title": "Testing Overview"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/testing",
+              "title": "Testing Your Database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/token-security",
+              "title": "Token Security and Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/pgtap-extended",
+              "title": "Advanced pgTAP Testing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            }
+          ],
+          "resultChars": 75875
+        }
       ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -2840,6 +3601,58 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"match_document_sections semantic search gte-small embedding\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/semantic-search",
+              "title": "Semantic Search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/vector/querying-vectors",
+              "title": "Querying Vectors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/choosing-compute-addon",
+              "title": "Choosing your Compute Add-on"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/concepts",
+              "title": "Concepts"
+            }
+          ],
+          "resultChars": 65363
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"gte-small model dimensions Supabase.ai Session embedding edge function\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/semantic-search",
+              "title": "Semantic Search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/ai-models",
+              "title": "Running AI Models"
+            }
+          ],
+          "resultChars": 37366
+        }
+      ]
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -2872,12 +3685,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase metrics scrape at /customer/v1/privileged/metrics targeting <project-ref>.supabase.co:443, uses basic_auth with password_file, and docker-compose mounts the secrets directory containing that password file."
+        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, Basic Auth with password_file, preserves the app job, and docker-compose mounts the secrets directory containing the password_file."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes Secret API key creation, secret file placement, Compose restart, and concrete verification via curl, Prometheus targets, and Grafana."
+        "judgeNotes": "README includes Secret API key creation, matching secret file placement, Prometheus reload, and concrete verification via Prometheus targets, PromQL, and Grafana."
       }
     ],
     "skills": {
@@ -2887,6 +3700,66 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"project metrics endpoint prometheus\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
+              "title": "Manual replication monitoring"
+            }
+          ],
+          "resultChars": 27147
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"metrics customer/v1/privileged/metrics\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/reports",
+              "title": "Reports"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            }
+          ],
+          "resultChars": 54724
+        }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -2927,7 +3800,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "judgeNotes": "Reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -2942,6 +3815,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
@@ -3000,32 +3876,15 @@
     "docs": {
       "calls": [
         {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"self-hosting with docker compose\", limit: 5) { nodes { title href content } } }",
+          "source": "web_fetch",
+          "query": "List the exact steps to set up self-hosted Supabase with Docker: which repo/files to clone or copy, the docker-compose.yml structure, which env vars need to be set in .env (list all of them with descriptions), and how JWT_SECRET, ANON_KEY, SERVICE_ROLE_KEY, POSTGRES_PASSWORD, DASHBOARD credentials, SECRET_KEY_BASE, VAULT_ENC_KEY are generated/used.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/self-hosting/docker",
-              "title": "Self-Hosting with Docker"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting",
-              "title": "Self-Hosting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth",
-              "title": "Configure Social Login (OAuth) Providers"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/postgres-upgrade-17",
-              "title": "Upgrade to Postgres 17"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-proxy-https",
-              "title": "Configure Reverse Proxy and HTTPS"
+              "url": "https://supabase.com/docs/guides/self-hosting/docker"
             }
           ],
-          "resultChars": 81653
+          "resultChars": 3336
         }
       ]
     },
@@ -3084,7 +3943,7 @@
       {
         "name": "diagnosed and explained session revocation",
         "passed": true,
-        "judgeNotes": "The answer identifies the soft-delete-only root cause, implements real auth user deletion with session/refresh token revocation via cascades, explains the remaining stateless JWT access-token window and mitigation considerations, and correctly distinguishes publishable frontend/RLS-bound keys from secret backend/RLS-bypassing keys."
+        "judgeNotes": "Meets all rubric requirements: correctly diagnoses soft-delete-only flow, implements hard auth user deletion/session revocation, accurately explains residual JWT access window consistent with the implemented fix and names mitigations, and correctly distinguishes publishable vs secret keys and RLS behavior."
       }
     ],
     "skills": {
@@ -3095,6 +3954,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -3147,7 +4009,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant identified the exact root cause: orders was missing from the supabase_realtime publication while the channel reached SUBSCRIBED. It fixed exactly that with ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verified membership, and did not weaken RLS/policies or disturb courier_locations."
+        "judgeNotes": "Diagnosed the missing orders table in supabase_realtime publication, applied ALTER PUBLICATION ADD TABLE public.orders, preserved courier_locations/RLS/policies, and did not blame or alter unrelated components."
       }
     ],
     "skills": {
@@ -3158,6 +4020,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
@@ -3188,17 +4053,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as affected and described the recurring 503 pattern across the morning of 2026-04-28, including 8 occurrences and examples from 07:00Z to 12:00Z. Did not incorrectly focus only on billing-webhook."
+        "judgeNotes": "The assistant named image-transform as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, covering the eight gateway failures from 07:00Z through 12:00Z. It also distinguished this from the older billing-webhook issue."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "The response clearly attributes the recurring image-transform 503s to the gateway/platform layer rather than function code, and grounds this in valid observations: 503s appear only in gateway logs with no runtime invocation rows, successful nearby invocations ran normally, and it distinguishes these gateway 503s from avatar-upload's function-level 500."
+        "judgeNotes": "Attributes the recurring image-transform 503s to the API gateway/platform layer before function code ran, grounded in the observation that 503 entries appear only in gateway logs with no execution_time_ms/deployment_id/version while nearby 200s succeeded. Also distinguishes these gateway 503s from avatar-upload's function-level 500."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including investigating concurrency/cold-start limits, pulling specific avatar-upload logs for a request/time, adding retry/backoff and alerting, and checking with Supabase support about platform-side throttling around the affected dates."
+        "judgeNotes": "Recommended concrete next steps including adding retry/backoff, reducing cold-start frequency, improving alerting by gateway vs runtime failures, and investigating slow initialization in the private package."
       }
     ],
     "skills": {
@@ -3209,6 +4074,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
@@ -3266,7 +4134,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS deny-all due to no policies, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all Data API results; kept RLS enabled; created authenticated SELECT policy owner-scoped by user_id = auth.uid(); created authenticated INSERT policy with WITH CHECK enforcing user_id = auth.uid()."
       }
     ],
     "skills": {
@@ -3277,6 +4145,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -3327,7 +4198,7 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Applied avatar_url via `supabase db push` in #12, which output `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled orphan bio migration by adding local file `supabase/migrations/20240115000000_add_profile_bio.sql` in #10, after which `supabase migration list` showed local/remote matched and push proceeded. No disallowed workaround seen; psql usage was read-only inspection."
+        "judgeNotes": "Applied avatar_url via `supabase db push` in #25, which showed `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled orphan bio migration by adding local file `supabase/migrations/20240115000000_add_profile_bio.sql` in #23, after which `supabase migration list` showed local and remote aligned in #24. Direct `psql` commands were read-only inspection; no prohibited workaround seen."
       }
     ],
     "skills": {
@@ -3338,6 +4209,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
@@ -3396,6 +4270,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -3471,6 +4348,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -3523,7 +4403,7 @@
       {
         "name": "REST API returns no todos to anonymous requests",
         "passed": true,
-        "notes": "error 42501: permission denied for table todos"
+        "notes": "0 rows"
       },
       {
         "name": "REST API returns the todos to authenticated requests",
@@ -3534,6 +4414,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
@@ -3583,6 +4466,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -3621,7 +4507,7 @@
       {
         "name": "cron command enqueues to the 'tasks' queue",
         "passed": true,
-        "notes": "queue depth 1 -> 2"
+        "notes": "queue depth 0 -> 1"
       },
       {
         "name": "process-tasks function drains the queue",
@@ -3632,6 +4518,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
@@ -3683,6 +4572,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
@@ -3744,6 +4636,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -3788,17 +4683,17 @@
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: {\"data\":[{\"user_id\":\"fb359075-eed0-4261-ac6b-6e2671cd2aa6\",\"metric\":\"steps_a_mrnhme01\",\"value\":111}]}"
+        "notes": "status 200: {\"data\":[{\"user_id\":\"470e6d3d-5da0-4456-ac30-a58f189b2226\",\"metric\":\"steps_a_mrnyzk12\",\"value\":111}]}"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: {\"data\":[{\"user_id\":\"fb359075-eed0-4261-ac6b-6e2671cd2aa6\",\"metric\":\"steps_a_mrnhme01\",\"value\":111}]}"
+        "notes": "status 200: {\"data\":[{\"user_id\":\"470e6d3d-5da0-4456-ac30-a58f189b2226\",\"metric\":\"steps_a_mrnyzk12\",\"value\":111}]}"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: {\"data\":[{\"user_id\":\"b7f7e483-97f2-484c-9594-d5375e14548e\",\"metric\":\"steps_b_mrnhme01\",\"value\":222}]}"
+        "notes": "status 200: {\"data\":[{\"user_id\":\"d5cf03db-1898-4d2d-8721-801cafe8f82a\",\"metric\":\"steps_b_mrnyzk12\",\"value\":222}]}"
       },
       {
         "name": "non-service key is not granted service access",
@@ -3825,9 +4720,97 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"@supabase/server edge function new API keys secret key publishable key\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/choosing-a-server-package",
+              "title": "Which package to use"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            }
+          ],
+          "resultChars": 55720
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"@supabase/server edge function sb-api-key header createClient\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/reference/javascript/oauth-admin-createclient"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/passkeys",
+              "title": "Passkey authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/oauth-admin-getclient"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/oauth-admin-updateclient"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/oauth-admin-deleteclient"
+            }
+          ],
+          "resultChars": 13437
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"edge functions authentication verify_jwt service_role apikey header user JWT\", limit: 6) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            }
+          ],
+          "resultChars": 75098
+        }
+      ]
+    },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
     "promptSourcePath": "evals/build-functions-005-dual-auth-user-secret/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-sonnet-5-no-skills/build-functions-005-dual-auth-user-secret.json"
   },
   {
@@ -3868,7 +4851,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-2a23-7648-947a-5ffca7f548b6/receipt-alpha.pdf, 019f4d37-2a23-7648-947a-5ffca7f548b6/receipt-beta.pdf"
+        "notes": "saw: 019f6c9c-ff09-73dd-9a80-8ae97a305e9f/receipt-alpha.pdf, 019f6c9c-ff09-73dd-9a80-8ae97a305e9f/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -3889,12 +4872,15 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets all criteria: creates a private user-files bucket, keeps RLS enabled, adds authenticated owner-scoped SELECT and INSERT policies on storage.objects using folder prefix = auth.uid(), and provides supabase-js createSignedUrl with an expiry. No public bucket, permissive policies, anon access, getPublicUrl, or client-side service key usage."
+        "judgeNotes": "Meets requirements: private user-files bucket, authenticated owner-scoped SELECT and INSERT policies with WITH CHECK, no RLS disabling or public access, and signed URL sharing via createSignedUrl with expiry."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
@@ -3926,22 +4912,25 @@
       {
         "name": "pgTAP test file(s) written under supabase/tests/",
         "passed": true,
-        "notes": "1 file(s): supabase/tests/tenant_isolation_test.sql"
+        "notes": "1 file(s): supabase/tests/rls_tenant_isolation_test.sql"
       },
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "6 passed, 2 failed"
+        "notes": "9 passed, 3 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as the table with the broken tenant isolation policy, explains that authenticated members can read posts from organizations they are not members of, and grounds the conclusion in pgTAP test failures. It also correctly treats `notes` as isolated and the test results as authoritative."
+        "judgeNotes": "The agent correctly identifies posts as having the broken tenant isolation policy, specifically that members of any org can read posts from other orgs because the policy checks only membership existence and not org_id. It grounds this in the pgTAP failure (test 8) and treats the test results as authoritative. It also discusses memberships, but does not blame notes and explicitly says notes isolation passes."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
@@ -4007,6 +4996,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
     "attempts": 1,
@@ -4039,21 +5031,53 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Adds Supabase scrape over HTTPS to /customer/v1/privileged/metrics using HTTP Basic Auth with password_file, preserves app scrape, and docker-compose mounts the secrets directory containing the password file."
+        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase metrics endpoint with correct path and project target, uses HTTP Basic Auth with password_file, and docker-compose mounts the secrets directory containing that password file."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes steps to create a Secret API key, write it to the mounted secret file, reload Prometheus, and verify via Prometheus targets or direct curl."
+        "judgeNotes": "README includes required live setup steps: create Secret API key, place it in the mounted secret file, replace project ref, and restart/reload Compose/Prometheus. It also provides concrete verification via Prometheus Targets, direct curl, and Grafana dashboard."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"project metrics endpoint prometheus\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
+              "title": "Manual replication monitoring"
+            }
+          ],
+          "resultChars": 27147
+        }
+      ]
+    },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-sonnet-5-no-skills/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -4099,6 +5123,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
@@ -4148,6 +5175,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
@@ -4204,13 +5234,16 @@
       },
       {
         "name": "diagnosed and explained session revocation",
-        "passed": false,
-        "judgeNotes": "The answer correctly diagnoses the soft-delete-only flow, implements auth-layer revocation via banning and session deletion, explains JWT expiry behavior, and correctly distinguishes publishable vs secret keys. However, it does not clarify that server-side checks should use auth.getUser() or short JWT expiry rather than only local JWT validation such as getClaims(), which is an explicit passing requirement."
+        "passed": true,
+        "judgeNotes": "The answer diagnoses the soft-delete-only bug, implements real session/refresh-token revocation and blocks future sign-in, explains JWT expiry and the remaining/local-validation window consistently with its RLS mitigation, and correctly states publishable keys are client-safe while secret/service-role keys are server-only and bypass RLS. There is one slightly contradictory closing phrase about RLS being the enforcement layer regardless of key, but the surrounding explanation clearly says secret keys bypass RLS."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -4263,12 +5296,15 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "Identifies the missing orders table in supabase_realtime publication as root cause, explains SUBSCRIBED without INSERT events, adds public.orders via ALTER PUBLICATION, preserves courier_locations and does not alter RLS/policies or blame client/networking."
+        "judgeNotes": "Diagnosed the missing orders table in supabase_realtime publication, added public.orders to the existing publication, preserved courier_locations and RLS/policies, and did not blame or alter unrelated areas."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
@@ -4299,22 +5335,25 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as affected and described the recurring 8 HTTP 503 gateway failures across the morning of 2026-04-28 (roughly 07:00Z-12:00Z), while distinguishing unrelated billing-webhook 503s."
+        "judgeNotes": "The assistant identified `image-transform` as the main affected function and described a recurring morning pattern of gateway HTTP 503s on 2026-04-28 with timestamps spread from 07:00Z to 12:00Z. Although it listed five rather than all eight failures, it recognized the correct function and recurring pattern, satisfying the pass criteria."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "Attributes the 503s to the gateway/platform layer before function invocation, grounded in absence of corresponding runtime logs for failed requests and unchanged deployment/version. It also distinguishes these from avatar-upload's function-level 500."
+        "judgeNotes": "Attributes recurring image-transform 503s to gateway/infrastructure layer, grounded in observation that 503s appear only in API gateway logs with no corresponding edge-function execution logs, while nearby requests succeeded. It also distinguishes avatar-upload's function-level 500 from the gateway 503s."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended multiple concrete next steps, including correlating traffic volume for the specific time window, adding instrumentation, moving image processing async, checking/raising function memory/time limits, and setting up gateway 503 alerting."
+        "judgeNotes": "The assistant recommended concrete next steps: checking bundle/init cost, adding warm-up pings and retries, investigating the separate function error, and adding monitoring/alerting. These are specific actionable steps beyond vague log checking."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
@@ -4372,12 +5411,15 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies as deny-all for Data API users, kept RLS enabled, and created authenticated-role SELECT and INSERT policies scoped to user_id = auth.uid() with USING and WITH CHECK."
+        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies as deny-all for the Data API, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid(), using WITH CHECK for INSERT."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -4428,12 +5470,15 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Avatar migration was applied through `supabase db push` in action #16, with output showing `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration history was reconciled by adding the missing local migration file `20240115000000_add_profile_bio.sql` in action #14, after which `supabase migration list` showed local and remote aligned in action #15. Only read-only `psql` inspection was used; no disallowed workaround was observed."
+        "judgeNotes": "Avatar migration was applied by `supabase db push` in #19, which shows `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration was reconciled by adding the matching local migration file `20240115000000_add_profile_bio.sql` in #17, after which `supabase migration list` in #18 showed local and remote aligned. Only read-only psql inspection was used; no direct SQL mutation or prepared-statement workaround was seen."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
@@ -4487,6 +5532,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -4557,6 +5605,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -4626,6 +5677,905 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"local development migrations RLS insert policies seed data Data API exposed table\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api",
+              "title": "Securing your API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#add-rls-policies",
+              "title": "Add RLS policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#grant-access-explicitly",
+              "title": "Grant access explicitly"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#use-a-dedicated-api-schema",
+              "title": "Use a dedicated API schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#default-privileges-for-new-tables-and-functions",
+              "title": "Default privileges for new tables and functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#examples",
+              "title": "Examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#accessing-request-information",
+              "title": "Accessing request information"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#enforce-additional-rules-on-each-request",
+              "title": "Enforce additional rules on each request"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#disable-the-data-api",
+              "title": "Disable the Data API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-2-start-the-local-stack",
+              "title": "Step 2: Start the local stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-3-create-your-schema",
+              "title": "Step 3: Create your schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-4-add-seed-data",
+              "title": "Step 4: Add seed data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-5-verify",
+              "title": "Step 5: Verify"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-6-commit",
+              "title": "Step 6: Commit"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#the-daily-workflow",
+              "title": "The daily workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#making-schema-changes",
+              "title": "Making schema changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#generating-types",
+              "title": "Generating types"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#staying-in-sync-with-your-team",
+              "title": "Staying in sync with your team"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#pushing-to-a-remote-project",
+              "title": "Pushing to a remote project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#resetting-a-remote-dev-or-staging-project",
+              "title": "Resetting a remote dev or staging project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#key-commands-at-a-glance",
+              "title": "Key commands at a glance"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#cleaning-up-generated-migrations",
+              "title": "Cleaning up generated migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#grants",
+              "title": "Grants"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#revokere-grant-patterns",
+              "title": "Revoke/re-grant patterns"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#extension-statements",
+              "title": "Extension statements"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#known-limitations-of-db-diff",
+              "title": "Known limitations of db diff"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#the-supabase-directory",
+              "title": "The ./supabase directory"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#move-an-existing-project-to-local-development",
+              "title": "Move an existing project to local development"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-1-initialize",
+              "title": "Step 1: Initialize"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-2-authenticate",
+              "title": "Step 2: Authenticate"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-3-link-to-your-remote-project",
+              "title": "Step 3: Link to your remote project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-4-pull-the-remote-schema",
+              "title": "Step 4: Pull the remote schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-5-create-seed-data",
+              "title": "Step 5: Create seed data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-6-verify",
+              "title": "Step 6: Verify"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-7-commit",
+              "title": "Step 7: Commit"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#start-a-new-project-from-scratch",
+              "title": "Start a new project from scratch"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-1-initialize-1",
+              "title": "Step 1: Initialize"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#more-information",
+              "title": "More information"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#frontend-access",
+              "title": "Frontend access"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#direct-database-connections",
+              "title": "Direct database connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#edge-functions",
+              "title": "Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#data-api",
+              "title": "Data API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#connecting-your-app-securely",
+              "title": "Connecting your app securely"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres",
+              "title": "Connect to your database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection",
+              "title": "Direct connection"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#data-apis-and-client-libraries",
+              "title": "Data APIs and client libraries"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#quickstarts",
+              "title": "Quickstarts"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#how-to-connect-to-your-postgres-databases",
+              "title": "How to connect to your Postgres databases"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#what-is-the-max-pooler-clients-limit",
+              "title": "What is the max pooler clients limit?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#how-to-choose-the-right-connection-method",
+              "title": "How to choose the right connection method?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#does-connection-pooling-affect-latency",
+              "title": "Does connection pooling affect latency?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#why-do-connection-strings-have-different-ports",
+              "title": "Why do connection strings have different ports?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#why-are-there-active-connections-when-the-app-is-idle",
+              "title": "Why are there active connections when the app is idle?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#where-can-you-see-current-connection-usage",
+              "title": "Where can you see current connection usage?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#what-is-the-difference-between-client-connections-and-backend-connections",
+              "title": "What is the difference between client connections and backend connections?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#how-does-the-default-pool-size-work",
+              "title": "How does the default pool size work?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#can-you-use-supavisor-and-pgbouncer-together",
+              "title": "Can you use Supavisor and PgBouncer together?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#where-is-the-postgres-connection-string-in-supabase",
+              "title": "Where is the Postgres connection string in Supabase?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#how-do-you-connect-using-ipv4",
+              "title": "How do you connect using IPv4?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#what-is-the-fatal-password-authentication-failed-error",
+              "title": "What is the “FATAL: Password authentication failed” error?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#what-is-a-connection-refused-error",
+              "title": "What is a “connection refused” error?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#troubleshooting-and-postgres-connection-string-faqs",
+              "title": "Troubleshooting and Postgres connection string FAQs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#resources",
+              "title": "Resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#connecting-with-ssl",
+              "title": "Connecting with SSL"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#server-side-poolers",
+              "title": "Server-side poolers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#application-side-poolers",
+              "title": "Application-side poolers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#more-about-connection-pooling",
+              "title": "More about connection pooling"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#dedicated-pooler",
+              "title": "Dedicated pooler"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#pooler-transaction-mode",
+              "title": "Pooler transaction mode"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#pooler-session-mode",
+              "title": "Pooler session mode"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres#poolers",
+              "title": "Poolers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling",
+              "title": "Storage Optimizations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#egress",
+              "title": "Egress"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#optimizing-rls",
+              "title": "Optimizing RLS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#optimize-listing-objects",
+              "title": "Optimize listing objects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#smart-cdn",
+              "title": "Smart CDN"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#limit-the-upload-size",
+              "title": "Limit the upload size"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#set-a-high-cache-control-value",
+              "title": "Set a high cache-control value"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/production/scaling#resize-images",
+              "title": "Resize images"
+            }
+          ],
+          "resultChars": 180379
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com changelog.md supabase",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "\"https://supabase.com/changelog.md\"",
+          "pages": []
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase CLI init migration new seed local development\", limit: 10) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#the-supabase-directory",
+              "title": "The ./supabase directory"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#move-an-existing-project-to-local-development",
+              "title": "Move an existing project to local development"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-1-initialize",
+              "title": "Step 1: Initialize"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-2-authenticate",
+              "title": "Step 2: Authenticate"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-3-link-to-your-remote-project",
+              "title": "Step 3: Link to your remote project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-4-pull-the-remote-schema",
+              "title": "Step 4: Pull the remote schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-5-create-seed-data",
+              "title": "Step 5: Create seed data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-6-verify",
+              "title": "Step 6: Verify"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-7-commit",
+              "title": "Step 7: Commit"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#start-a-new-project-from-scratch",
+              "title": "Start a new project from scratch"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-1-initialize-1",
+              "title": "Step 1: Initialize"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-2-start-the-local-stack",
+              "title": "Step 2: Start the local stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-3-create-your-schema",
+              "title": "Step 3: Create your schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-4-add-seed-data",
+              "title": "Step 4: Add seed data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-5-verify",
+              "title": "Step 5: Verify"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#step-6-commit",
+              "title": "Step 6: Commit"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#the-daily-workflow",
+              "title": "The daily workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#making-schema-changes",
+              "title": "Making schema changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#generating-types",
+              "title": "Generating types"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#staying-in-sync-with-your-team",
+              "title": "Staying in sync with your team"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#pushing-to-a-remote-project",
+              "title": "Pushing to a remote project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#resetting-a-remote-dev-or-staging-project",
+              "title": "Resetting a remote dev or staging project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#key-commands-at-a-glance",
+              "title": "Key commands at a glance"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#cleaning-up-generated-migrations",
+              "title": "Cleaning up generated migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#grants",
+              "title": "Grants"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#revokere-grant-patterns",
+              "title": "Revoke/re-grant patterns"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#extension-statements",
+              "title": "Extension statements"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#known-limitations-of-db-diff",
+              "title": "Known limitations of db diff"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#add-sample-data",
+              "title": "Add sample data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#deploy-your-project",
+              "title": "Deploy your project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#diffing-changes",
+              "title": "Diffing changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#log-in-to-the-supabase-cli",
+              "title": "Log in to the Supabase CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#link-your-project",
+              "title": "Link your project"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#deploy-database-changes",
+              "title": "Deploy database changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#deploy-edge-functions",
+              "title": "Deploy Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#use-auth-locally",
+              "title": "Use Auth locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#sync-storage-buckets",
+              "title": "Sync storage buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#sync-any-schema-with---schema",
+              "title": "Sync any schema with --schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#limitations-and-considerations",
+              "title": "Limitations and considerations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations#database-migrations",
+              "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/seeding-your-database",
+              "title": "Seeding your database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/seeding-your-database#generating-seed-data",
+              "title": "Generating seed data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/seeding-your-database#what-is-seed-data",
+              "title": "What is seed data?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/seeding-your-database#using-seed-files",
+              "title": "Using seed files"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/seeding-your-database#splitting-up-your-seed-file",
+              "title": "Splitting up your seed file"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cli",
+              "title": "Local Dev with CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cli#resources",
+              "title": "Resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech",
+              "title": "Transcription Telegram Bot"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#create-a-supabase-edge-function-to-handle-telegram-webhook-requests",
+              "title": "Create a Supabase Edge Function to handle Telegram webhook requests"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#set-up-the-environment-variables",
+              "title": "Set up the environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#dependencies",
+              "title": "Dependencies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#code-the-telegram-bot",
+              "title": "Code the Telegram bot"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#deploy-to-supabase",
+              "title": "Deploy to Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#apply-the-database-migrations",
+              "title": "Apply the database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#set-up-the-webhook",
+              "title": "Set up the webhook"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#set-the-function-secrets",
+              "title": "Set the function secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#test-the-bot",
+              "title": "Test the bot"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#introduction",
+              "title": "Introduction"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#requirements",
+              "title": "Requirements"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#setup",
+              "title": "Setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#register-a-telegram-bot",
+              "title": "Register a Telegram bot"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#create-a-supabase-project-locally",
+              "title": "Create a Supabase project locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech#create-a-database-table-to-log-the-transcription-results",
+              "title": "Create a database table to log the transcription results"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream",
+              "title": "Streaming Speech with ElevenLabs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#configure-background-tasks-for-supabase-edge-functions",
+              "title": "Configure background tasks for Supabase Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#configure-the-storage-bucket",
+              "title": "Configure the storage bucket"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#create-a-supabase-project-locally",
+              "title": "Create a Supabase project locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#setup",
+              "title": "Setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#requirements",
+              "title": "Requirements"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#try-it-out",
+              "title": "Try it out"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#run-locally",
+              "title": "Run locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#set-the-function-secrets",
+              "title": "Set the function secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#test-the-function",
+              "title": "Test the function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#deploy-to-supabase",
+              "title": "Deploy to Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#code-the-supabase-edge-function",
+              "title": "Code the Supabase Edge Function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#dependencies",
+              "title": "Dependencies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#set-up-the-environment-variables",
+              "title": "Set up the environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#create-a-supabase-edge-function-for-speech-generation",
+              "title": "Create a Supabase Edge Function for speech generation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream#introduction",
+              "title": "Introduction"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration",
+              "title": "GitHub integration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#preparing-your-git-repository",
+              "title": "Preparing your Git repository"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#set-the-working-directory",
+              "title": "Set the working directory"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#installation",
+              "title": "Installation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#email-notifications",
+              "title": "Email notifications"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#preventing-migration-failures",
+              "title": "Preventing migration failures"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#deploying-changes-to-production",
+              "title": "Deploying changes to production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#seeding",
+              "title": "Seeding"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#migrations",
+              "title": "Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#configuration",
+              "title": "Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/github-integration#syncing-github-branches",
+              "title": "Syncing GitHub branches"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started",
+              "title": "Supabase CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#installing-the-supabase-cli",
+              "title": "Installing the Supabase CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#beta-channel",
+              "title": "Beta channel"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#learn-more",
+              "title": "Learn more"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#how-to-opt-out",
+              "title": "How to opt out"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#telemetry",
+              "title": "Telemetry"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#stopping-local-services",
+              "title": "Stopping local services"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#access-your-projects-services",
+              "title": "Access your project's services"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#running-supabase-locally",
+              "title": "Running Supabase locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started#updating-the-supabase-cli",
+              "title": "Updating the Supabase CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments",
+              "title": "Managing Environments"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#set-up-a-local-environment",
+              "title": "Set up a local environment"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#release-to-production",
+              "title": "Release to production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#open-a-pr-with-new-migration",
+              "title": "Open a PR with new migration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#configure-github-actions",
+              "title": "Configure GitHub Actions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#rebasing-new-migrations",
+              "title": "Rebasing new migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#permission-denied-on-db-push",
+              "title": "Permission denied on db push"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#permission-denied-on-db-pull",
+              "title": "Permission denied on db pull"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#sync-production-project-to-staging",
+              "title": "Sync production project to staging"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#deploy-a-migration",
+              "title": "Deploy a migration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#auto-schema-diff",
+              "title": "Auto schema diff"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#manual-migration",
+              "title": "Manual migration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments#create-a-new-migration",
+              "title": "Create a new migration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches",
+              "title": "Working with branches"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#managing-branch-environments",
+              "title": "Managing branch environments"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#subscribing-to-notifications",
+              "title": "Subscribing to notifications"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#migration-and-seeding-behavior",
+              "title": "Migration and seeding behavior"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#using-orm-or-custom-seed-scripts",
+              "title": "Using ORM or custom seed scripts"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#rolling-back-migrations",
+              "title": "Rolling back migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#seeding-behavior",
+              "title": "Seeding behavior"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#developing-with-branches",
+              "title": "Developing with branches"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#local-development-workflow",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#remote-development-workflow",
+              "title": "Remote development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#switching-between-branches",
+              "title": "Switching between branches"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#accessing-branch-credentials",
+              "title": "Accessing branch credentials"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#branch-isolation",
+              "title": "Branch isolation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches#next-steps",
+              "title": "Next steps"
+            }
+          ],
+          "resultChars": 396779
+        }
+      ]
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -4679,9 +6629,41 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"declarative database schemas supabase local development alter table add column\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/tables",
+              "title": "Tables and Data"
+            }
+          ],
+          "resultChars": 96255
+        }
+      ]
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema.json"
   },
   {
@@ -4732,6 +6714,334 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"cron jobs queue edge function tasks schedule background worker\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } ... on ClientLibraryFunctionReference { language methodName } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions",
+              "title": "Scheduling Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions#resources",
+              "title": "Resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions#invoke-an-edge-function-every-minute",
+              "title": "Invoke an Edge Function every minute"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions#examples",
+              "title": "Examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#delete-usage",
+              "title": "Usage "
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#enable-the-extension",
+              "title": "Enable the extension"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#get-signature",
+              "title": "Signature "
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#get-usage",
+              "title": "Usage "
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#http_post",
+              "title": "http_post"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#post-signature",
+              "title": "Signature "
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#call-an-endpoint-every-minute-with-pg_cron",
+              "title": "Call an endpoint every minute with pg_cron"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#execute-pg_net-in-a-trigger",
+              "title": "Execute pg_net in a trigger"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#send-multiple-table-rows-in-one-request",
+              "title": "Send multiple table rows in one request"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#limitations",
+              "title": "Limitations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#resources",
+              "title": "Resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#debugging-requests",
+              "title": "Debugging requests"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#analyzing-responses",
+              "title": "Analyzing responses"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#http_get",
+              "title": "http_get"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#post-usage",
+              "title": "Usage "
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#http_delete",
+              "title": "http_delete"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#post-signature-1",
+              "title": "Signature "
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#inspecting-request-data",
+              "title": "Inspecting request data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#inspecting-failed-requests",
+              "title": "Inspecting failed requests"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#configuration",
+              "title": "Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#get-current-settings",
+              "title": "Get current settings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#alter-settings",
+              "title": "Alter settings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#examples",
+              "title": "Examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net#invoke-a-supabase-edge-function",
+              "title": "Invoke a Supabase Edge Function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/background-tasks",
+              "title": "Background Tasks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/background-tasks#overview",
+              "title": "Overview"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/background-tasks#handling-errors",
+              "title": "Handling errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/background-tasks#testing-background-tasks-locally",
+              "title": "Testing background tasks locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings",
+              "title": "Automatic embeddings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#see-also",
+              "title": "See also"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#why-not-one-request-per-row",
+              "title": "Why not one request per row?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#is-10-seconds-a-good-interval-for-processing",
+              "title": "Is 10 seconds a good interval for processing?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#step-4-create-the-edge-function",
+              "title": "Step 4: Create the Edge Function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#how-do-visibility-timeouts-work",
+              "title": "How do visibility timeouts work?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#why-queue-requests-instead-of-processing-them-immediately",
+              "title": "Why queue requests instead of processing them immediately?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#why-not-generate-all-embeddings-in-a-single-edge-function-request",
+              "title": "Why not generate all embeddings in a single Edge Function request?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#step-3-create-queue-and-triggers",
+              "title": "Step 3: Create queue and triggers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#step-2-create-utility-functions",
+              "title": "Step 2: Create utility functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#step-1-enable-extensions",
+              "title": "Step 1: Enable extensions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#implementation",
+              "title": "Implementation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#understanding-the-architecture",
+              "title": "Understanding the architecture"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#understanding-the-challenge",
+              "title": "Understanding the challenge"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#conclusion",
+              "title": "Conclusion"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#how-do-we-handle-retries",
+              "title": "How do we handle retries?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#usage",
+              "title": "Usage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#1-create-table-to-store-documents-with-embeddings",
+              "title": "1. Create table to store documents with embeddings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#2-create-triggers-to-enqueue-embedding-jobs",
+              "title": "2. Create triggers to enqueue embedding jobs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#optional-clearing-embeddings-on-update",
+              "title": "(Optional) Clearing embeddings on update"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings#3-insert-and-update-documents",
+              "title": "3. Insert and update documents"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#inspecting-job-runs",
+              "title": "Inspecting job runs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#caution-scheduling-system-maintenance",
+              "title": "Caution: Scheduling system maintenance"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#invoke-supabase-edge-function-every-30-seconds",
+              "title": "Invoke Supabase Edge Function every 30 seconds"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#call-a-database-stored-procedure",
+              "title": "Call a database stored procedure"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#call-a-database-function-every-5-minutes",
+              "title": "Call a database function every 5 minutes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#run-a-vacuum-every-day",
+              "title": "Run a vacuum every day"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#delete-data-every-week",
+              "title": "Delete data every week"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#examples",
+              "title": "Examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#unschedule-a-job",
+              "title": "Unschedule a job"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#activatedeactivate-a-job",
+              "title": "Activate/Deactivate a job"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#edit-a-job",
+              "title": "Edit a job"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart#schedule-a-job",
+              "title": "Schedule a job"
+            }
+          ],
+          "resultChars": 142727
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"pgmq create queue pop delete read Supabase queues create queue\", limit: 10) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues",
+              "title": "Supabase Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/expose-self-hosted-queues",
+              "title": "Expose Queues for local and self-hosted Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/consuming-messages-with-edge-functions",
+              "title": "Consuming Supabase Queue Messages with Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/api",
+              "title": "API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pgmq",
+              "title": "pgmq: Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/pgmq",
+              "title": "PGMQ Extension"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/migrating-to-supabase",
+              "title": "Migrating to Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes",
+              "title": "Subscribing to Database Changes"
+            }
+          ],
+          "resultChars": 50907
+        }
       ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
@@ -4790,6 +7100,9 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
     "attempts": 2,
@@ -4838,12 +7151,12 @@
       {
         "name": "user A cannot force-read user B note",
         "passed": true,
-        "notes": "status=200"
+        "notes": "status=403"
       },
       {
         "name": "user B cannot force-read user A note",
         "passed": true,
-        "notes": "status=200"
+        "notes": "status=403"
       }
     ],
     "skills": {
@@ -4853,6 +7166,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Edge Functions get user auth createClient Authorization header anon key\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs",
+              "title": "Build a User Management App with Next.js"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            }
+          ],
+          "resultChars": 84907
+        }
       ]
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
@@ -4884,7 +7229,7 @@
     "suite": "benchmark",
     "interface": "cli",
     "cliVersion": "2.109.1",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "seed rows present",
@@ -4894,37 +7239,37 @@
       {
         "name": "rejects request with no credentials",
         "passed": true,
-        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "user with JWT reads only their own rows",
-        "passed": true,
-        "notes": "status 200: [{\"user_id\":\"50aa3479-a830-489b-9394-0e0d94ee43fe\",\"metric\":\"steps_a_mrnhhgc0\",\"value\":111}]"
+        "passed": false,
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
-        "passed": true,
-        "notes": "status 200: [{\"user_id\":\"50aa3479-a830-489b-9394-0e0d94ee43fe\",\"metric\":\"steps_a_mrnhhgc0\",\"value\":111}]"
+        "passed": false,
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
-        "passed": true,
-        "notes": "status 200: [{\"user_id\":\"0e745e1d-e46c-4853-b519-ca4ea1895df4\",\"metric\":\"steps_b_mrnhhgc0\",\"value\":222}]"
+        "passed": false,
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "non-service key is not granted service access",
         "passed": true,
-        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "rejects an unverified (forged) user token",
         "passed": true,
-        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "a user token in the apikey slot is not treated as the service key",
         "passed": true,
-        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+        "notes": "status 503: {\"message\":\"name resolution failed\"}"
       },
       {
         "name": "implementation uses @supabase/server",
@@ -4939,6 +7284,134 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"Edge Functions authentication service_role getUser verify JWT supabase-js\", limit: 5) {\n    nodes {\n      __typename\n      ... on Guide {\n        title\n        href\n        content\n      }\n      ... on ClientLibraryFunctionReference {\n        title\n        href\n        content\n        language\n        methodName\n      }\n      ... on TroubleshootingGuide {\n        title\n        href\n        content\n      }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs",
+              "title": "Build a User Management App with Next.js"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/jwts",
+              "title": "JSON Web Token (JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions",
+              "title": "Edge Functions"
+            }
+          ],
+          "resultChars": 84447
+        },
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"verify_jwt edge functions auth secret user combined modes withSupabase\", limit: 10) {\n    nodes {\n      __typename\n      ... on Guide { title href content }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/jwts",
+              "title": "JSON Web Token (JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/auth-mfa",
+              "title": "Multi-Factor Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/websockets",
+              "title": "Handling WebSockets"
+            }
+          ],
+          "resultChars": 120341
+        },
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"supabase functions config.toml entrypoint import_map local serve\", limit: 10) {\n    nodes {\n      __typename\n      ... on Guide { title href content }\n      ... on CLICommandReference { title href content }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/dependencies",
+              "title": "Managing dependencies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/managing-config",
+              "title": "Managing config and secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream",
+              "title": "Streaming Speech with ElevenLabs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/third-party/clerk",
+              "title": "Clerk"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment",
+              "title": "Deployment & Branching"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-functions-serve",
+              "title": "Serve all Functions locally"
+            }
+          ],
+          "resultChars": 79104
+        }
       ]
     },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
@@ -4984,7 +7457,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-4140-76ca-8edb-5f20209955b7/receipt-alpha.pdf, 019f4d37-4140-76ca-8edb-5f20209955b7/receipt-beta.pdf"
+        "notes": "saw: 019f6c9d-1652-7625-a693-586f70ac5f7c/receipt-alpha.pdf, 019f6c9d-1652-7625-a693-586f70ac5f7c/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -5005,7 +7478,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets all requirements: private user-files bucket, RLS kept enabled, authenticated owner-scoped SELECT and INSERT policies with WITH CHECK, and supabase-js createSignedUrl with expiry for sharing."
+        "judgeNotes": "Configured a private user-files bucket, owner-scoped authenticated SELECT and INSERT policies with WITH CHECK on storage.objects while keeping RLS intact, and provided supabase-js createSignedUrl code with an expiry. No fail conditions present."
       }
     ],
     "skills": {
@@ -5015,6 +7488,92 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Storage policy restrict file uploads to authenticated user's folder path RLS bucket storage.objects signed upload signed URL\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on TroubleshootingGuide { title href content } ... on ClientLibraryFunctionReference { title href language methodName content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/storage-error-403-forbidden-new-row-violates-row-level-security-policy-on-upload-a94384",
+              "title": "Storage error: 403 Forbidden: 'new row violates row-level security policy' on upload"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/buckets/fundamentals",
+              "title": "Storage Buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/helper-functions",
+              "title": "Storage Helper Functions"
+            }
+          ],
+          "resultChars": 23119
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"supabase-js storage from createSignedUrl signed url method syntax JavaScript\", limit: 5) { nodes { __typename ... on ClientLibraryFunctionReference { title href language methodName content } ... on Guide { title href content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads",
+              "title": "Serving assets from Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurl"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurls"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads",
+              "title": "Resumable Uploads"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-saml-sso",
+              "title": "Configure SAML SSO"
+            }
+          ],
+          "resultChars": 47474
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"storage.objects create policy authenticated foldername auth.uid select insert update delete\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on ClientLibraryFunctionReference { title href language methodName content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/management/copy-move-objects",
+              "title": "Copy Objects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/custom-roles",
+              "title": "Custom Roles"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/quickstart",
+              "title": "Storage Quickstart"
+            }
+          ],
+          "resultChars": 29933
+        }
       ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
@@ -5052,12 +7611,12 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "6 passed, 0 failed"
+        "notes": "9 passed, 0 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as having the tenant isolation flaw: authenticated users could read posts for organizations they are not members of because the policy checked membership in any org rather than the row's `org_id`. It also grounds the conclusion in pgTAP verification. Although it additionally discusses `memberships`, it does not blame `notes` or dismiss the test results."
+        "judgeNotes": "The agent correctly identifies `posts` as having a tenant isolation flaw, specifically exposing posts to authenticated members outside the post's org, and treats pgTAP testing as verification. It does mention other tables, including `memberships` and `notes`, but does not blame `notes` instead of `posts`."
       }
     ],
     "skills": {
@@ -5067,6 +7626,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"row level security testing local auth.uid pgtap policies\", limit: 5) {\n    nodes {\n      title\n      href\n      content\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/overview",
+              "title": "Testing Overview"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/pgtap-extended",
+              "title": "Advanced pgTAP Testing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/features",
+              "title": "Features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/testing",
+              "title": "Testing Your Database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pgtap",
+              "title": "pgTAP: Unit Testing"
+            }
+          ],
+          "resultChars": 56902
+        }
       ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -5105,12 +7696,12 @@
       {
         "name": "HNSW index on the embedding column",
         "passed": true,
-        "notes": "CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
+        "notes": "CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops) WHERE (embedding IS NOT NULL)"
       },
       {
         "name": "index operator class matches the search operator",
         "passed": true,
-        "notes": "function operators: <=>\nindexes: CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
+        "notes": "function operators: <=>\nindexes: CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops) WHERE (embedding IS NOT NULL)"
       },
       {
         "name": "user A search returns only own sections, best match first",
@@ -5135,12 +7726,136 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"pgvector semantic search row level security documents owned by user\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/rag-with-permissions",
+              "title": "RAG with Permissions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/features",
+              "title": "Features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/hybrid-search",
+              "title": "Hybrid search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            }
+          ],
+          "resultChars": 81105
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase vector index hnsw cosine ops syntax extensions.vector\", limit: 10) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/vector-indexes/hnsw-indexes",
+              "title": "HNSW indexes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM",
+              "title": "Increase vector lookup speeds by applying an HSNW index"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/vector-indexes/ivf-indexes",
+              "title": "IVFFlat indexes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/vector-indexes",
+              "title": "Vector indexes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/vector/working-with-indexes",
+              "title": "Working with Vector Indexes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/vector-columns",
+              "title": "Vector columns"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/vector/querying-vectors",
+              "title": "Querying Vectors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/going-to-prod",
+              "title": "Going to Production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/vecs-python-client",
+              "title": "Python client"
+            }
+          ],
+          "resultChars": 89986
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Project not specified edge functions endpoint supabase functions host project ref\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/log-drains",
+              "title": "Log Drains"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/analytics/connecting-to-analytics-bucket",
+              "title": "Iceberg Catalog"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/quickstart-dashboard",
+              "title": "Getting Started with Edge Functions (Dashboard)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/architecture",
+              "title": "Edge Functions Architecture"
+            }
+          ],
+          "resultChars": 42668
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com \"Project not specified\" \"functions.supabase.co\" supabase",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "\"Project not specified\" \"Supabase\" \"functions\"",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/docs \"functions/v1\" \"Project not specified\"",
+          "pages": []
+        }
       ]
     },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini/build-vectors-001-rag-with-permissions.json"
   },
   {
@@ -5170,12 +7885,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails because prometheus.yml uses basic_auth.password from an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount the password_file via a volume or Compose secret."
+        "judgeNotes": "Fails because the Supabase scrape uses basic_auth.password with an injected Secret API key instead of basic_auth.password_file, and docker-compose.yml does not mount that password_file via a volume or Compose secret. The app scrape is preserved and endpoint/HTTPS target are otherwise correct."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README explains creating a Supabase Secret API key and starting the Compose stack, but it does not require placing a matching secret file, and the setup uses environment variables instead. It also lacks concrete verification steps such as checking Prometheus targets or running PromQL/Grafana queries."
+        "judgeNotes": "README mentions creating a Supabase Secret API key and setting env vars, but it does not instruct placing a matching secret file, lacks a concrete compose restart/reload command, and does not include concrete verification via Prometheus targets, PromQL, Grafana, or equivalent."
       }
     ],
     "skills": {
@@ -5185,6 +7900,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"metrics prometheus supabase project metrics endpoint observability\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on CLICommandReference { title href content } ... on ClientLibraryFunctionReference { title href content } ... on ManagementApiReference { title href content } ... on TroubleshootingGuide { title href content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas",
+              "title": "Read Replicas"
+            }
+          ],
+          "resultChars": 32819
+        }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -5241,6 +7988,38 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Edge Functions secrets deploy WEATHER_API_KEY runtime environment variables\", limit: 5) { nodes { ... on Guide { title href content } ... on CLICommandReference { title href content } ... on ManagementApiReference { title href content } ... on ClientLibraryFunctionReference { title href content language methodName } ... on TroubleshootingGuide { title href content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/integrations/supabase-for-platforms",
+              "title": "Supabase for Platforms"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            }
+          ],
+          "resultChars": 51647
+        }
+      ]
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -5295,6 +8074,918 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"self-hosting docker compose Supabase official docker compose env secrets\", limit: 5) { nodes { title href ... on Guide { content subsections { nodes { title href content } } } ... on CLICommandReference { content } ... on TroubleshootingGuide { content } } totalCount } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#how-it-works",
+              "title": "How it works"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#what-client-sdk-sends",
+              "title": "What client SDK sends"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#kong-api-gateway-routing",
+              "title": "Kong API gateway routing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#request-flows",
+              "title": "Request flows"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#unauthenticated-requests-api-key-only-no-user-session-jwt",
+              "title": "Unauthenticated requests (API key only, no user session JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#authenticated-requests-user-session-jwt",
+              "title": "Authenticated requests (user session JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#adding-the-new-keys",
+              "title": "Adding the new keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#new-api-keys-format",
+              "title": "New API keys format"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#verifying-the-setup",
+              "title": "Verifying the setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#environment-variables-configuration",
+              "title": "Environment variables configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#differences-from-the-supabase-platform",
+              "title": "Differences from the Supabase platform"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#backward-compatibility",
+              "title": "Backward compatibility"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#rotating-the-new-api-keys",
+              "title": "Rotating the new API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#regenerating-asymmetric-key-pair",
+              "title": "Regenerating asymmetric key pair"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker",
+              "title": "Self-Hosting with Docker"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-secrets",
+              "title": "Configuring secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#setting-database-password",
+              "title": "Setting database password"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#changing-database-password",
+              "title": "Changing database password"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-supabase-services",
+              "title": "Configuring Supabase services"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-social-login-oauth-providers",
+              "title": "Configuring social login (OAuth) providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-phone-login-sms-and-mfa",
+              "title": "Configuring phone login, SMS, and MFA"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-an-email-server",
+              "title": "Configuring an email server"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-s3-storage",
+              "title": "Configuring S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#using-file-backend-in-storage-on-macos",
+              "title": "Using file backend in Storage on macOS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-supabase-ai-assistant",
+              "title": "Configuring Supabase AI Assistant"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-postgres-through-supavisor",
+              "title": "Accessing Postgres through Supavisor"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#exposing-your-postgres-database",
+              "title": "Exposing your Postgres database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#setting-log_min_messages-in-postgres",
+              "title": "Setting log_min_messages in Postgres"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#managing-your-secrets",
+              "title": "Managing your secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#demo",
+              "title": "Demo"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#contents",
+              "title": "Contents"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#system-requirements",
+              "title": "System requirements"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#installing-supabase",
+              "title": "Installing Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#quick-start-linux",
+              "title": "Quick start (Linux)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#manual-installation",
+              "title": "Manual installation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-and-securing-supabase",
+              "title": "Configuring and securing Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#generate-keys-and-secrets",
+              "title": "Generate keys and secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configure-supabase-urls",
+              "title": "Configure Supabase URLs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#where-to-find-your-credentials",
+              "title": "Where to find your credentials"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#studio-authentication",
+              "title": "Studio authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#starting-and-stopping",
+              "title": "Starting and stopping"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-supabase-studio-dashboard",
+              "title": "Accessing Supabase Studio (Dashboard)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-postgres",
+              "title": "Accessing Postgres"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-edge-functions",
+              "title": "Accessing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-apis",
+              "title": "Accessing APIs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#enabling-analytics",
+              "title": "Enabling analytics"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-https",
+              "title": "Configuring HTTPS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#managing-the-stack",
+              "title": "Managing the stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#updating",
+              "title": "Updating"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#uninstalling",
+              "title": "Uninstalling"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#advanced-topics",
+              "title": "Advanced topics"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#architecture",
+              "title": "Architecture"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting",
+              "title": "Self-Hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#get-started",
+              "title": "Get started"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#community-driven-projects",
+              "title": "Community-driven projects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#about-self-hosting",
+              "title": "About self-hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#how-self-hosted-supabase-differs",
+              "title": "How self-hosted Supabase differs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#your-responsibilities-when-self-hosting",
+              "title": "Your responsibilities when self-hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#telemetry",
+              "title": "Telemetry"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#support-and-community",
+              "title": "Support and community"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting#enterprise-self-hosting",
+              "title": "Enterprise self-hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#test-with-the-aws-cli",
+              "title": "Test with the AWS CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#how-to-configure-an-s3-backend",
+              "title": "How to configure an S3 backend"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#using-rustfs",
+              "title": "Using RustFS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#using-minio",
+              "title": "Using MinIO"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#using-aws-s3",
+              "title": "Using AWS S3"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#s3-compatible-providers",
+              "title": "S3-compatible providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#verify",
+              "title": "Verify"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#session-token",
+              "title": "Session token"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#signature-mismatch-errors",
+              "title": "Signature mismatch errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#enable-the-s3-protocol-endpoint",
+              "title": "Enable the S3 protocol endpoint"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#tus-upload-errors-on-cloudflare-r2",
+              "title": "TUS upload errors on Cloudflare R2"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#permission-denied-on-uploads",
+              "title": "Permission denied on uploads"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#upload-urls-point-to-localhost",
+              "title": "Upload URLs point to localhost"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3#test-with-rclone",
+              "title": "Test with rclone"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth",
+              "title": "Configure Social Login (OAuth) Providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#nonce-check-failure-on-mobile-google-sign-in",
+              "title": "Nonce check failure on mobile (Google Sign In)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#oauth-request-flow",
+              "title": "OAuth request flow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#auth-environment-variables",
+              "title": "Auth environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-by-step-configuration",
+              "title": "Step-by-step configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-1-register-your-app-with-the-provider",
+              "title": "Step 1: Register your app with the provider"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-2-configure-environment-variables",
+              "title": "Step 2: Configure environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-3-enable-the-matching-lines-in-docker-compose-configuration",
+              "title": "Step 3: Enable the matching lines in Docker Compose configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-4-restart-the-auth-service",
+              "title": "Step 4: Restart the auth service"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-5-verify-the-configuration",
+              "title": "Step 5: Verify the configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#provider-specific-setup",
+              "title": "Provider-specific setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#other-supported-providers",
+              "title": "Other supported providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#auth-service-fails-to-start",
+              "title": "Auth service fails to start"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#environment-variable-reference",
+              "title": "Environment variable reference"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#variables-added-to-the-environment-but-provider-still-not-working",
+              "title": "Variables added to the environment but provider still not working"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#test-the-login-flow",
+              "title": "Test the login flow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#site-url-or-redirect-url-errors-after-login",
+              "title": "Site URL or redirect URL errors after login"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#provider-not-enabled-or-provider-seen-as-false-in-settings"
+            }
+          ],
+          "resultChars": 341620
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Self-Hosting with Docker quick start Linux generate keys env example docker compose\", limit: 5) { nodes { title href ... on Guide { content subsections { nodes { title href content } } } } totalCount } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker",
+              "title": "Self-Hosting with Docker"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#enabling-analytics",
+              "title": "Enabling analytics"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-an-email-server",
+              "title": "Configuring an email server"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-s3-storage",
+              "title": "Configuring S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#using-file-backend-in-storage-on-macos",
+              "title": "Using file backend in Storage on macOS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-edge-functions",
+              "title": "Accessing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-apis",
+              "title": "Accessing APIs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-phone-login-sms-and-mfa",
+              "title": "Configuring phone login, SMS, and MFA"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-https",
+              "title": "Configuring HTTPS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#managing-the-stack",
+              "title": "Managing the stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#updating",
+              "title": "Updating"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#uninstalling",
+              "title": "Uninstalling"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#advanced-topics",
+              "title": "Advanced topics"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#architecture",
+              "title": "Architecture"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#setting-database-password",
+              "title": "Setting database password"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#changing-database-password",
+              "title": "Changing database password"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-secrets",
+              "title": "Configuring secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-supabase-services",
+              "title": "Configuring Supabase services"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-social-login-oauth-providers",
+              "title": "Configuring social login (OAuth) providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#demo",
+              "title": "Demo"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#managing-your-secrets",
+              "title": "Managing your secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#setting-log_min_messages-in-postgres",
+              "title": "Setting log_min_messages in Postgres"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#exposing-your-postgres-database",
+              "title": "Exposing your Postgres database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-postgres-through-supavisor",
+              "title": "Accessing Postgres through Supavisor"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-supabase-ai-assistant",
+              "title": "Configuring Supabase AI Assistant"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#contents",
+              "title": "Contents"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#system-requirements",
+              "title": "System requirements"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#installing-supabase",
+              "title": "Installing Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#quick-start-linux",
+              "title": "Quick start (Linux)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#manual-installation",
+              "title": "Manual installation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configuring-and-securing-supabase",
+              "title": "Configuring and securing Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#generate-keys-and-secrets",
+              "title": "Generate keys and secrets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#configure-supabase-urls",
+              "title": "Configure Supabase URLs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#where-to-find-your-credentials",
+              "title": "Where to find your credentials"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#studio-authentication",
+              "title": "Studio authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#starting-and-stopping",
+              "title": "Starting and stopping"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-supabase-studio-dashboard",
+              "title": "Accessing Supabase Studio (Dashboard)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker#accessing-postgres",
+              "title": "Accessing Postgres"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#verifying-the-setup",
+              "title": "Verifying the setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#what-client-sdk-sends",
+              "title": "What client SDK sends"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#how-it-works",
+              "title": "How it works"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#regenerating-asymmetric-key-pair",
+              "title": "Regenerating asymmetric key pair"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#rotating-the-new-api-keys",
+              "title": "Rotating the new API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#backward-compatibility",
+              "title": "Backward compatibility"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#differences-from-the-supabase-platform",
+              "title": "Differences from the Supabase platform"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#environment-variables-configuration",
+              "title": "Environment variables configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#kong-api-gateway-routing",
+              "title": "Kong API gateway routing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#new-api-keys-format",
+              "title": "New API keys format"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#adding-the-new-keys",
+              "title": "Adding the new keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#authenticated-requests-user-session-jwt",
+              "title": "Authenticated requests (user session JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#unauthenticated-requests-api-key-only-no-user-session-jwt",
+              "title": "Unauthenticated requests (API key only, no user session JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys#request-flows",
+              "title": "Request flows"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth",
+              "title": "Configure Social Login (OAuth) Providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-4-restart-the-auth-service",
+              "title": "Step 4: Restart the auth service"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#environment-variable-reference",
+              "title": "Environment variable reference"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#auth-service-fails-to-start",
+              "title": "Auth service fails to start"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#nonce-check-failure-on-mobile-google-sign-in",
+              "title": "Nonce check failure on mobile (Google Sign In)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#site-url-or-redirect-url-errors-after-login",
+              "title": "Site URL or redirect URL errors after login"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#variables-added-to-the-environment-but-provider-still-not-working",
+              "title": "Variables added to the environment but provider still not working"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#oauth-request-flow",
+              "title": "OAuth request flow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#auth-environment-variables",
+              "title": "Auth environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-by-step-configuration",
+              "title": "Step-by-step configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-1-register-your-app-with-the-provider",
+              "title": "Step 1: Register your app with the provider"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-2-configure-environment-variables",
+              "title": "Step 2: Configure environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-3-enable-the-matching-lines-in-docker-compose-configuration",
+              "title": "Step 3: Enable the matching lines in Docker Compose configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#step-5-verify-the-configuration",
+              "title": "Step 5: Verify the configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#provider-specific-setup",
+              "title": "Provider-specific setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#other-supported-providers",
+              "title": "Other supported providers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#test-the-login-flow",
+              "title": "Test the login flow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
+              "title": "Envoy API Gateway"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#how-the-configuration-is-rendered-at-startup",
+              "title": "How the configuration is rendered at startup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#routes",
+              "title": "Routes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#authentication",
+              "title": "Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#dashboard-basic-auth",
+              "title": "Dashboard basic auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#api-key-enforcement-on-protected-routes",
+              "title": "API key enforcement on protected routes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#opaque-key-translation",
+              "title": "Opaque key translation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#forwarded-headers-and-cors",
+              "title": "Forwarded headers and CORS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#x-forwarded-headers",
+              "title": "X-Forwarded headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening",
+              "title": "Security hardening"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#cors",
+              "title": "CORS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#customizing-the-configuration",
+              "title": "Customizing the configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#admin-interface",
+              "title": "Admin interface"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#logs",
+              "title": "Logs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#common-issues",
+              "title": "Common issues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#see-also",
+              "title": "See also"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#before-you-begin",
+              "title": "Before you begin"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#enabling-the-envoy-gateway",
+              "title": "Enabling the Envoy gateway"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#verify",
+              "title": "Verify"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#architecture",
+              "title": "Architecture"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#configuration-file-structure",
+              "title": "Configuration file structure"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#changes-to-function-code-not-reflected-after-editing",
+              "title": "Changes to function code not reflected after editing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#copying-functions-from-supabase-platform",
+              "title": "Copying functions from Supabase platform"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#deploying-functions-to-a-remote-server",
+              "title": "Deploying functions to a remote server"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#managing-functions-via-dashboard",
+              "title": "Managing functions via dashboard"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#internal-vs-external-urls",
+              "title": "Internal vs external URLs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#500-error-on-invocation",
+              "title": "500 error on invocation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#calling-supabase-services-from-functions",
+              "title": "Calling Supabase services from functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#accessing-variables-in-functions",
+              "title": "Accessing variables in functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#using-inline-environment-variables",
+              "title": "Using inline environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#using-an-env-file-recommended",
+              "title": "Using an env file (recommended)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#custom-environment-variables",
+              "title": "Custom environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#step-3-invoke-your-function",
+              "title": "Step 3: Invoke your function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#step-2-restart-the-functions-service-to-pick-up-the-new-function",
+              "title": "Step 2: Restart the functions service to pick up the new function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#step-1-add-a-new-function-directory-and-the-function-code",
+              "title": "Step 1: Add a new function directory and the function code"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#create-a-new-function",
+              "title": "Create a new function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#invoke-the-default-function",
+              "title": "Invoke the default function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#troubleshooting",
+              "title": "Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#memory-or-timeout-errors",
+              "title": "Memory or timeout errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#custom-env-vars-not-available-in-functions",
+              "title": "Custom env vars not available in functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth#provider-not-enabled-or-provider-seen-as-false-in-settings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#401-invalid-jwt"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions#400-missing-function-name-in-request"
+            }
+          ],
+          "resultChars": 323616
+        }
+      ]
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -5320,12 +9011,11 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "victim session active before delete-account",
-        "passed": false,
-        "notes": "permission denied for table users"
+        "passed": true
       },
       {
         "name": "delete_account flow ran for the victim",
@@ -5346,13 +9036,12 @@
       },
       {
         "name": "other users keep their sessions and access",
-        "passed": false,
-        "notes": "permission denied for table users"
+        "passed": true
       },
       {
         "name": "diagnosed and explained session revocation",
-        "passed": false,
-        "judgeNotes": "The answer correctly identifies the soft-delete bug, implements real auth-user deletion/session cascade, explains JWTs can remain cryptographically valid until expiry, and correctly distinguishes publishable vs secret keys. However it does not clarify the required server-side validation point: use auth.getUser() (or short JWT expiry/session checks) rather than only local JWT validation such as getClaims()."
+        "passed": true,
+        "judgeNotes": "Meets rubric: identifies soft-delete-only delete_account as cause, changes flow to delete auth.users and closes RLS data path for stale JWTs, explains JWT expiry caveat consistently, and correctly distinguishes publishable vs secret keys."
       }
     ],
     "skills": {
@@ -5361,13 +9050,255 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/changelog.md supabase changelog md",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "Supabase changelog breaking change auth delete user sessions publishable secret key",
+          "pages": []
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"delete user revoke sessions auth.admin.deleteUser auth.sessions\", limit: 5) { nodes { __typename title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data",
+              "title": "User Management"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data#accessing-user-data-via-api",
+              "title": "Accessing user data via API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data#adding-and-retrieving-user-metadata",
+              "title": "Adding and retrieving user metadata"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data#exporting-users",
+              "title": "Exporting users"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data#deleting-users",
+              "title": "Deleting users"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-deleteuser"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/dart/auth-admin-deleteuser"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/swift/auth-admin-deleteuser",
+              "title": "deleteUser()"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary",
+              "title": "Glossary"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#row-level-security-policies-rls",
+              "title": "Row level security policies (RLS)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#access-token",
+              "title": "Access token"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#authentication",
+              "title": "Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#authenticator-app",
+              "title": "Authenticator app"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#authorization",
+              "title": "Authorization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#identity-provider",
+              "title": "Identity provider"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#json-web-token-jwt",
+              "title": "JSON Web Token (JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#jwt-signing-secret",
+              "title": "JWT signing secret"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#multi-factor-authentication-mfa-or-2fa",
+              "title": "Multi-factor authentication (MFA or 2FA)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#nonce",
+              "title": "Nonce"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#oauth",
+              "title": "OAuth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#oidc",
+              "title": "OIDC"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#one-time-password-otp",
+              "title": "One-time password (OTP)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#password-hashing-function",
+              "title": "Password hashing function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#password-strength",
+              "title": "Password strength"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#pkce",
+              "title": "PKCE"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#provider-refresh-token",
+              "title": "Provider refresh token"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#provider-tokens",
+              "title": "Provider tokens"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#refresh-token",
+              "title": "Refresh token"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#refresh-token-flow",
+              "title": "Refresh token flow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#replay-attack",
+              "title": "Replay attack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#saml",
+              "title": "SAML"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#session",
+              "title": "Session"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#single-sign-on-sso",
+              "title": "Single-sign on (SSO)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary#time-based-one-time-password-totp",
+              "title": "Time-based one-time password (TOTP)"
+            }
+          ],
+          "resultChars": 35929
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"migrating to new API keys publishable secret frontend RLS\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-redwoodjs",
+              "title": "Build a User Management App with RedwoodJS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/getting-started",
+              "title": "Getting Started with OAuth 2.1 Server"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            }
+          ],
+          "resultChars": 109403
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"revoke sessions delete user auth.sessions sign out current user delete account\", limit: 10) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data",
+              "title": "User Management"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-signout"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-signout"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signout",
+              "title": "Signing out"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/sessions",
+              "title": "User sessions"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/dart/auth-signout"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary",
+              "title": "Glossary"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/swift/auth-signout",
+              "title": "signOut()"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/auth-anonymous",
+              "title": "Anonymous Sign-Ins"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/oauth-flows",
+              "title": "OAuth 2.1 Flows"
+            }
+          ],
+          "resultChars": 84801
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/docs deleting a user does not automatically sign out a user JWT remain valid until it has expired Supabase",
+          "pages": []
+        }
       ]
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini/investigate-auth-001-deleted-user-access.json"
   },
   {
@@ -5416,7 +9347,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "Diagnosed missing public.orders from supabase_realtime publication, added it with ALTER PUBLICATION, verified courier_locations remained included, and did not alter RLS or policies."
+        "judgeNotes": "The assistant correctly identified that subscriptions could reach SUBSCRIBED while INSERT events for orders were silent because public.orders was missing from the supabase_realtime publication. It applied the narrow fix `alter publication supabase_realtime add table public.orders;`, verified both orders and courier_locations remained in the existing publication, and did not alter RLS/policies or recreate/drop the publication."
       }
     ],
     "skills": {
@@ -5426,6 +9357,458 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"supabase_realtime publication postgres_changes table not receiving events\", limit: 5) {\n    nodes {\n      title\n      href\n      content\n      ... on Guide {\n        subsections {\n          nodes {\n            title\n            href\n            content\n          }\n        }\n      }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes",
+              "title": "Subscribing to Database Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#streaming-inserts",
+              "title": "Streaming inserts"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#using-broadcast",
+              "title": "Using Broadcast"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#broadcast-authorization",
+              "title": "Broadcast authorization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#create-a-trigger-function",
+              "title": "Create a trigger function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#create-a-trigger",
+              "title": "Create a trigger"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#listening-on-client-side",
+              "title": "Listening on client side"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#using-postgres-changes",
+              "title": "Using Postgres Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#enable-postgres-changes",
+              "title": "Enable Postgres Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#streaming-updates",
+              "title": "Streaming updates"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes",
+              "title": "Postgres Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#less-than-lt",
+              "title": "Less than (lt)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#quick-start",
+              "title": "Quick start"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#usage",
+              "title": "Usage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#listening-to-specific-schemas",
+              "title": "Listening to specific schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#listening-to-insert-events",
+              "title": "Listening to INSERT events"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#listening-to-update-events",
+              "title": "Listening to UPDATE events"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#listening-to-delete-events",
+              "title": "Listening to DELETE events"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#listening-to-specific-tables",
+              "title": "Listening to specific tables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#listening-to-multiple-changes",
+              "title": "Listening to multiple changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#filtering-for-specific-changes",
+              "title": "Filtering for specific changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#available-filters",
+              "title": "Available filters"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#equal-to-eq",
+              "title": "Equal to (eq)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#not-equal-to-neq",
+              "title": "Not equal to (neq)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#less-than-or-equal-to-lte",
+              "title": "Less than or equal to (lte)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#greater-than-gt",
+              "title": "Greater than (gt)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#greater-than-or-equal-to-gte",
+              "title": "Greater than or equal to (gte)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#contained-in-list-in",
+              "title": "Contained in list (in)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#receiving-old-records",
+              "title": "Receiving old records"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#private-schemas",
+              "title": "Private schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#custom-tokens",
+              "title": "Custom tokens"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#refreshed-tokens",
+              "title": "Refreshed tokens"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#limitations",
+              "title": "Limitations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#delete-events-are-not-filterable",
+              "title": "Delete events are not filterable"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#spaces-in-table-names",
+              "title": "Spaces in table names"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes#database-instance-and-realtime-performance",
+              "title": "Database instance and realtime performance"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#methodology",
+              "title": "Methodology"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#workloads",
+              "title": "Workloads"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#results",
+              "title": "Results"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#broadcast-using-websockets",
+              "title": "Broadcast: Using WebSockets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#broadcast-using-the-database",
+              "title": "Broadcast: Using the database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#broadcast-impact-of-payload-size",
+              "title": "Broadcast: Impact of payload size"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#1kb-payload",
+              "title": "1KB payload"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#10kb-payload",
+              "title": "10KB payload"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#50kb-payload",
+              "title": "50KB payload"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#broadcast-scalability-scenarios",
+              "title": "Broadcast: Scalability scenarios"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#realtime-auth",
+              "title": "Realtime Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks#postgres-changes",
+              "title": "Postgres Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol",
+              "title": "Realtime Protocol"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#presence-errors",
+              "title": "Presence errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#access-token-refresh",
+              "title": "Access token refresh"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#join-errors",
+              "title": "Join errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#websocket-connection-setup",
+              "title": "WebSocket connection setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#protocol-messages",
+              "title": "Protocol messages"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#100",
+              "title": "1.0.0"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#200",
+              "title": "2.0.0"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#text-frames",
+              "title": "Text frames"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#binary-frames",
+              "title": "Binary frames"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#user-broadcast-push",
+              "title": "User Broadcast Push"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#user-broadcast",
+              "title": "User Broadcast"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#event-types",
+              "title": "Event types"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#client-sent-events",
+              "title": "Client sent events"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#phx_join",
+              "title": "phx_join"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#phx_leave",
+              "title": "phx_leave"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#heartbeat",
+              "title": "heartbeat"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#access_token",
+              "title": "access_token"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#broadcast-text-frame",
+              "title": "broadcast (text frame)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#broadcast-binary-frame",
+              "title": "broadcast (binary frame)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#presence",
+              "title": "presence"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#server-sent-events",
+              "title": "Server sent events"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#phx_close",
+              "title": "phx_close"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#phx_error",
+              "title": "phx_error"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#phx_reply",
+              "title": "phx_reply"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#system",
+              "title": "system"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#broadcast-text-frame-1",
+              "title": "broadcast (text frame)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#broadcast-binary-frame-1",
+              "title": "broadcast (binary frame)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#postgres_changes",
+              "title": "postgres_changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#presence_state",
+              "title": "presence_state"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#presence_diff",
+              "title": "presence_diff"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#reconnection",
+              "title": "Reconnection"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#channel-level-system-errors",
+              "title": "Channel-level system errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#error-handling",
+              "title": "Error handling"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#postgres-changes-subscription-errors",
+              "title": "Postgres Changes subscription errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol#broadcast-errors",
+              "title": "Broadcast errors"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started",
+              "title": "Getting Started with Realtime"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#next-steps",
+              "title": "Next steps"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#framework-examples",
+              "title": "Framework examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#integration-guides",
+              "title": "Integration guides"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#advanced-topics",
+              "title": "Advanced topics"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#security--configuration",
+              "title": "Security & configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#core-features",
+              "title": "Core features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#when-to-use-postgres-changes",
+              "title": "When to use Postgres Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#when-to-use-presence",
+              "title": "When to use Presence"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#when-to-use-broadcast",
+              "title": "When to use Broadcast"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#choose-the-right-feature",
+              "title": "Choose the right feature"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#clean-up-subscriptions",
+              "title": "Clean up subscriptions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#follow-naming-conventions",
+              "title": "Follow naming conventions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#use-private-channels",
+              "title": "Use private channels"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#essential-best-practices",
+              "title": "Essential best practices"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#53-using-database-triggers",
+              "title": "5.3 using database triggers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#52-using-httprest-api",
+              "title": "5.2 using HTTP/REST API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#51-using-client-libraries",
+              "title": "5.1 using client libraries"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#5-send-and-receive-messages",
+              "title": "5. Send and receive messages"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#4-set-up-authorization",
+              "title": "4. Set up authorization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#3-create-your-first-channel",
+              "title": "3. Create your first Channel"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#get-api-details",
+              "title": "Get API details"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#2-initialize-the-client",
+              "title": "2. Initialize the client"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#1-install-the-client-library",
+              "title": "1. Install the client library"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/getting_started#quick-start",
+              "title": "Quick start"
+            }
+          ],
+          "resultChars": 335915
+        }
       ]
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -5452,22 +9835,22 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as the affected function and described the recurring 503 pattern across 8 failures from 07:00Z to 12:00Z on 2026-04-28."
+        "judgeNotes": "The assistant named `image-transform` as the affected function and explicitly identified the recurring 503 pattern across 2026-04-28 from 07:00Z to 12:00Z, listing all 8 gateway failures. It did not misattribute the issue to old billing-webhook errors."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": false,
-        "judgeNotes": "The response does not clearly attribute the recurring 503s to the gateway/platform layer in front of the function. It frames them as an Edge Function/runtime or upstream dependency issue, recommends inspecting function implementation and redeploying/rolling back, and does not ground a gateway-layer attribution in observations like missing invocation/runtime rows or unchanged deployment across the outage."
+        "passed": true,
+        "judgeNotes": "Attributes recurring image-transform 503s to gateway/Functions-layer instability rather than function code, and grounds this in gateway 503 pattern, successful 200s between failures on same deployed version, and distinction from avatar-upload's isolated function-level 500."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete actionable next steps, including inspecting the Edge Function implementation/dependencies, correlating request behavior around specific failure times, adding targeted error logging, and rolling back or redeploying a known-good version if users are blocked."
+        "judgeNotes": "The assistant recommended concrete next steps, including checking for a platform incident/rollout during the affected time window, adding explicit function logging, adding retry/backoff, reviewing dependency changes, and collecting exact request IDs to distinguish gateway from handler failures."
       }
     ],
     "skills": {
@@ -5479,9 +9862,12 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini/investigate-reliability-003-edge-function-5xx-correlation.json"
   },
   {
@@ -5535,7 +9921,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Pass: diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated owner-scoped SELECT and INSERT policies using auth.uid() = user_id / WITH CHECK. Extra update/delete and index do not violate rubric."
+        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all/zero Data API rows, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid(), with INSERT using WITH CHECK. Extra index and verification are acceptable."
       }
     ],
     "skills": {
@@ -5544,8 +9930,287 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Exposing a Table to the Data API RLS grants anon authenticated bookmarks\", limit: 5) { nodes { __typename title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api",
+              "title": "Securing your API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#enforce-additional-rules-on-each-request",
+              "title": "Enforce additional rules on each request"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#add-rls-policies",
+              "title": "Add RLS policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#disable-the-data-api",
+              "title": "Disable the Data API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#examples",
+              "title": "Examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#accessing-request-information",
+              "title": "Accessing request information"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#grant-access-explicitly",
+              "title": "Grant access explicitly"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#default-privileges-for-new-tables-and-functions",
+              "title": "Default privileges for new tables and functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api#use-a-dedicated-api-schema",
+              "title": "Use a dedicated API schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#more-information",
+              "title": "More information"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#frontend-access",
+              "title": "Frontend access"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#direct-database-connections",
+              "title": "Direct database connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#edge-functions",
+              "title": "Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#data-api",
+              "title": "Data API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data#connecting-your-app-securely",
+              "title": "Connecting your app securely"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0013_rls_disabled_in_public",
+              "title": "Database Advisor: Lint 0013_rls_disabled_in_public"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#authuid",
+              "title": "auth.uid()"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#authjwt",
+              "title": "auth.jwt()"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#mfa",
+              "title": "MFA"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#bypassing-row-level-security",
+              "title": "Bypassing Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations",
+              "title": "RLS performance recommendations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#add-indexes",
+              "title": "Add indexes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#benchmarks",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select",
+              "title": "Call functions with select"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#benchmarks-1",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#add-filters-to-every-query",
+              "title": "Add filters to every query"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#benchmarks-2",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#use-security-definer-functions",
+              "title": "Use security definer functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#minimize-joins",
+              "title": "Minimize joins"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#benchmarks-3",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#specify-roles-in-your-policies",
+              "title": "Specify roles in your policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#benchmarks-4",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#more-resources",
+              "title": "More resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#row-level-security-in-supabase",
+              "title": "Row Level Security in Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#policies",
+              "title": "Policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#enabling-row-level-security",
+              "title": "Enabling Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#auto-enable-rls-for-new-tables",
+              "title": "Auto-enable RLS for new tables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#authenticated-and-unauthenticated-roles",
+              "title": "Authenticated and unauthenticated roles"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#creating-policies",
+              "title": "Creating policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#select-policies",
+              "title": "SELECT policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#insert-policies",
+              "title": "INSERT policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#update-policies",
+              "title": "UPDATE policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#delete-policies",
+              "title": "DELETE policies"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#views",
+              "title": "Views"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security#helper-functions",
+              "title": "Helper functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0017_foreign_table_in_api",
+              "title": "Database Advisor: Lint 0017_foreign_table_in_api"
+            }
+          ],
+          "resultChars": 203452
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"row level security insert select update delete policies auth.uid bookmarks\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/column-level-security",
+              "title": "Column Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/features",
+              "title": "Features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary",
+              "title": "Glossary"
+            }
+          ],
+          "resultChars": 60041
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"auth.uid request.jwt.claims current_setting Supabase Postgres JWT claims\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/realtime/authorization",
+              "title": "Realtime Authorization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/rls-performance-and-best-practices-Z5Jjwv",
+              "title": "RLS Performance and Best Practices"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/rag-with-permissions",
+              "title": "RAG with Permissions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/third-party/firebase-auth",
+              "title": "Firebase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes",
+              "title": "Postgres Changes"
+            }
+          ],
+          "resultChars": 103093
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"auth.uid implementation request.jwt.claim.sub current_setting\", limit: 3) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/rag-with-permissions",
+              "title": "RAG with Permissions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/authorization",
+              "title": "Realtime Authorization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/oauth-flows",
+              "title": "OAuth 2.1 Flows"
+            }
+          ],
+          "resultChars": 61357
+        }
       ]
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -5576,12 +10241,12 @@
     "checks": [
       {
         "name": "the avatar_url column is applied on the hosted profiles table",
-        "passed": true
+        "passed": false,
+        "notes": "avatar_url not found on public.profiles"
       },
       {
         "name": "migration 20240220000000 is recorded in the remote history",
-        "passed": false,
-        "notes": "remote history versions: [\"20240101000000\",\"20240115000000\"]"
+        "passed": true
       },
       {
         "name": "remote migration history matches local migration files",
@@ -5589,8 +10254,7 @@
       },
       {
         "name": "local migrations are a valid reconciled sequence",
-        "passed": false,
-        "notes": "migration(s) not applied on the remote: [\"20240220000000\"]"
+        "passed": true
       },
       {
         "name": "production profile data is intact (not reset)",
@@ -5598,8 +10262,8 @@
       },
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
-        "passed": false,
-        "judgeNotes": "FAIL: `supabase db push` never actually succeeded; only dry-runs/errors were recorded. The avatar_url migration was applied via a direct Management API `curl` POST to `/database/migrations` in command #98, which routes around the Supabase CLI. The bio history was only addressed by adding a local migration file in #32, but no successful CLI push/repair/pull reconciled it remotely. Workaround seen: direct Management API migration application."
+        "passed": true,
+        "judgeNotes": "Applied via `supabase db push --db-url \"$DB_URL\"` (#22), which showed `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled the orphan bio migration by adding local `supabase/migrations/20240115000000_add_profile_bio.sql` (#20) and then using `supabase db push`/migration workflow; final `supabase migration list --db-url` showed local and remote histories aligned (#23). No disallowed direct SQL mutation or prepared-statement reset workaround seen."
       }
     ],
     "skills": {
@@ -5610,6 +10274,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
@@ -5653,7 +10320,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -5668,6 +10335,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -5743,6 +10413,38 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"row level security multi tenant notes workspace\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on ClientLibraryFunctionReference { title href content language methodName } ... on TroubleshootingGuide { title href content } ... on ManagementApiReference { title href content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/auth/enterprise-sso/auth-sso-saml",
+              "title": "Single Sign-On with SAML 2.0 for Projects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/token-security",
+              "title": "Token Security and Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/pgtap-extended",
+              "title": "Advanced pgTAP Testing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/maturity-model",
+              "title": "Maturity Model"
+            }
+          ],
+          "resultChars": 97790
+        }
+      ]
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -5807,6 +10509,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -5844,17 +10549,19 @@
       },
       {
         "name": "a new migration was generated for the change",
-        "passed": false,
-        "notes": "found 1 migration file(s)"
+        "passed": true
       },
       {
         "name": "description column exists in the live database",
-        "passed": false
+        "passed": true
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
@@ -5899,16 +10606,76 @@
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 3) from the queue"
+        "notes": "function removed the seeded message (id 4) from the queue"
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"pgmq create queue send pop delete archive read Supabase cron schedule\", limit: 5) {\n    totalCount\n    nodes {\n      __typename\n      title\n      href\n      content\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues",
+              "title": "Supabase Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron",
+              "title": "Cron"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/pgmq",
+              "title": "PGMQ Extension"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/expose-self-hosted-queues",
+              "title": "Expose Queues for local and self-hosted Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/install",
+              "title": "Install"
+            }
+          ],
+          "resultChars": 28867
+        },
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"pg_cron schedule cron.schedule cron.unschedule Supabase SQL job name\", limit: 5) {\n    totalCount\n    nodes {\n      __typename\n      title\n      href\n      content\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/pgcron-debugging-guide-n1KTaz",
+              "title": "pg_cron debugging guide"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron",
+              "title": "Cron"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/install",
+              "title": "Install"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            }
+          ],
+          "resultChars": 33057
+        }
+      ]
+    },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini-no-skills/build-cli-003-pg-cron-queue-workflow.json"
   },
   {
@@ -5956,6 +10723,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
@@ -6005,17 +10775,49 @@
       {
         "name": "user A cannot force-read user B note",
         "passed": true,
-        "notes": "status=403"
+        "notes": "status=200"
       },
       {
         "name": "user B cannot force-read user A note",
         "passed": true,
-        "notes": "status=403"
+        "notes": "status=200"
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Edge Functions environment variable SUPABASE_ANON_KEY auth user in Deno\", limit: 5) { nodes { title href content ... on Guide { subsections { totalCount } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions",
+              "title": "Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/testing-and-linting",
+              "title": "Testing and linting"
+            }
+          ],
+          "resultChars": 42100
+        }
+      ]
     },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
@@ -6049,54 +10851,122 @@
     "passed": false,
     "checks": [
       {
-        "name": "seed rows present",
-        "passed": true,
-        "notes": "found 2/2 seeded rows"
-      },
-      {
-        "name": "rejects request with no credentials",
-        "passed": true,
-        "notes": "status 401: {\"error\":\"Missing Authorization bearer token or trusted apikey\"}"
-      },
-      {
-        "name": "user with JWT reads only their own rows",
-        "passed": true,
-        "notes": "status 200: [{\"user_id\":\"a041627d-de49-49e0-91b0-90433aeb5c90\",\"metric\":\"steps_a_mrnhixci\",\"value\":111}]"
-      },
-      {
-        "name": "user cannot read another user's rows by passing user_id",
-        "passed": true,
-        "notes": "status 200: [{\"user_id\":\"a041627d-de49-49e0-91b0-90433aeb5c90\",\"metric\":\"steps_a_mrnhixci\",\"value\":111}]"
-      },
-      {
-        "name": "service key bypasses RLS to read the target user's rows",
-        "passed": true,
-        "notes": "status 200: [{\"user_id\":\"f0ec4ff7-12fe-497a-a571-b1aea26d1573\",\"metric\":\"steps_b_mrnhixci\",\"value\":222}]"
-      },
-      {
-        "name": "non-service key is not granted service access",
-        "passed": true,
-        "notes": "status 401: {\"error\":\"Missing Authorization bearer token or trusted apikey\"}"
-      },
-      {
-        "name": "rejects an unverified (forged) user token",
-        "passed": true,
-        "notes": "status 401: {\"error\":\"Unauthorized\"}"
-      },
-      {
-        "name": "a user token in the apikey slot is not treated as the service key",
-        "passed": true,
-        "notes": "status 401: {\"error\":\"Missing Authorization bearer token or trusted apikey\"}"
-      },
-      {
-        "name": "implementation uses @supabase/server",
+        "name": "read stack config from `supabase status`",
         "passed": false,
-        "notes": "hand-rolled (raw supabase-js or other) — this eval requires @supabase/server"
+        "notes": "missing API_URL/SECRET_KEY/PUBLISHABLE_KEY — new API keys are required for @supabase/server; is the stack running on a new-enough CLI? got keys: ANON_KEY, DB_URL, JWT_SECRET, PUBLISHABLE_KEY, SECRET_KEY, SERVICE_ROLE_KEY"
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Edge Functions verifyJWT apikey service role auth user access token Deno.env.get SUPABASE_SERVICE_ROLE_KEY\", limit: 5) { edges { node { ... on Guide { title href content } ... on ClientLibraryFunctionReference { title href language methodName content } ... on TroubleshootingGuide { title href content } ... on CLICommandReference { title href content } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/jwts",
+              "title": "JSON Web Token (JWT)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/resumable-websockets",
+              "title": "Resumable WebSockets with Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            }
+          ],
+          "resultChars": 55962
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Edge Functions failed to determine entrypoint index.ts config.toml entrypoint\", limit: 5) { edges { node { ... on Guide { title href content } ... on TroubleshootingGuide { title href content } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/error-codes",
+              "title": "Error codes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/status-codes",
+              "title": "Status codes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore",
+              "title": "Backup and Restore using the CLI"
+            }
+          ],
+          "resultChars": 58296
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"failed to determine entrypoint supabase functions serve local function layout index.ts\", limit: 10) { edges { node { ... on Guide { title href content } ... on TroubleshootingGuide { title href content } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/quickstart",
+              "title": "Getting Started with Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/error-codes",
+              "title": "Error codes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/status-codes",
+              "title": "Status codes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/unable-to-deploy-edge-function",
+              "title": "Unable to deploy Edge Function"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/issues-serving-edge-functions-locally",
+              "title": "Issues serving Edge Functions locally"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions",
+              "title": "Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/unit-test",
+              "title": "Testing your Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-environment",
+              "title": "Development Environment"
+            }
+          ],
+          "resultChars": 60734
+        }
+      ]
     },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
     "promptSourcePath": "evals/build-functions-005-dual-auth-user-secret/PROMPT.md",
@@ -6141,7 +11011,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d36-fbc7-7215-b0be-f495c8d2c912/receipt-alpha.pdf, 019f4d36-fbc7-7215-b0be-f495c8d2c912/receipt-beta.pdf"
+        "notes": "saw: 019f6c9d-552b-73d4-b26e-66eca00b3f0c/receipt-alpha.pdf, 019f6c9d-552b-73d4-b26e-66eca00b3f0c/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -6162,12 +11032,235 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets all required criteria: private user-files bucket, RLS kept enabled, authenticated owner-scoped SELECT and INSERT WITH CHECK policies on storage.objects, and supabase-js createSignedUrl with expiry for temporary sharing."
+        "judgeNotes": "Meets rubric: private user-files bucket, owner-scoped authenticated SELECT and INSERT policies with WITH CHECK, RLS kept enabled, and supabase-js createSignedUrl with short expiry."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"storage.objects policy foldername signed url supabase-js createSignedUrl\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads",
+              "title": "Serving assets from Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads#signing-urls",
+              "title": "Signing URLs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads#public-buckets",
+              "title": "Public buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads#downloading",
+              "title": "Downloading"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads#programmatic-downloads-with-query-parameters",
+              "title": "Programmatic downloads with query parameters"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads#private-buckets",
+              "title": "Private buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads",
+              "title": "Resumable Uploads"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads#overwriting-files",
+              "title": "Overwriting files"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads#presigned-uploads",
+              "title": "Presigned uploads"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads#uppy-example",
+              "title": "Uppy example"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads#concurrency",
+              "title": "Concurrency"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/uploads/resumable-uploads#upload-url",
+              "title": "Upload URL"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations",
+              "title": "Storage Image Transformations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#storage-api-configuration",
+              "title": "Storage API configuration:"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#imgproxy-configuration",
+              "title": "imgproxy configuration:"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#self-hosting",
+              "title": "Self hosting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#supported-image-formats",
+              "title": "Supported image formats"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#limits",
+              "title": "Limits"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#modes",
+              "title": "Modes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#resizing",
+              "title": "Resizing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#optimizing",
+              "title": "Optimizing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#transformation-options",
+              "title": "Transformation options"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#nextjs-loader",
+              "title": "Next.js loader"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#automatic-image-optimization-webp",
+              "title": "Automatic image optimization (WebP)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#downloading-images",
+              "title": "Downloading images"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#signing-urls-with-transformation-options",
+              "title": "Signing URLs with transformation options"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#get-a-public-url-for-a-transformed-image",
+              "title": "Get a public URL for a transformed image"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/image-transformations#manage-image-transformations",
+              "title": "Manage image transformations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations",
+              "title": "Manage Storage Image Transformations usage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#exceeding-quotas",
+              "title": "Exceeding Quotas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#optimize-usage",
+              "title": "Optimize usage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#view-usage",
+              "title": "View usage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#billing-examples",
+              "title": "Billing examples"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#exceeding-quota",
+              "title": "Exceeding quota"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#usage-on-your-invoice",
+              "title": "Usage on your invoice"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#what-you-are-charged-for",
+              "title": "What you are charged for"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#example",
+              "title": "Example"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#how-charges-are-calculated",
+              "title": "How charges are calculated"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#example-1",
+              "title": "Example"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations#within-quota",
+              "title": "Within quota"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/file-buckets-createsignedurl"
+            }
+          ],
+          "resultChars": 103502
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"storage.foldername storage.objects policy path tokens auth.uid\", limit: 10) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/security/product-security",
+              "title": "Secure configuration of Supabase products"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/helper-functions",
+              "title": "Storage Helper Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/management/copy-move-objects",
+              "title": "Copy Objects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/why-cant-i-uploadlistetc-my-public-bucket-Z6CmGt",
+              "title": "Why can't I upload/list/etc my public bucket?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/buckets/fundamentals",
+              "title": "Storage Buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/quickstart",
+              "title": "Storage Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/design",
+              "title": "The Storage Schema"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/features",
+              "title": "Features"
+            }
+          ],
+          "resultChars": 50894
+        }
+      ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
@@ -6204,17 +11297,20 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "4 passed, 0 failed"
+        "notes": "3 passed, 1 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as the table with the tenant isolation flaw, explains that the policy checked membership by user without matching `org_id`, and distinguishes it from `notes`. It also reports pgTAP verification after adding isolation tests and fixing the policy."
+        "judgeNotes": "The agent correctly identifies `posts` as having a tenant isolation flaw, specifically that members can read cross-org posts, and grounds the conclusion in the pgTAP result where the cross-org `posts` check returned 1 row instead of 0. It also distinguishes that `notes` passed."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
@@ -6252,12 +11348,12 @@
       {
         "name": "HNSW index on the embedding column",
         "passed": true,
-        "notes": "CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
+        "notes": "CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops) WHERE (embedding IS NOT NULL)"
       },
       {
         "name": "index operator class matches the search operator",
         "passed": true,
-        "notes": "function operators: <=>\nindexes: CREATE INDEX document_sections_embedding_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops)"
+        "notes": "function operators: <=>\nindexes: CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_cosine_ops) WHERE (embedding IS NOT NULL)"
       },
       {
         "name": "user A search returns only own sections, best match first",
@@ -6280,9 +11376,12 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.4-mini-no-skills/build-vectors-001-rag-with-permissions.json"
   },
   {
@@ -6312,17 +11411,57 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape preserves app job and uses HTTPS with the correct metrics path and project target, but it uses basic_auth.password with env-template substitution instead of basic_auth.password_file, and docker-compose.yml does not mount a password_file via volume or Compose secret."
+        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password instead of password_file, docker-compose.yml does not mount the password file via volume or Compose secret, and README instructs replacing the value with a Secret API key in prometheus.yml. Existing app scrape and HTTPS metrics path are present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README covers creating/copying a Supabase Secret API key, setting env vars, restarting the Compose stack, and verifying the Prometheus target is UP. However, the rubric requires placing the matching secret file, and this setup/README uses environment variables instead of a secret file, so the secret setup requirement is not met."
+        "judgeNotes": "README gives basic Supabase scrape setup and restart guidance, but fails required criteria: it instructs replacing the password inline rather than placing a matching secret file, does not configure/use a secret file, and lacks concrete verification steps via Prometheus targets, PromQL/Grafana, or equivalent."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"metrics Prometheus project metrics\", limit: 10) { edges { node { __typename title href content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
+              "title": "Manual replication monitoring"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/data-deletion",
+              "title": "Deleting data and dropping objects safely"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
+            }
+          ],
+          "resultChars": 35779
+        }
+      ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
@@ -6373,6 +11512,66 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"Edge Functions secrets set env-file deploy cli project-ref\", limit: 5) {\n    nodes {\n      ... on Guide {\n        title\n        href\n        content\n      }\n      ... on CLICommandReference {\n        title\n        href\n        content\n      }\n      ... on TroubleshootingGuide {\n        title\n        href\n        content\n      }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/push-notifications",
+              "title": "Sending Push Notifications"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/inspecting-edge-function-environment-variables-wg5qOQ",
+              "title": "Inspecting edge function environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/troubleshooting",
+              "title": "Troubleshooting"
+            }
+          ],
+          "resultChars": 40692
+        },
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"functions deploy no-verify-jwt config.toml verify_jwt false\", limit: 5) {\n    nodes {\n      ... on Guide { title href content }\n      ... on CLICommandReference { title href content }\n      ... on TroubleshootingGuide { title href content }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/deploy",
+              "title": "Deploy to Production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/examples/openai",
+              "title": "Generating OpenAI GPT3 completions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/upstash-redis",
+              "title": "Upstash Redis"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            }
+          ],
+          "resultChars": 22399
+        }
+      ]
+    },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
     "attempts": 1,
@@ -6422,6 +11621,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -6451,8 +11653,7 @@
     "checks": [
       {
         "name": "victim session active before delete-account",
-        "passed": false,
-        "notes": "permission denied for table users"
+        "passed": true
       },
       {
         "name": "delete_account flow ran for the victim",
@@ -6469,22 +11670,54 @@
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
-        "passed": false,
-        "notes": "permission denied for table users"
+        "passed": true
       },
       {
         "name": "diagnosed and explained session revocation",
         "passed": false,
-        "judgeNotes": "It correctly diagnosed the soft-delete-only bug, changed delete_account to delete auth.users, tightened RLS, and correctly described publishable vs secret keys. However, it failed the required JWT-window clarification: it claimed there is no practical post-commit window instead of explaining that stateless access tokens can remain valid until expiry after revocation, and it did not mention using auth.getUser() or short JWT expiry rather than relying only on local JWT validation/getClaims()."
+        "judgeNotes": "Fails because it does not explain that existing access tokens are stateless JWTs that remain cryptographically valid until expiry for purely local validation such as getClaims() or custom JWT middleware. It instead says the only remaining race is an in-flight request, which omits the required caveat. The diagnosis, RLS/data-path fix, session/refresh-token revocation, and publishable vs secret key explanation are otherwise largely correct."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"publishable secret keys RLS anon service_role\", limit: 5) {\n    nodes {\n      __typename\n      ... on Guide { title href content }\n      ... on TroubleshootingGuide { title href content }\n      ... on ClientLibraryFunctionReference { title href methodName language content }\n      ... on ManagementApiReference { title href content }\n      ... on CLICommandReference { title href content }\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/jwt-fields",
+              "title": "JWT Claims Reference"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/server-side/creating-a-client",
+              "title": "Creating a Supabase client for SSR"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            }
+          ],
+          "resultChars": 112269
+        }
+      ]
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -6537,16 +11770,19 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that orders was missing from the supabase_realtime publication while courier_locations was present, applied exactly ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, verified both tables remained published, and did not weaken RLS/policies or blame unrelated causes."
+        "judgeNotes": "Identified orders missing from supabase_realtime publication as root cause, added public.orders with ALTER PUBLICATION via migration, and preserved courier_locations/RLS/policies."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini-no-skills/investigate-realtime-001-subscribed-no-events.json"
   },
   {
@@ -6568,31 +11804,34 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as the affected function and described the recurring 503 pattern across the morning of 2026-04-28, including most/all eight failures from 07:00Z to 12:00Z."
+        "judgeNotes": "The assistant identified `image-transform` as the affected function and described a recurring morning pattern of gateway-level HTTP 503s on 2026-04-28, including alternating/intermittent failures across roughly 06:00–12:00 UTC. This satisfies the rubric despite mentioning an additional avatar-upload issue."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
-        "passed": true,
-        "judgeNotes": "Attributes recurring image-transform 503s to gateway/platform before handler execution, not function code. Grounds this in missing edge-function invocation logs for 503s, nearby successful fast invocations on same deployment/version, and distinguishes avatar-upload's 500 as a separate function-level error. Redeploy suggestion is a caveat, but not the primary attribution."
+        "passed": false,
+        "judgeNotes": "The assistant notes that the 503s lack function-side execution details and likely failed before runtime, but it also frames this as a function-level/edge-function issue and recommends redeploying the functions. The rubric explicitly fails answers that recommend fixing or redeploying the function as remediation."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "Recommended concrete next steps including checking Edge Function deployment/platform health and incidents for a specific time window, redeploying the function, and ruling out external dependencies."
+        "judgeNotes": "The assistant recommended multiple concrete next steps: redeploying functions, adding retry/backoff, instrumenting packages, correlating a specific 500 with request payload/time, and escalating to Supabase support if 503s continue."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.4-mini-no-skills/investigate-reliability-003-edge-function-5xx-correlation.json"
   },
   {
@@ -6646,12 +11885,15 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all, kept RLS enabled, and created authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies as deny-all, kept RLS enabled, and created authenticated-only SELECT and INSERT policies scoped to user_id = auth.uid() using USING and WITH CHECK."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -6702,16 +11944,19 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Avatar migration was applied through `supabase db push` in #25, which showed `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration was reconciled by adding the local migration file `supabase/migrations/20240115000000_add_profile_bio.sql` in #23, after which `supabase migration list` showed local/remote aligned. No disallowed workaround was used; psql commands were read-only inspection."
+        "judgeNotes": "Applied avatar_url via `supabase db push --db-url \"$(cat supabase/.temp/pooler-url)\" --include-all` (#35), which showed `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled the orphan bio migration by adding local migration file `supabase/migrations/20240115000000_add_profile_bio.sql` (#34) and then letting the successful `supabase db push` align local/remote history; `supabase migration list` (#36) showed all three migrations matched. Read-only psql inspections were used; no forbidden direct SQL mutation or prepared-statement workaround observed."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.4-mini-no-skills/resolve-database-001-migration-history-mismatch.json"
   },
   {
@@ -6751,7 +11996,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=79.74..79.86 rows=50 width=58)\n  ->  Sort  (cost=79.74..79.99 rows=100 width=58)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=5.06..76.42 rows=100 width=58)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..5.03 rows=100 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -6761,6 +12006,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -6831,6 +12079,9 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",
     "attempts": 1,
@@ -6897,8 +12148,39 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"expose table data API RLS grants anon authenticated Supabase PostgREST\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api",
+              "title": "Securing your API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0028_anon_security_definer_function_executable",
+              "title": "Database Advisor: Lint 0028_anon_security_definer_function_executable"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0029_authenticated_security_definer_function_executable",
+              "title": "Database Advisor: Lint 0029_authenticated_security_definer_function_executable"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            }
+          ],
+          "resultChars": 68311
+        }
       ]
     },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
@@ -6954,6 +12236,30 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase CLI local development database migrations db diff pull declarative schemas\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            }
+          ],
+          "resultChars": 55139
+        }
+      ]
+    },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "attempts": 1,
@@ -6997,7 +12303,7 @@
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 4) from the queue"
+        "notes": "function removed the seeded message (id 6) from the queue"
       }
     ],
     "skills": {
@@ -7006,7 +12312,68 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Queues pgmq read delete send Edge Functions cron pg_cron\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions",
+              "title": "Scheduling Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron",
+              "title": "Cron"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues",
+              "title": "Supabase Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/pgcron-debugging-guide-n1KTaz",
+              "title": "pg_cron debugging guide"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            }
+          ],
+          "resultChars": 26766
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Queues API read messages delete pgmq_public create queue SQL\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues",
+              "title": "Supabase Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0019_insecure_queue_exposed_in_api",
+              "title": "Database Advisor: Lint 0019_insecure_queue_exposed_in_api"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/api",
+              "title": "API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/consuming-messages-with-edge-functions",
+              "title": "Consuming Supabase Queue Messages with Edge Functions"
+            }
+          ],
+          "resultChars": 21959
+        }
       ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
@@ -7063,6 +12430,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase CLI local development init start database connection\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development",
+              "title": "Local Development & CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cli",
+              "title": "Local Dev with CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/getting-started",
+              "title": "Supabase CLI"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/restoring-downloaded-backup",
+              "title": "Restoring a downloaded backup locally"
+            }
+          ],
+          "resultChars": 47901
+        }
       ]
     },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
@@ -7130,6 +12529,66 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Edge Functions authorization header createClient getUser service role RLS\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs",
+              "title": "Build a User Management App with Next.js"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/why-is-my-service-role-key-client-getting-rls-errors-or-not-returning-data-7_1K9z",
+              "title": "Why is my service role key client getting RLS errors or not returning data?"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            }
+          ],
+          "resultChars": 81320
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Edge Functions Supabase client Authorization header anon key user JWT\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            }
+          ],
+          "resultChars": 81447
+        }
+      ]
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -7174,17 +12633,17 @@
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"eff913f1-6288-49c9-b8cb-3fed2fb8aa87\",\"metric\":\"steps_a_mrnhfrov\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"3fee493b-8454-4e34-86b5-2e389fe60e38\",\"metric\":\"steps_a_mro1xue7\",\"value\":111}]"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"eff913f1-6288-49c9-b8cb-3fed2fb8aa87\",\"metric\":\"steps_a_mrnhfrov\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"3fee493b-8454-4e34-86b5-2e389fe60e38\",\"metric\":\"steps_a_mro1xue7\",\"value\":111}]"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"f44b6e12-603c-454d-ad35-1d92713376fb\",\"metric\":\"steps_b_mrnhfrov\",\"value\":222}]"
+        "notes": "status 200: [{\"user_id\":\"e89fbb83-f307-4c31-b8e4-c80af82fa46f\",\"metric\":\"steps_b_mro1xue7\",\"value\":222}]"
       },
       {
         "name": "non-service key is not granted service access",
@@ -7216,9 +12675,83 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Edge Functions create function Deno serve verify JWT no-verify-jwt Authorization apikey service role\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/quickstart-dashboard",
+              "title": "Getting Started with Edge Functions (Dashboard)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions",
+              "title": "Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/resumable-websockets",
+              "title": "Resumable WebSockets with Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connecting-to-postgres/serverless-drivers",
+              "title": "Serverless Drivers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/testing-and-linting",
+              "title": "Testing and linting"
+            }
+          ],
+          "resultChars": 40523
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"config.toml functions verify_jwt false Edge Functions Supabase\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/deploy",
+              "title": "Deploy to Production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/github-actions",
+              "title": "GitHub Actions"
+            }
+          ],
+          "resultChars": 24808
+        },
+        {
+          "source": "web_search",
+          "query": "Supabase functions serve failed to determine entrypoint deno.json @supabase/server CLI 2.109",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/quickstart",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/quickstart"
+            }
+          ]
+        }
+      ]
+    },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
     "promptSourcePath": "evals/build-functions-005-dual-auth-user-secret/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.5/build-functions-005-dual-auth-user-secret.json"
   },
   {
@@ -7259,7 +12792,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-75e4-746a-afbf-929a0bfbffd0/receipt-alpha.pdf, 019f4d37-75e4-746a-afbf-929a0bfbffd0/receipt-beta.pdf"
+        "notes": "saw: 019f6c9f-8f6d-718b-bae6-5ea7f32899d1/receipt-alpha.pdf, 019f6c9f-8f6d-718b-bae6-5ea7f32899d1/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -7280,7 +12813,7 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Meets rubric: private user-files bucket, RLS enabled, authenticated owner-scoped SELECT and INSERT WITH CHECK policies on storage.objects, and supabase-js createSignedUrl with expiry for temporary sharing."
+        "judgeNotes": "The answer creates a private user-files bucket, keeps storage.objects RLS enabled, adds authenticated-only SELECT and INSERT policies scoped to the user id path prefix via storage.foldername(name)[1] = auth.uid()::text, and provides supabase-js code using createSignedUrl with a 1-hour expiry. No public bucket, permissive/public policies, getPublicUrl sharing, RLS disabling, or client service-role use."
       }
     ],
     "skills": {
@@ -7292,9 +12825,83 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/changelog.md Supabase changelog storage policies signed urls",
+          "pages": []
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Storage row level security policies bucket folder auth.uid storage.objects createSignedUrl supabase-js\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads",
+              "title": "Serving assets from Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/custom-roles",
+              "title": "Custom Roles"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/s3/authentication",
+              "title": "S3 Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/s3/compatibility",
+              "title": "S3 Compatibility"
+            }
+          ],
+          "resultChars": 59376
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Storage access control policies foldername auth.uid upload download owner user id\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage",
+              "title": "Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/management/download-objects",
+              "title": "Download Objects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/supabase-storage-inefficient-folder-operations-and-hierarchical-rls-challenges-b05a4d",
+              "title": "Supabase Storage: Inefficient folder operations and hierarchical RLS challenges"
+            }
+          ],
+          "resultChars": 19018
+        }
+      ]
+    },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.5/build-storage-001-private-bucket-access.json"
   },
   {
@@ -7327,12 +12934,12 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "10 passed, 0 failed"
+        "notes": "9 passed, 0 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "Pass: the agent explicitly identifies `posts` as having the tenant isolation flaw, stating its RLS only checked that a user had any membership rather than membership in the post’s `org_id`. It also grounds the conclusion in pgTAP coverage/results (`supabase test db`: PASS after the fix)."
+        "judgeNotes": "The agent correctly identified `posts` as having a tenant isolation flaw where membership was not tied to the post's `org_id`, and grounded this in pgTAP baseline failures showing cross-org post leakage. It did not blame `notes` or dismiss the tests."
       }
     ],
     "skills": {
@@ -7341,8 +12948,39 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase CLI database testing pgTAP RLS auth.uid set local role authenticated\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/overview",
+              "title": "Testing Overview"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/testing-and-linting",
+              "title": "Testing and linting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/token-security",
+              "title": "Token Security and Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/pgtap-extended",
+              "title": "Advanced pgTAP Testing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/testing",
+              "title": "Testing Your Database"
+            }
+          ],
+          "resultChars": 55311
+        }
       ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
@@ -7411,8 +13049,39 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"pgvector semantic search match_documents Supabase RLS vector\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/rag-with-permissions",
+              "title": "RAG with Permissions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/hybrid-search",
+              "title": "Hybrid search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pgvector",
+              "title": "pgvector: Embeddings and vector similarity"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/vector-columns",
+              "title": "Vector columns"
+            }
+          ],
+          "resultChars": 53178
+        }
       ]
     },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
@@ -7446,13 +13115,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase Metrics API scrape with correct path and project target templating, uses Basic Auth with password_file, and docker-compose wires the password file as a Compose secret mounted at /run/secrets/supabase_metrics_api_key."
+        "passed": false,
+        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics_path, basic_auth with password_file, preserves app job, and mounts the password file. However, the actual Supabase project target is not present in the provided prometheus.yml and the referenced supabase-targets.yml content is not provided, so the required <project-ref>.supabase.co/.red target wiring cannot be verified."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes correct Supabase Metrics endpoint/auth, Secret API key creation, secret file path, and compose startup. However, it does not clearly require restarting/reloading the Compose stack after making the config live, and verification is limited to a pre-start curl credential check rather than concrete verification that Prometheus is scraping successfully via Prometheus targets, PromQL, Grafana, or equivalent."
+        "judgeNotes": "README covers the secret file placement, Compose start/reload, and Prometheus target verification, with correct endpoint/auth and no hardcoded secret. However, it does not provide steps to create/generate the Supabase Secret API key itself, which the rubric explicitly requires."
       }
     ],
     "skills": {
@@ -7462,6 +13131,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase metrics Prometheus endpoint project metrics\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas",
+              "title": "Read Replicas"
+            }
+          ],
+          "resultChars": 32694
+        }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
@@ -7502,7 +13203,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "Reads WEATHER_API_KEY from runtime environment via Deno.env.get(\"WEATHER_API_KEY\")."
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -7516,6 +13217,52 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Edge Functions environment variables secrets WEATHER_API_KEY deploy function supabase CLI\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/integrations/supabase-for-platforms",
+              "title": "Supabase for Platforms"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/inspecting-edge-function-environment-variables-wg5qOQ",
+              "title": "Inspecting edge function environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech",
+              "title": "Transcription Telegram Bot"
+            }
+          ],
+          "resultChars": 52353
+        },
+        {
+          "source": "web_search",
+          "query": "\"Project not specified\" \"functions.supabase.co\"",
+          "pages": []
+        }
       ]
     },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
@@ -7572,6 +13319,38 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"self-hosting Supabase docker compose .env JWT_SECRET ANON_KEY SERVICE_ROLE_KEY\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker",
+              "title": "Self-Hosting with Docker"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-saml-sso",
+              "title": "Configure SAML SSO"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-proxy-https",
+              "title": "Configure Reverse Proxy and HTTPS"
+            }
+          ],
+          "resultChars": 94132
+        }
+      ]
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -7618,7 +13397,8 @@
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": true
+        "passed": false,
+        "notes": "deleted account can still sign in"
       },
       {
         "name": "other users keep their sessions and access",
@@ -7626,8 +13406,8 @@
       },
       {
         "name": "diagnosed and explained session revocation",
-        "passed": false,
-        "judgeNotes": "The answer diagnoses the soft-delete-only flow, updates deletion to remove the auth user and tighten RLS, and correctly distinguishes publishable vs secret keys. However, it does not clearly explain the required server-side JWT validation guidance: that stateless access tokens remain valid until expiry and backend checks that need revocation awareness should use auth.getUser() or short JWT expiry rather than relying only on local JWT validation/getClaims()."
+        "passed": true,
+        "judgeNotes": "Meets rubric: diagnoses soft-delete-only flow, implements real session/refresh revocation and Auth-user blocking/deleted state plus RLS session-existence checks, explains remaining JWT/local-validation window consistently, and correctly distinguishes publishable vs secret keys/RLS behavior."
       }
     ],
     "skills": {
@@ -7637,6 +13417,80 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/changelog.md Supabase changelog",
+          "pages": []
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"delete user invalidate sessions Supabase Auth JWT session_id auth.sessions\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/auth/sessions",
+              "title": "User sessions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data",
+              "title": "User Management"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth",
+              "title": "Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/jwts",
+              "title": "JSON Web Token (JWT)"
+            }
+          ],
+          "resultChars": 69557
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase publishable key secret key anon key service_role RLS\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/server-side/creating-a-client",
+              "title": "Creating a Supabase client for SSR"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            }
+          ],
+          "resultChars": 97109
+        }
       ]
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
@@ -7690,7 +13544,7 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly identified that the channel reached SUBSCRIBED but orders INSERT events were silent because public.orders was missing from the supabase_realtime publication. It applied the minimal fix by adding public.orders to the existing publication, preserved courier_locations, RLS, and policies, and did not blame or change client code/RLS/grants/networking."
+        "judgeNotes": "The assistant correctly identified that the channel could subscribe but orders INSERT events were silent because public.orders was missing from the supabase_realtime publication. It fixed exactly that by adding public.orders to the existing publication, preserved courier_locations, kept RLS/policies intact, and did not blame or alter client code/networking/RLS as root cause."
       }
     ],
     "skills": {
@@ -7700,6 +13554,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Realtime postgres_changes publication table enable insert events RLS\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/realtime/postgres-changes",
+              "title": "Postgres Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/authorization",
+              "title": "Realtime Authorization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/benchmarks",
+              "title": "Benchmarks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/subscribing-to-database-changes",
+              "title": "Subscribing to Database Changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/realtime/protocol",
+              "title": "Realtime Protocol"
+            }
+          ],
+          "resultChars": 119071
+        }
       ]
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
@@ -7731,17 +13617,17 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as the affected function and described the recurring HTTP 503 pattern across the morning of 2026-04-28, including all 8 gateway failure times from 07:00Z-12:00Z."
+        "judgeNotes": "Identified image-transform as the affected function and described the recurring HTTP 503 pattern across 2026-04-28 morning, covering all 8 gateway failures from 07:00Z to 12:00Z."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "Attributes recurring image-transform 503s to Edge Function gateway/platform before handler execution, grounded in API/gateway-only 503s with no Edge Function execution logs, nearby successful invocations, and distinction from avatar-upload's function-level 500."
+        "judgeNotes": "Attributes recurring image-transform 503s to the gateway/Edge Function platform layer, grounded in gateway-only 503s with successful/absent function execution logs and distinction from avatar-upload's function-level 500."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including opening a Supabase support/platform incident with project/timestamps, adding correlation logging, and inspecting a specific function error window."
+        "judgeNotes": "Recommended concrete next steps including treating it as an Edge Function availability issue, adding retries, opening a Supabase support ticket with exact UTC timestamps and gateway log IDs, pinning dependency/redeploying, and adding correlation IDs."
       }
     ],
     "skills": {
@@ -7752,6 +13638,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
@@ -7809,7 +13698,7 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all behavior, kept RLS enabled, and created authenticated SELECT and INSERT owner-scoped policies using auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "Diagnosed RLS deny-all due to enabled RLS with no policies, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
       }
     ],
     "skills": {
@@ -7818,8 +13707,31 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Data API expose table grants RLS policies authenticated role\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/api/securing-your-api",
+              "title": "Securing your API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0027_pg_graphql_authenticated_table_exposed",
+              "title": "Database Advisor: Lint 0027_pg_graphql_authenticated_table_exposed"
+            }
+          ],
+          "resultChars": 57429
+        }
       ]
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
@@ -7871,7 +13783,7 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Avatar migration was applied through Supabase CLI with `supabase db push --db-url \"$(cat supabase/.temp/pooler-url)\" --yes`, whose output showed `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` The orphan bio migration was reconciled by adding the missing local file `supabase/migrations/20240115000000_add_profile_bio.sql`, after which `supabase migration list --db-url ...` showed local and remote aligned. I saw only read-only `psql` inspections, not direct SQL mutation or prepared-statement reset workarounds."
+        "judgeNotes": "Avatar migration was applied by `supabase db push --db-url \"$DB_URL\"` (#33), which output `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` History was reconciled by adding local migration file `supabase/migrations/20240115000000_add_profile_bio.sql` (#29), after which `supabase migration list --db-url \"$DB_URL\"` showed local/remote aligned (#30, #37). Workaround seen: used `--db-url` with the pooler URL due linked IPv6/DNS issue; no forbidden direct SQL mutation or prepared-statement reset was used."
       }
     ],
     "skills": {
@@ -7883,9 +13795,41 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase CLI db push migration list repair remote migration history\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-push",
+              "title": "Push new migrations to the remote database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-migration-repair",
+              "title": "Repair the migration history table"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-migration-list",
+              "title": "List local and remote migrations"
+            }
+          ],
+          "resultChars": 50099
+        }
+      ]
+    },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.5/resolve-database-001-migration-history-mismatch.json"
   },
   {
@@ -7925,7 +13869,7 @@
       {
         "name": "query plan uses an index and avoids sequential scan",
         "passed": true,
-        "notes": "Limit  (cost=79.74..79.86 rows=50 width=58)\n  ->  Sort  (cost=79.74..79.99 rows=100 width=58)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=5.06..76.42 rows=100 width=58)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..5.03 rows=100 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
+        "notes": "Limit  (cost=55.55..55.61 rows=25 width=88)\n  ->  Sort  (cost=55.55..55.61 rows=25 width=88)\n        Sort Key: created_at DESC\n        ->  Bitmap Heap Scan on events  (cost=4.48..54.97 rows=25 width=88)\n              Recheck Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)\n              ->  Bitmap Index Scan on events_user_id_created_at_desc_idx  (cost=0.00..4.47 rows=25 width=0)\n                    Index Cond: (user_id = '00000000-0000-0000-0000-000000000001'::uuid)"
       },
       {
         "name": "inserts still work",
@@ -7940,6 +13884,44 @@
       "loaded": [
         "supabase",
         "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/changelog.md Supabase changelog",
+          "pages": []
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Postgres query optimization indexes pg_stat_statements explain analyze\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/database/inspect",
+              "title": "Debugging and monitoring"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/query-optimization",
+              "title": "Query Optimization"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/configuration",
+              "title": "Database configuration"
+            }
+          ],
+          "resultChars": 22478
+        }
       ]
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
@@ -8013,7 +13995,46 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/changelog.md supabase changelog",
+          "pages": []
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase row level security workspace team member policy auth.uid\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/auth/users",
+              "title": "Users"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/third-party/firebase-auth",
+              "title": "Firebase Auth"
+            }
+          ],
+          "resultChars": 31265
+        }
       ]
     },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
@@ -8080,6 +14101,38 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Row Level Security policies authenticated users select insert update delete migrations seed local development\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/database/secure-data",
+              "title": "Securing your data"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/column-level-security",
+              "title": "Column Level Security"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/postgres/row-level-security",
+              "title": "Row Level Security"
+            }
+          ],
+          "resultChars": 64944
+        }
+      ]
+    },
     "prompt": "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
     "promptSourcePath": "evals/build-cli-001-bootstrap-app/PROMPT.md",
     "attempts": 1,
@@ -8105,11 +14158,11 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "supabase db diff used to generate the migration",
-        "passed": false
+        "passed": true
       },
       {
         "name": "schema file updated to include description column",
@@ -8127,6 +14180,30 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase CLI local migrations add column table\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            }
+          ],
+          "resultChars": 54403
+        }
+      ]
     },
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
@@ -8166,17 +14243,105 @@
       {
         "name": "cron command enqueues to the 'tasks' queue",
         "passed": true,
-        "notes": "queue depth 1 -> 2"
+        "notes": "queue depth 0 -> 1"
       },
       {
         "name": "process-tasks function drains the queue",
         "passed": true,
-        "notes": "function removed the seeded message (id 4) from the queue"
+        "notes": "function removed the seeded message (id 38) from the queue"
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase queues pgmq cron schedule every minute edge function read delete messages\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/automatic-embeddings",
+              "title": "Automatic embeddings"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/consuming-messages-with-edge-functions",
+              "title": "Consuming Supabase Queue Messages with Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/cron/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/schedule-functions",
+              "title": "Scheduling Edge Functions"
+            }
+          ],
+          "resultChars": 61052
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase config.toml edge function verify_jwt false functions local\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/deploy",
+              "title": "Deploy to Production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/discord-bot",
+              "title": "Building a Discord Bot"
+            }
+          ],
+          "resultChars": 29896
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Queues API pgmq create read send delete queue_name sleep_seconds n\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/queues/api",
+              "title": "API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues",
+              "title": "Supabase Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/quickstart",
+              "title": "Quickstart"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pgmq",
+              "title": "pgmq: Queues"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/queues/expose-self-hosted-queues",
+              "title": "Expose Queues for local and self-hosted Supabase"
+            }
+          ],
+          "resultChars": 17990
+        }
+      ]
     },
     "prompt": "I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.",
     "promptSourcePath": "evals/build-cli-003-pg-cron-queue-workflow/PROMPT.md",
@@ -8228,6 +14393,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
     "promptSourcePath": "evals/build-database-001-migrate-postgres-to-supabase/PROMPT.md",
@@ -8289,6 +14457,30 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Edge Functions Supabase client Authorization header SUPABASE_ANON_KEY\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            }
+          ],
+          "resultChars": 34912
+        }
+      ]
+    },
     "prompt": "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
     "promptSourcePath": "evals/build-functions-004-service-role-bypass/PROMPT.md",
     "attempts": 1,
@@ -8328,37 +14520,37 @@
       {
         "name": "rejects request with no credentials",
         "passed": true,
-        "notes": "status 401: {\"error\":\"Unauthorized\"}"
+        "notes": "status 401: {\"error\":\"Missing valid user token or service apikey\"}"
       },
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"758f23f9-dfd3-445b-976a-3ad452c8b578\",\"metric\":\"steps_a_mrnhio7f\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"da51d778-2281-4348-ab14-4cee82e56866\",\"metric\":\"steps_a_mro22iax\",\"value\":111}]"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"758f23f9-dfd3-445b-976a-3ad452c8b578\",\"metric\":\"steps_a_mrnhio7f\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"da51d778-2281-4348-ab14-4cee82e56866\",\"metric\":\"steps_a_mro22iax\",\"value\":111}]"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"dd27ac2d-d183-46de-a701-e103f81933a9\",\"metric\":\"steps_b_mrnhio7f\",\"value\":222}]"
+        "notes": "status 200: [{\"user_id\":\"7bd8d1f5-a711-4de0-af32-12c9ccd8e465\",\"metric\":\"steps_b_mro22iax\",\"value\":222}]"
       },
       {
         "name": "non-service key is not granted service access",
         "passed": true,
-        "notes": "status 401: {\"error\":\"Unauthorized\"}"
+        "notes": "status 401: {\"error\":\"Missing valid user token or service apikey\"}"
       },
       {
         "name": "rejects an unverified (forged) user token",
         "passed": true,
-        "notes": "status 401: {\"error\":\"Unauthorized\"}"
+        "notes": "status 401: {\"error\":\"Invalid or expired access token\"}"
       },
       {
         "name": "a user token in the apikey slot is not treated as the service key",
         "passed": true,
-        "notes": "status 401: {\"error\":\"Unauthorized\"}"
+        "notes": "status 401: {\"error\":\"Missing valid user token or service apikey\"}"
       },
       {
         "name": "implementation uses @supabase/server",
@@ -8369,6 +14561,62 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Edge Functions JWT authorization apikey service role headers\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            }
+          ],
+          "resultChars": 53802
+        },
+        {
+          "source": "web_search",
+          "query": "Supabase CLI 2.109 functions serve failed to determine entrypoint",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "\"failed to determine entrypoint\" \"entrypoint\" \"functions\" \"config.toml\" Supabase",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "Supabase Edge Function func.yaml verify_jwt entrypoint",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/function-configuration",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration"
+            }
+          ]
+        }
+      ]
     },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
     "promptSourcePath": "evals/build-functions-005-dual-auth-user-secret/PROMPT.md",
@@ -8413,7 +14661,7 @@
       {
         "name": "user A lists only own files",
         "passed": true,
-        "notes": "saw: 019f4d37-0fd6-7282-8095-915f03a1602e/receipt-alpha.pdf, 019f4d37-0fd6-7282-8095-915f03a1602e/receipt-beta.pdf"
+        "notes": "saw: 019f6c9c-f4f5-7321-b7e3-f7554d86bf17/receipt-alpha.pdf, 019f6c9c-f4f5-7321-b7e3-f7554d86bf17/receipt-beta.pdf"
       },
       {
         "name": "user B cannot read user A files",
@@ -8434,12 +14682,44 @@
       {
         "name": "configured private per-user storage access",
         "passed": true,
-        "judgeNotes": "Creates a private user-files bucket, authenticated owner-scoped SELECT and INSERT policies using user-id path prefix, does not disable RLS or use public access, and provides supabase-js createSignedUrl with an expiry."
+        "judgeNotes": "Meets rubric: private user-files bucket, authenticated owner-scoped SELECT and INSERT policies with WITH CHECK using first path segment = auth.uid(), RLS not disabled, and supabase-js createSignedUrl with expiry for temporary sharing. No disallowed public bucket/getPublicUrl/service-role client usage."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Storage create bucket RLS policies auth.uid foldername signed URL createSignedUrl supabase-js\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/storage/serving/downloads",
+              "title": "Serving assets from Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/buckets/fundamentals",
+              "title": "Storage Buckets"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/helper-functions",
+              "title": "Storage Helper Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/schema/custom-roles",
+              "title": "Custom Roles"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/storage/security/access-control",
+              "title": "Storage Access Control"
+            }
+          ],
+          "resultChars": 17747
+        }
+      ]
     },
     "prompt": "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
     "promptSourcePath": "evals/build-storage-001-private-bucket-access/PROMPT.md",
@@ -8476,17 +14756,49 @@
       {
         "name": "pgTAP isolation tests ran and pass",
         "passed": true,
-        "notes": "8 passed, 0 failed"
+        "notes": "4 passed, 0 failed"
       },
       {
         "name": "agent correctly identifies the posts isolation bug from test results",
         "passed": true,
-        "judgeNotes": "The agent correctly identifies `posts` as the table with broken tenant isolation, states that authenticated members could read posts outside their organization, and grounds this in the pgTAP result where `notes` passed but `posts` cross-tenant assertions failed. It treats the test results as authoritative and does not blame `notes` or dismiss the failures."
+        "judgeNotes": "The agent correctly identified `posts` as the table with the tenant isolation flaw, specifically that tenant A/authenticated members could read tenant B posts, and grounded this in the initial pgTAP failure. It did not blame `notes` or dismiss the tests."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase CLI database tests pgTAP supabase test db\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-test-db",
+              "title": "Tests local database with pgTAP"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli/testing-and-linting",
+              "title": "Testing and linting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/overview",
+              "title": "Testing Overview"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/testing",
+              "title": "Testing Your Database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pgtap",
+              "title": "pgTAP: Unit Testing"
+            }
+          ],
+          "resultChars": 23900
+        }
+      ]
     },
     "prompt": "Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.",
     "promptSourcePath": "evals/build-tests-001-rls-tenant-isolation/PROMPT.md",
@@ -8524,12 +14836,12 @@
       {
         "name": "HNSW index on the embedding column",
         "passed": true,
-        "notes": "CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_ip_ops) WHERE (embedding IS NOT NULL)"
+        "notes": "CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_ip_ops)"
       },
       {
         "name": "index operator class matches the search operator",
         "passed": true,
-        "notes": "function operators: <#>\nindexes: CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_ip_ops) WHERE (embedding IS NOT NULL)"
+        "notes": "function operators: <#>\nindexes: CREATE INDEX document_sections_embedding_hnsw_idx ON public.document_sections USING hnsw (embedding vector_ip_ops)"
       },
       {
         "name": "user A search returns only own sections, best match first",
@@ -8551,6 +14863,38 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"pgvector semantic search match_documents row level security policies\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/ai/rag-with-permissions",
+              "title": "RAG with Permissions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/features",
+              "title": "Features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/semantic-search",
+              "title": "Semantic search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/ai/hybrid-search",
+              "title": "Hybrid search"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/resources/glossary",
+              "title": "Glossary"
+            }
+          ],
+          "resultChars": 62456
+        }
+      ]
     },
     "prompt": "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
     "promptSourcePath": "evals/build-vectors-001-rag-with-permissions/PROMPT.md",
@@ -8584,21 +14928,49 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Prometheus preserves the app job and adds a Supabase HTTPS scrape at /customer/v1/privileged/metrics with basic_auth password_file. docker-compose mounts a secrets volume and wires the secret file into the password_file path before starting Prometheus. Target is templated to <project-ref>.supabase.co."
+        "judgeNotes": "Prometheus preserves the app scrape and adds a Supabase HTTPS scrape at /customer/v1/privileged/metrics with Basic Auth using password_file. docker-compose wires the matching password file via a Compose secret mounted at /run/secrets/supabase_metrics_secret_key. No bearer auth or hardcoded key is present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes Secret API key creation, correct secret file placement, Compose start/reload steps, and concrete verification via Prometheus targets/Grafana."
+        "judgeNotes": "README explains creating a Supabase Secret API key, storing it in the matching Docker secret file, restarting/reloading the Compose stack, and verifying via Prometheus targets."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase CLI metrics prometheus endpoint\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            }
+          ],
+          "resultChars": 23580
+        }
+      ]
+    },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.5-no-skills/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -8634,7 +15006,7 @@
       {
         "name": "the weather function reads WEATHER_API_KEY from the environment",
         "passed": true,
-        "judgeNotes": "Reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
+        "judgeNotes": "The function reads WEATHER_API_KEY from the runtime environment using Deno.env.get(\"WEATHER_API_KEY\")."
       },
       {
         "name": "WEATHER_API_KEY value is not committed to the repo",
@@ -8644,6 +15016,38 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Supabase Edge Functions environment variables secrets deploy CLI\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/inspecting-edge-function-environment-variables-wg5qOQ",
+              "title": "Inspecting edge function environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream",
+              "title": "Streaming Speech with ElevenLabs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech",
+              "title": "Transcription Telegram Bot"
+            }
+          ],
+          "resultChars": 41461
+        }
+      ]
     },
     "prompt": "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
     "promptSourcePath": "evals/deploy-functions-001-edge-function-secrets/PROMPT.md",
@@ -8694,6 +15098,38 @@
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"self-hosting docker compose Supabase docker .env\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/docker",
+              "title": "Self-Hosting with Docker"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-s3",
+              "title": "Configure S3 Storage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting",
+              "title": "Self-Hosting"
+            }
+          ],
+          "resultChars": 74361
+        }
+      ]
+    },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",
     "attempts": 1,
@@ -8719,7 +15155,7 @@
     ],
     "suite": "benchmark",
     "interface": "mcp",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "victim session active before delete-account",
@@ -8731,8 +15167,8 @@
       },
       {
         "name": "delete-account revokes the user's sessions",
-        "passed": false,
-        "notes": "sessions left: 1"
+        "passed": true,
+        "notes": "sessions left: 0"
       },
       {
         "name": "deleted user's refresh token is rejected",
@@ -8740,8 +15176,7 @@
       },
       {
         "name": "deleted user cannot sign back in",
-        "passed": false,
-        "notes": "deleted account can still sign in"
+        "passed": true
       },
       {
         "name": "other users keep their sessions and access",
@@ -8749,13 +15184,73 @@
       },
       {
         "name": "diagnosed and explained session revocation",
-        "passed": false,
-        "judgeNotes": "The answer diagnoses the soft-delete cause, implements revocation/active-user RLS checks, and correctly explains publishable vs secret keys. However, it does not clearly explain that access tokens are stateless JWTs that remain valid until expiry after revocation, nor does it advise server-side auth.getUser() or short JWT expiry instead of local-only JWT validation such as getClaims()."
+        "passed": true,
+        "judgeNotes": "Meets all rubric requirements: identifies soft-delete-only root cause, implements auth user/session/refresh-token revocation plus RLS defense, explains JWT expiry caveat consistently with the RLS fix, and correctly distinguishes publishable vs secret keys and RLS behavior."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase publishable secret keys RLS anon service_role\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/server-side/creating-a-client",
+              "title": "Creating a Supabase client for SSR"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
+            }
+          ],
+          "resultChars": 112503
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase Auth delete user refresh tokens sessions deleted_at banned_until\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/auth/managing-user-data",
+              "title": "User Management"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/sessions",
+              "title": "User sessions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/rate-limits",
+              "title": "Rate limits"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/oauth-flows",
+              "title": "OAuth 2.1 Flows"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/users",
+              "title": "Users"
+            }
+          ],
+          "resultChars": 77188
+        }
+      ]
     },
     "prompt": "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
     "promptSourcePath": "evals/investigate-auth-001-deleted-user-access/PROMPT.md",
@@ -8808,12 +15303,15 @@
       {
         "name": "diagnosed missing publication membership",
         "passed": true,
-        "judgeNotes": "The assistant correctly diagnosed that orders was missing from the supabase_realtime publication, added only public.orders via ALTER PUBLICATION, verified courier_locations remained included, and did not alter RLS/policies or blame client/RLS/networking."
+        "judgeNotes": "Identified orders missing from supabase_realtime publication as the cause, applied ALTER PUBLICATION supabase_realtime ADD TABLE public.orders, preserved courier_locations and RLS/policies, and did not blame unrelated causes or weaken security."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
     "promptSourcePath": "evals/investigate-realtime-001-subscribed-no-events/PROMPT.md",
@@ -8844,26 +15342,29 @@
       {
         "name": "identified image-transform and the recurring 503 pattern",
         "passed": true,
-        "judgeNotes": "Identified image-transform as affected and listed the recurring 503 pattern across the morning of 2026-04-28, covering all 8 gateway failures from 07:00Z to 12:00Z."
+        "judgeNotes": "Identified image-transform as the affected function and explicitly described the recurring 503 pattern across all 8 gateway failures from 07:00Z to 12:00Z on 2026-04-28."
       },
       {
         "name": "attributed recurring 503s to gateway/platform layer, not function code",
         "passed": true,
-        "judgeNotes": "Attributes the 503s to the Edge/API gateway layer before the function handler/user code, grounded in the observation that 503s appear in gateway logs but not Edge Function execution logs while nearby invocations succeeded. Some remediation mentions dependency/runtime, but the primary layer attribution is not function application code."
+        "judgeNotes": "Attributes the recurring image-transform 503s to the gateway/platform invocation layer rather than function code, grounded in valid observations: 503s appear in API/gateway logs but not Edge Function execution logs, nearby image-transform invocations succeeded, and the avatar-upload 500 is treated as a distinct function-level error."
       },
       {
         "name": "recommended a concrete next step",
         "passed": true,
-        "judgeNotes": "The assistant recommended concrete next steps, including adding retry/backoff, improving logging around the transform call, checking the dependency for incidents or rate limits during the affected time window, and considering asynchronous queueing."
+        "judgeNotes": "The assistant recommended concrete next steps, including opening a Supabase support/status investigation with specific failed gateway log IDs and identifying the relevant time window."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?",
     "promptSourcePath": "evals/investigate-reliability-003-edge-function-5xx-correlation/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.5-no-skills/investigate-reliability-003-edge-function-5xx-correlation.json"
   },
   {
@@ -8917,12 +15418,15 @@
       {
         "name": "diagnosed RLS and added owner-scoped policies",
         "passed": true,
-        "judgeNotes": "Diagnosed RLS enabled with no policies causing deny-all/zero rows, kept RLS enabled, and created authenticated SELECT and INSERT policies scoped to user_id = auth.uid() with WITH CHECK for inserts."
+        "judgeNotes": "The assistant correctly diagnosed RLS enabled with no policies causing deny-all Data API behavior, kept RLS enabled, and created authenticated-only SELECT and INSERT owner-scoped policies using auth.uid() = user_id with USING and WITH CHECK respectively."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-001-empty-results/PROMPT.md",
@@ -8973,12 +15477,36 @@
       {
         "name": "the avatar migration and history reconciliation were done via the Supabase CLI",
         "passed": true,
-        "judgeNotes": "Applied avatar_url via Supabase CLI command #24: `supabase db push --db-url \"$(cat supabase/.temp/pooler-url)\" --yes`, which showed `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled orphan bio migration by adding local file #22 `supabase/migrations/20240115000000_add_profile_bio.sql`, after which `supabase db push` proceeded successfully. Read-only psql inspections were used; no disallowed workaround or direct SQL mutation observed."
+        "judgeNotes": "Applied avatar_url via Supabase CLI command #25: `supabase db push --db-url ...`, with output `Applying migration 20240220000000_add_avatar_url.sql...` and `Finished supabase db push.` Reconciled orphan bio migration by adding local file `supabase/migrations/20240115000000_add_profile_bio.sql`, after which `supabase migration list --db-url ...` showed local and remote aligned. No prohibited direct SQL mutation or prepared-statement workaround observed; psql usage was read-only inspection."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase CLI db push migration list link project ref IPv4 pooler\", limit: 3) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-push",
+              "title": "Push new migrations to the remote database"
+            }
+          ],
+          "resultChars": 39190
+        }
+      ]
     },
     "prompt": "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
     "promptSourcePath": "evals/resolve-database-001-migration-history-mismatch/PROMPT.md",
@@ -9032,6 +15560,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.",
     "promptSourcePath": "evals/resolve-performance-001-slow-query-cpu-spike/PROMPT.md",
@@ -9101,6 +15632,9 @@
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?",
     "promptSourcePath": "evals/resolve-security-002-rls-cross-tenant-leak/PROMPT.md",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -2969,11 +2969,12 @@
     ],
     "suite": "benchmark",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "cloned the self-host stack (docker-compose.yml + volumes/db)",
-        "passed": true
+        "passed": false,
+        "notes": "supabase-docker/ is missing docker-compose.yml or volumes/db — not the self-host docker/ tree"
       },
       {
         "name": "didn't conflate with the CLI (no supabase/config.toml in the stack)",
@@ -2981,11 +2982,13 @@
       },
       {
         "name": "secrets rotated off the shipped defaults",
-        "passed": true
+        "passed": false,
+        "notes": "still default or empty: POSTGRES_PASSWORD, JWT_SECRET, DASHBOARD_PASSWORD, VAULT_ENC_KEY, PG_META_CRYPTO_KEY"
       },
       {
         "name": "ANON_KEY and SERVICE_ROLE_KEY are HS256 JWTs signed by JWT_SECRET",
-        "passed": true
+        "passed": false,
+        "notes": "JWT_SECRET missing"
       }
     ],
     "skills": {
@@ -2993,94 +2996,10 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": [
-        "supabase"
-      ]
+      "loaded": []
     },
     "docs": {
-      "calls": [
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"self-hosting with Docker docker-compose setup\", limit: 10) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/docker",
-              "title": "Self-Hosting with Docker"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting",
-              "title": "Self-Hosting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
-              "title": "New API Keys and Asymmetric Authentication"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/postgres-upgrade-17",
-              "title": "Upgrade to Postgres 17"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
-              "title": "Envoy API Gateway"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-oauth",
-              "title": "Configure Social Login (OAuth) Providers"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/custom-email-templates",
-              "title": "Custom Email Templates"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development",
-              "title": "Local Development & CLI"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-proxy-https",
-              "title": "Configure Reverse Proxy and HTTPS"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/restore-from-platform",
-              "title": "Restore a Platform Project to Self-Hosted"
-            }
-          ],
-          "resultChars": 144083
-        },
-        {
-          "source": "web_fetch",
-          "query": "List any breaking-change tagged entries related to self-hosting, docker-compose, or the self-hosting docker setup.",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ],
-          "resultChars": 1093
-        },
-        {
-          "source": "web_fetch",
-          "query": "Return the raw list of entries verbatim, especially any tagged breaking-change, from the last 12 months, with their dates and links.",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ],
-          "resultChars": 3617
-        },
-        {
-          "source": "web_fetch",
-          "query": "Return the full setup instructions for self-hosting Supabase with Docker, including the exact git clone / download steps, .env setup, and how to generate secrets (JWT secret, ANON_KEY, SERVICE_ROLE_KEY, dashboard credentials, POSTGRES_PASSWORD).",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/docker.md"
-            }
-          ],
-          "resultChars": 3222
-        }
-      ]
+      "calls": []
     },
     "prompt": "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
     "promptSourcePath": "evals/deploy-self-hosting-001-docker-compose/PROMPT.md",

--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -38,17 +38,17 @@
       {
         "name": "user with JWT reads only their own rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"55f057b8-85d6-4181-ac86-e477d460bc32\",\"metric\":\"steps_a_mrnh4gnx\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"5b224b3b-e1d0-4197-a22f-a738858b2315\",\"metric\":\"steps_a_mrnyrvhs\",\"value\":111}]"
       },
       {
         "name": "user cannot read another user's rows by passing user_id",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"55f057b8-85d6-4181-ac86-e477d460bc32\",\"metric\":\"steps_a_mrnh4gnx\",\"value\":111}]"
+        "notes": "status 200: [{\"user_id\":\"5b224b3b-e1d0-4197-a22f-a738858b2315\",\"metric\":\"steps_a_mrnyrvhs\",\"value\":111}]"
       },
       {
         "name": "service key bypasses RLS to read the target user's rows",
         "passed": true,
-        "notes": "status 200: [{\"user_id\":\"7454ff9b-79f9-420e-af91-c0572d707ebb\",\"metric\":\"steps_b_mrnh4gnx\",\"value\":222}]"
+        "notes": "status 200: [{\"user_id\":\"34a127c9-7278-4fe6-b65c-03d6f9f9fe6d\",\"metric\":\"steps_b_mrnyrvhs\",\"value\":222}]"
       },
       {
         "name": "non-service key is not granted service access",
@@ -78,6 +78,105 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"edge function Deno.serve npm import export default fetch handler\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions",
+              "title": "Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/features",
+              "title": "Features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/http-methods",
+              "title": "Routing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/architecture",
+              "title": "Architecture"
+            }
+          ],
+          "resultChars": 55368
+        },
+        {
+          "source": "web_fetch",
+          "query": "List any breaking-change tagged entries related to Edge Functions, edge runtime, npm imports, or the export default fetch handler style, or @supabase/server.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ],
+          "resultChars": 1362
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"@supabase/server withSupabase edge function auth secret key user_id\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/passkeys",
+              "title": "Passkey authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/choosing-a-server-package",
+              "title": "Which package to use"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/extensions/pg_net",
+              "title": "pg_net: Async Networking"
+            }
+          ],
+          "resultChars": 51855
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"verify_jwt config.toml functions apikey header authorization edge functions\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/deploy",
+              "title": "Deploy to Production"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            }
+          ],
+          "resultChars": 32345
+        }
       ]
     },
     "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nImplement it with the **`@supabase/server`** package, which is built for exactly\nthis kind of multi-auth Edge Function. Import it directly in your function:\n\n```ts\nimport { withSupabase } from \"npm:@supabase/server\";\n```\n\nOur product stores per-user metrics in a `user_stats` table that already exists\n(see `supabase/migrations/`), protected by row-level security so a user can read\nonly their own rows.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.\n\nGet the local stack running so the function is reachable at the path above.",
@@ -114,7 +213,7 @@
       {
         "name": "did not recommend read replicas for Realtime",
         "passed": true,
-        "judgeNotes": "The answer treats the request as Supabase Realtime/Postgres Changes setup, adds public.messages to the supabase_realtime publication, provides a postgres_changes client snippet, and does not recommend read replicas or confuse them with logical replication/publications."
+        "judgeNotes": "The answer correctly treats the issue as a Supabase Realtime/Postgres Changes setup, identifies the missing supabase_realtime publication entry, adds public.messages to it, and provides a postgres_changes client subscription. It does not recommend or imply read replicas are needed or useful for live updates."
       }
     ],
     "skills": {
@@ -125,6 +224,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
     "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
@@ -154,17 +256,17 @@
       {
         "name": "identified video-thumbnails and the 546 resource-limit pattern",
         "passed": true,
-        "judgeNotes": "Identified `video-thumbnails` as the affected function and explicitly recognized failures as HTTP 546 due to CPU/resource limit, not 500/503."
+        "judgeNotes": "The assistant correctly identified `video-thumbnails` as the affected function and explicitly recognized the failures as HTTP 546 shutdowns due to CPUTime/resource limits, not 500/503 server errors."
       },
       {
         "name": "attributed the 546s to CPU time exhaustion",
         "passed": true,
-        "judgeNotes": "The assistant specifically attributes the 546 failures to CPU time exhaustion, citing shutdown reason CPUTime and cpu_time_used=2000ms at cpu_time_limit=2000ms, and distinguishes it from wall-clock/network/code issues."
+        "judgeNotes": "The assistant specifically attributes the 546s to CPU time exhaustion, citing shutdown reason `CPUTime` and `cpu_time_used: 2000ms / limit: 2000ms`. It does not blame memory, wall-clock time, code exceptions, or unrelated errors."
       },
       {
         "name": "recommended reducing/offloading CPU work as the fix",
         "passed": true,
-        "judgeNotes": "The assistant clearly recommends moving CPU-heavy video decoding/thumbnail extraction out of the Edge Function into an async/background worker or external/container service, and also suggests reducing inline CPU work by decoding only needed frames, downscaling, and routing oversized videos asynchronously. It explicitly says not to increase the CPU limit."
+        "judgeNotes": "The assistant identifies CPU-intensive thumbnail generation as the root cause and recommends reducing CPU cost per call through optimization, as well as moving the work off Edge Functions to a background worker/container. It mentions retry only as a short-term mitigation, not the fix."
       }
     ],
     "skills": {
@@ -174,6 +276,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"edge function CPU time limit shutdown reason\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-function-shutdown-reasons-explained",
+              "title": "Edge Function shutdown reasons explained"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-function-cpu-limits",
+              "title": "Understanding Edge Function CPU limits"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-functions-worker-timeouts-and-websocket-drops",
+              "title": "Edge Functions worker timeouts and WebSocket drops"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/status-codes",
+              "title": "Status codes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-function-monitoring-resource-usage",
+              "title": "Monitoring Edge Function resource usage"
+            }
+          ],
+          "resultChars": 25339
+        }
       ]
     },
     "prompt": "Our `video-thumbnails` edge function has been failing intermittently since this morning. It generates a thumbnail from a user-uploaded video, and about half the calls are erroring out.\n\nCan you investigate the project logs and tell me what's going on and what we should do about it?",
@@ -248,7 +382,7 @@
       {
         "name": "diagnosed secure default grants without weakening RLS",
         "passed": true,
-        "judgeNotes": "The answer correctly diagnoses missing table-level grants/Data API exposure separate from RLS, preserves existing owner-scoped RLS, grants only SELECT and INSERT on public.journal_entries to authenticated, does not grant anon/public, and keeps RLS enabled with verification."
+        "judgeNotes": "Diagnoses missing table-level grants before RLS, distinguishes grants from RLS, preserves owner-scoped RLS, grants only SELECT/INSERT on public.journal_entries to authenticated, and does not weaken RLS or grant anon/public."
       }
     ],
     "skills": {
@@ -259,6 +393,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-002-secure-default-grants/PROMPT.md",
@@ -293,7 +430,7 @@
       {
         "name": "user A's update actually checks off their own task",
         "passed": true,
-        "notes": "saw: [{\"id\":\"a5fd1475-664f-4723-9885-cd18d2aaa382\",\"is_done\":true}]"
+        "notes": "saw: [{\"id\":\"5715257d-45fa-4c7e-b70b-ee9b85de2392\",\"is_done\":true}]"
       },
       {
         "name": "user B cannot update user A's task",
@@ -302,7 +439,7 @@
       {
         "name": "diagnosed the missing USING clause and added it",
         "passed": true,
-        "judgeNotes": "Diagnosed the missing USING clause on the UPDATE RLS policy, explained why WITH CHECK alone causes zero-row updates, and fixed it with a user_id = auth.uid() USING while preserving WITH CHECK and authenticated/owner scoping."
+        "judgeNotes": "Diagnosed the missing USING clause on the UPDATE RLS policy, explained WITH CHECK vs USING, and fixed it with an authenticated, owner-scoped USING plus retained WITH CHECK."
       }
     ],
     "skills": {
@@ -313,6 +450,9 @@
       "loaded": [
         "supabase"
       ]
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users manage a personal `tasks` list. Users can create tasks and check them off (`is_done`).\n\nCreating a task works fine, and I can see the row in the table. But when a user checks off a task, the app's update call succeeds with no error, yet `is_done` never actually changes, and the API doesn't return the updated row either.\n\nFind out why the update has no effect and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-002-update-zero-rows-affected/PROMPT.md",
@@ -342,7 +482,7 @@
       {
         "name": "answered unhealthy project recovery question safely",
         "passed": true,
-        "judgeNotes": "The answer clearly says not to use pause/restore first, recommends restart as the first recovery step, distinguishes restart from pause/restore, mentions resource constraints/tuning and support, and points to Supabase troubleshooting docs. It could more explicitly define restore as backup/data recovery and include logs/waiting steps, but it provides concrete safe recovery guidance."
+        "judgeNotes": "Answers with safe recovery guidance: clearly rejects pause/restore as first step, distinguishes restart from restore, recommends restart plus checking resource pressure/tuning/scaling, and suggests support if unresolved."
       }
     ],
     "skills": {
@@ -352,6 +492,38 @@
       ],
       "loaded": [
         "supabase"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"project unhealthy restart pause restore dashboard unresponsive\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/project-status-reports-unhealthy-services",
+              "title": "Project Status reports unhealthy services"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/backups",
+              "title": "Database Backups"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/upgrading",
+              "title": "Upgrading"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/free-project-pausing",
+              "title": "Project Pausing"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/failed-to-run-sql-query-connection-terminated-due-to-connection-timeout",
+              "title": "Error: Failed to run sql query: Connection terminated due to connection timeout"
+            }
+          ],
+          "resultChars": 28446
+        }
       ]
     },
     "prompt": "My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?",
@@ -400,7 +572,7 @@
       {
         "name": "user A can replace their own avatar via upsert",
         "passed": true,
-        "notes": "saw: [{\"name\":\"019f6b4d-e03f-7180-87cb-a6467be87a16/avatar.png\",\"metadata\":{\"version\":\"replacement\"}}]"
+        "notes": "saw: [{\"name\":\"019f6c9d-21f1-7326-8f11-28be4547cdcb/avatar.png\",\"metadata\":{\"version\":\"replacement\"}}]"
       },
       {
         "name": "user B cannot overwrite user A's avatar",
@@ -409,7 +581,7 @@
       {
         "name": "added an owner-scoped UPDATE policy without weakening public reads",
         "passed": true,
-        "judgeNotes": "Diagnosed missing UPDATE policy for Supabase Storage upsert, distinguished public bucket/read from write/update permissions, added authenticated owner-scoped UPDATE policy with USING and WITH CHECK, and kept public read/RLS intact."
+        "judgeNotes": "Diagnosed missing UPDATE RLS policy for upsert replacements, explained public bucket only affects reads, kept public read/RLS, and added an authenticated owner-scoped UPDATE policy with USING and WITH CHECK."
       }
     ],
     "skills": {
@@ -421,10 +593,97 @@
         "supabase"
       ]
     },
+    "docs": {
+      "calls": []
+    },
     "prompt": "Our app has a public `avatars` bucket so profile photos have a public URL. Each user's avatar is stored at `<user_id>/avatar.png`, and the app uploads it with `upsert: true` so a new photo replaces the old one at that same path.\n\nThe very first upload for a user always works, but replacing an existing avatar fails. Find out why and fix it.",
     "promptSourcePath": "evals/resolve-storage-001-upsert-missing-update-policy/PROMPT.md",
     "attempts": 1,
     "sourcePath": "claude-code-sonnet-5/resolve-storage-001-upsert-missing-update-policy.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5-no-skills",
+    "experimentSuite": "regression",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-functions-006-dual-auth-with-server",
+    "stage": "build",
+    "product": [
+      "edge-functions",
+      "auth",
+      "database"
+    ],
+    "topic": [
+      "sdk",
+      "rls",
+      "security"
+    ],
+    "suite": "regression",
+    "interface": "cli",
+    "cliVersion": "2.109.1",
+    "passed": true,
+    "checks": [
+      {
+        "name": "seed rows present",
+        "passed": true,
+        "notes": "found 2/2 seeded rows"
+      },
+      {
+        "name": "rejects request with no credentials",
+        "passed": true,
+        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+      },
+      {
+        "name": "user with JWT reads only their own rows",
+        "passed": true,
+        "notes": "status 200: {\"data\":[{\"user_id\":\"a8c13bcc-f391-46b0-978e-fd87f0850208\",\"metric\":\"steps_a_mrnyr9ob\",\"value\":111}]}"
+      },
+      {
+        "name": "user cannot read another user's rows by passing user_id",
+        "passed": true,
+        "notes": "status 200: {\"data\":[{\"user_id\":\"a8c13bcc-f391-46b0-978e-fd87f0850208\",\"metric\":\"steps_a_mrnyr9ob\",\"value\":111}]}"
+      },
+      {
+        "name": "service key bypasses RLS to read the target user's rows",
+        "passed": true,
+        "notes": "status 200: {\"data\":[{\"user_id\":\"c37e9490-678e-42c0-a1cc-4695f478a717\",\"metric\":\"steps_b_mrnyr9ob\",\"value\":222}]}"
+      },
+      {
+        "name": "non-service key is not granted service access",
+        "passed": true,
+        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+      },
+      {
+        "name": "rejects an unverified (forged) user token",
+        "passed": true,
+        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+      },
+      {
+        "name": "a user token in the apikey slot is not treated as the service key",
+        "passed": true,
+        "notes": "status 401: {\"message\":\"Invalid credentials\",\"code\":\"INVALID_CREDENTIALS\"}"
+      },
+      {
+        "name": "implementation uses @supabase/server",
+        "passed": true,
+        "notes": "imports @supabase/server / withSupabase"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nImplement it with the **`@supabase/server`** package, which is built for exactly\nthis kind of multi-auth Edge Function. Import it directly in your function:\n\n```ts\nimport { withSupabase } from \"npm:@supabase/server\";\n```\n\nOur product stores per-user metrics in a `user_stats` table that already exists\n(see `supabase/migrations/`), protected by row-level security so a user can read\nonly their own rows.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.\n\nGet the local stack running so the function is reachable at the path above.",
+    "promptSourcePath": "evals/build-functions-006-dual-auth-with-server/PROMPT.md",
+    "attempts": 1,
+    "sourcePath": "claude-code-sonnet-5-no-skills/build-functions-006-dual-auth-with-server.json"
   },
   {
     "experiment": "claude-code-sonnet-5-no-skills",
@@ -455,12 +714,15 @@
       {
         "name": "did not recommend read replicas for Realtime",
         "passed": true,
-        "judgeNotes": "The answer correctly treats the task as Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, provides a postgres_changes subscription snippet, and does not recommend or confuse read replicas."
+        "judgeNotes": "The assistant correctly treats the request as Supabase Realtime/Postgres Changes setup, adds the messages table to the supabase_realtime publication, and provides a postgres_changes subscription example. It does not recommend or imply read replicas are needed or useful for live updates."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
     "promptSourcePath": "evals/build-realtime-001-live-chat-updates/PROMPT.md",
@@ -490,22 +752,54 @@
       {
         "name": "identified video-thumbnails and the 546 resource-limit pattern",
         "passed": true,
-        "judgeNotes": "Identified `video-thumbnails` as the affected function and explicitly recognized HTTP 546 CPU/resource-limit shutdowns, not 500s/503s."
+        "judgeNotes": "The assistant correctly identified the affected function as video-thumbnails and recognized the failures as HTTP 546 WORKER_RESOURCE_LIMIT/WORKER_RESOURCE_LIMIT-style CPUTime resource limit responses, not 500s or 503s."
       },
       {
         "name": "attributed the 546s to CPU time exhaustion",
         "passed": true,
-        "judgeNotes": "The assistant explicitly attributes the 546 shutdowns to CPU time exhaustion, citing log evidence: `shutdown (reason: CPUTime, cpu_time_used: 2000ms, cpu_time_limit: 2000ms)`, and explains this as hitting the CPU cap rather than memory, wall-clock time, exceptions, or unrelated errors."
+        "judgeNotes": "The assistant specifically attributes the 546s to CPU time exhaustion, citing log evidence including `reason: CPUTime`, `cpu_time_used: 2000ms`, and `cpu_time_limit: 2000ms`, and distinguishes this from wall-clock time, memory, code exceptions, or unrelated errors."
       },
       {
         "name": "recommended reducing/offloading CPU work as the fix",
         "passed": true,
-        "judgeNotes": "The assistant explicitly recommends reducing CPU cost per call and moving CPU-heavy thumbnail generation off the Edge Function hot path to a background worker/external processing service. It does not rely only on retries, timeouts, or raising limits."
+        "judgeNotes": "The assistant correctly identifies the CPUTime limit and recommends reducing/offloading CPU-intensive thumbnail generation via background/external workers, cheaper strategies, smaller inputs, and splitting work."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"edge function CPU time limit 546 shutdown\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-function-546-error-response",
+              "title": "546 - WORKER_RESOURCE_LIMIT Exceeded / WORKER_LIMIT Exceeded"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-function-wall-clock-time-limit-reached-Nk38bW",
+              "title": "Edge Function 'wall clock time limit reached'"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/edge-function-cpu-limits",
+              "title": "Understanding Edge Function CPU limits"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/limits",
+              "title": "Limits"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/status-codes",
+              "title": "Status codes"
+            }
+          ],
+          "resultChars": 22567
+        }
+      ]
     },
     "prompt": "Our `video-thumbnails` edge function has been failing intermittently since this morning. It generates a thumbnail from a user-uploaded video, and about half the calls are erroring out.\n\nCan you investigate the project logs and tell me what's going on and what we should do about it?",
     "promptSourcePath": "evals/investigate-functions-001-546-resource-limit/PROMPT.md",
@@ -579,12 +873,15 @@
       {
         "name": "diagnosed secure default grants without weakening RLS",
         "passed": true,
-        "judgeNotes": "Diagnoses missing Data API/table grants under secure-default behavior, distinguishes grants from RLS, preserves owner-scoped RLS, grants SELECT/INSERT to authenticated, and does not grant anon/public or weaken RLS. Extra service_role grant is not disqualifying."
+        "judgeNotes": "Diagnoses secure-by-default revoked/default grants behavior, distinguishes GRANTs from RLS, preserves existing owner-scoped RLS, grants only SELECT/INSERT on public.journal_entries to authenticated, and does not grant anon/public or disable/weaken RLS."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-002-secure-default-grants/PROMPT.md",
@@ -619,7 +916,7 @@
       {
         "name": "user A's update actually checks off their own task",
         "passed": true,
-        "notes": "saw: [{\"id\":\"6d830c6f-831f-421b-97b0-73d45aabc9f3\",\"is_done\":true}]"
+        "notes": "saw: [{\"id\":\"90ce5151-322b-44e2-9cd9-c3bd65c41c9c\",\"is_done\":true}]"
       },
       {
         "name": "user B cannot update user A's task",
@@ -628,12 +925,15 @@
       {
         "name": "diagnosed the missing USING clause and added it",
         "passed": true,
-        "judgeNotes": "Diagnosed the silent zero-row UPDATE as the tasks UPDATE RLS policy missing a USING clause, explained WITH CHECK vs USING behavior, and fixed it by adding owner-scoped USING while preserving WITH CHECK and authenticated/user isolation."
+        "judgeNotes": "The answer correctly identifies the missing USING clause on the UPDATE RLS policy, explains why it causes zero-row updates, and fixes it with USING (user_id = auth.uid()) while preserving WITH CHECK (user_id = auth.uid()). It keeps the policy scoped to authenticated/user ownership and does not disable RLS."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app lets signed-in users manage a personal `tasks` list. Users can create tasks and check them off (`is_done`).\n\nCreating a task works fine, and I can see the row in the table. But when a user checks off a task, the app's update call succeeds with no error, yet `is_done` never actually changes, and the API doesn't return the updated row either.\n\nFind out why the update has no effect and fix it.",
     "promptSourcePath": "evals/resolve-dataapi-002-update-zero-rows-affected/PROMPT.md",
@@ -663,12 +963,64 @@
       {
         "name": "answered unhealthy project recovery question safely",
         "passed": true,
-        "judgeNotes": "The answer clearly advises against pause/restore as the first recovery step, distinguishes restart from pause/restore, recommends restart first plus checking status/logs/advisors, and suggests support if dashboard access is blocked. It is safe and does not conflate restore with restart."
+        "judgeNotes": "The answer clearly says pause/restore is not the right first recovery path, recommends restart first, distinguishes restart from pause/restore, and suggests concrete follow-up diagnostics such as logs/advisors and scaling resources if overloaded. It omits contacting Supabase support and waiting a few minutes, but overall provides safe, docs-grounded recovery guidance."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "Supabase project unhealthy dashboard unusable restart vs pause restore",
+          "hasContent": false,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/restore-project-after-90-days-pause",
+              "title": "Supabase Docs | Troubleshooting | How To Restore Project After 90-Day Pause"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/project-status-reports-unhealthy-services",
+              "title": "Supabase Docs | Troubleshooting | Project Status reports unhealthy services"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/free-project-pausing",
+              "title": "Project Pausing | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/pausing-pro-projects-vNL-2a",
+              "title": "Supabase Docs | Troubleshooting | Pausing Pro-Projects"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting",
+              "title": "Supabase Docs | Troubleshooting"
+            },
+            {
+              "url": "https://status.supabase.com/",
+              "title": "Supabase Status"
+            },
+            {
+              "url": "https://supabase.com/dashboard/support/new?category=Dashboard_bug&subject=Failed+to+retrieve+pause+status&error=No+backups+found",
+              "title": "Supabase"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/restoring-downloaded-backup",
+              "title": "Restoring a downloaded backup locally | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/upgrading",
+              "title": "Upgrading | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/changelog?next=Y3Vyc29yOnYyOpK0MjAyNC0wNy0xNVQxNDozODoxOVrOAGneGA%3D%3D&restPage=2",
+              "title": "Changelog"
+            }
+          ],
+          "resultChars": 2656
+        }
+      ]
     },
     "prompt": "My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?",
     "promptSourcePath": "evals/resolve-reliability-001-unhealthy-project-recovery/PROMPT.md",
@@ -716,7 +1068,7 @@
       {
         "name": "user A can replace their own avatar via upsert",
         "passed": true,
-        "notes": "saw: [{\"name\":\"019f6b4d-a79d-7121-84f4-2001ba455934/avatar.png\",\"metadata\":{\"version\":\"replacement\"}}]"
+        "notes": "saw: [{\"name\":\"019f6c9c-e0c1-713e-aa5c-8aaa9da10640/avatar.png\",\"metadata\":{\"version\":\"replacement\"}}]"
       },
       {
         "name": "user B cannot overwrite user A's avatar",
@@ -725,12 +1077,15 @@
       {
         "name": "added an owner-scoped UPDATE policy without weakening public reads",
         "passed": true,
-        "judgeNotes": "Diagnosed missing UPDATE RLS policy for upsert replacement, kept public read/RLS intact, and added authenticated owner-scoped UPDATE policy with USING and WITH CHECK."
+        "judgeNotes": "The answer correctly diagnoses missing UPDATE RLS policy for upsert replacement, notes public bucket only affects reads, keeps public/RLS setup intact, and adds an authenticated owner-scoped UPDATE policy with both USING and WITH CHECK."
       }
     ],
     "skills": {
       "available": [],
       "loaded": []
+    },
+    "docs": {
+      "calls": []
     },
     "prompt": "Our app has a public `avatars` bucket so profile photos have a public URL. Each user's avatar is stored at `<user_id>/avatar.png`, and the app uploads it with `upsert: true` so a new photo replaces the old one at that same path.\n\nThe very first upload for a user always works, but replacing an existing avatar fails. Find out why and fix it.",
     "promptSourcePath": "evals/resolve-storage-001-upsert-missing-update-policy/PROMPT.md",

--- a/packages/core/src/agents/claude-code/parser.test.ts
+++ b/packages/core/src/agents/claude-code/parser.test.ts
@@ -156,6 +156,7 @@ describe("adaptTranscript", () => {
       {
         endpoint: "Bash",
         body: { command: "ls -la" },
+        name: "shell",
         command: "ls -la",
         result: "file1\nfile2",
         error: undefined,
@@ -164,6 +165,7 @@ describe("adaptTranscript", () => {
       {
         endpoint: "mcp__supabase__search_docs",
         body: { query: "rls" },
+        name: "tool_use",
         result: undefined,
         error: "boom",
         ts: 0,

--- a/packages/core/src/agents/codex/parser.test.ts
+++ b/packages/core/src/agents/codex/parser.test.ts
@@ -65,6 +65,7 @@ describe("codexParser", () => {
       {
         endpoint: "command_execution",
         body: { command: "/bin/zsh -lc 'echo hi'" },
+        name: "shell",
         command: "/bin/zsh -lc 'echo hi'",
         result: "hi\n",
         error: undefined,
@@ -73,6 +74,7 @@ describe("codexParser", () => {
       {
         endpoint: "file_change",
         body: { changes: [{ path: "/work/note.txt", kind: "add" }] },
+        name: "file_write",
         path: "/work/note.txt",
         result: "completed",
         error: undefined,

--- a/packages/core/src/docs-results.test.ts
+++ b/packages/core/src/docs-results.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import { buildDocsResult } from "./docs-results.js";
+import type { ToolCallRecord } from "./index.js";
+
+/** Builds the minimal tool call record needed by docs-result tests. */
+function toolCall(
+  endpoint: string,
+  body: Record<string, unknown>,
+  options: Partial<Pick<ToolCallRecord, "url" | "result" | "name">> = {},
+): ToolCallRecord {
+  return { endpoint, body, ...options, ts: 0 };
+}
+
+describe("buildDocsResult", () => {
+  it("builds one call from a search_docs invocation, flagging no content when the query didn't select it", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "mcp__supabase-mcp__search_docs",
+        { graphql_query: '{ searchDocs(query: "rls") { nodes { title href } } }' },
+        {
+          result: {
+            searchDocs: {
+              nodes: [
+                {
+                  title: "Row Level Security",
+                  href: "https://supabase.com/docs/guides/database/postgres/row-level-security",
+                },
+              ],
+            },
+          },
+        },
+      ),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "search_docs",
+        query: '{ searchDocs(query: "rls") { nodes { title href } } }',
+        hasContent: false,
+        pages: [
+          {
+            url: "https://supabase.com/docs/guides/database/postgres/row-level-security",
+            title: "Row Level Security",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("flags hasContent true from the query's own field selection, not the result, so it survives truncation", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "rls") { nodes { title href content } } }' },
+        { result: "Error: result exceeds maximum allowed tokens. Output has been saved to a file." },
+      ),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "search_docs",
+        query: '{ searchDocs(query: "rls") { nodes { title href content } } }',
+        hasContent: true,
+        pages: [],
+      },
+    ]);
+  });
+
+  it("doesn't mistake the word content inside a quoted search term for a field selection", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "content management") { nodes { title href } } }' },
+        { result: { searchDocs: { nodes: [] } } },
+      ),
+    ]);
+
+    expect(result.calls[0].hasContent).toBe(false);
+  });
+
+  it("finds the query nested under body.arguments (real Codex mcp_tool_call shape)", () => {
+    const result = buildDocsResult([
+      toolCall(
+        // Codex's parser sets originalName to the MCP tool's own name
+        // (item.tool), not the "mcp_tool_call" item type, and reports the
+        // whole raw item as `body`, args nested under `body.arguments`.
+        "search_docs",
+        {
+          id: "item_9",
+          type: "mcp_tool_call",
+          server: "supabase-mcp",
+          tool: "search_docs",
+          arguments: { graphql_query: '{ searchDocs(query: "rls") { nodes { title href } } }' },
+        },
+        {
+          result: {
+            searchDocs: {
+              nodes: [
+                {
+                  title: "Row Level Security",
+                  href: "https://supabase.com/docs/guides/database/postgres/row-level-security",
+                },
+              ],
+            },
+          },
+        },
+      ),
+    ]);
+
+    expect(result.calls[0].query).toBe('{ searchDocs(query: "rls") { nodes { title href } } }');
+    expect(result.calls[0].pages.map((p) => p.url)).toEqual([
+      "https://supabase.com/docs/guides/database/postgres/row-level-security",
+    ]);
+  });
+
+  it("unwraps a content-array result whose text field is a JSON-encoded string (real Claude Code shape)", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "mcp__supabase-mcp__search_docs",
+        { graphql_query: '{ searchDocs(query: "rls") { nodes { title href } } }' },
+        {
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                result: {
+                  searchDocs: {
+                    nodes: [
+                      {
+                        title: "Row Level Security",
+                        href: "https://supabase.com/docs/guides/database/postgres/row-level-security",
+                      },
+                    ],
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      ),
+    ]);
+
+    expect(result.calls[0].pages).toEqual([
+      {
+        url: "https://supabase.com/docs/guides/database/postgres/row-level-security",
+        title: "Row Level Security",
+      },
+    ]);
+  });
+
+  it("still records the call, with no pages, when the result is truncated and the query didn't select href either", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "rls") { nodes { content } } }' },
+        { result: "Error: result exceeds maximum allowed tokens. Output has been saved to a file." },
+      ),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "search_docs",
+        query: '{ searchDocs(query: "rls") { nodes { content } } }',
+        hasContent: true,
+        pages: [],
+      },
+    ]);
+  });
+
+  it("takes a WebFetch call from its url arg, matched by canonical name not raw tool name, always counted as having content", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "WebFetch",
+        { url: "https://supabase.com/docs/guides/auth", prompt: "summarize" },
+        { url: "https://supabase.com/docs/guides/auth", name: "web_fetch" },
+      ),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "web_fetch",
+        query: "https://supabase.com/docs/guides/auth",
+        hasContent: true,
+        pages: [{ url: "https://supabase.com/docs/guides/auth" }],
+      },
+    ]);
+  });
+
+  it("ignores a fetch call on a non-Supabase domain", () => {
+    const result = buildDocsResult([
+      toolCall("WebFetch", { url: "https://example.com/foo" }, { url: "https://example.com/foo", name: "web_fetch" }),
+    ]);
+
+    expect(result.calls).toEqual([]);
+  });
+
+  it("parses title+url pairs out of Claude Code's WebSearch Links blob, flagged as hits not reads", () => {
+    const resultText =
+      'Web search results for query: "Supabase RLS"\n\n' +
+      'Links: [{"title":"Row Level Security | Supabase Docs","url":"https://supabase.com/docs/guides/database/postgres/row-level-security"},' +
+      '{"title":"Unrelated","url":"https://example.com/rls"}]\n\nSummary text.';
+
+    const result = buildDocsResult([
+      toolCall("WebSearch", { query: "Supabase RLS documentation" }, { result: resultText, name: "web_search" }),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "web_search",
+        query: "Supabase RLS documentation",
+        hasContent: false,
+        pages: [
+          {
+            url: "https://supabase.com/docs/guides/database/postgres/row-level-security",
+            title: "Row Level Security | Supabase Docs",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("drops a web search call that isn't Supabase-related", () => {
+    const result = buildDocsResult([
+      toolCall("WebSearch", { query: "how to configure nginx" }, { result: "no matches", name: "web_search" }),
+    ]);
+
+    expect(result.calls).toEqual([]);
+  });
+
+  it("treats a URL-shaped Codex web_search query as a fetch call of unknown content, same as Claude's WebSearch fetch pattern would", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "web_search",
+        { query: "https://supabase.com/docs/guides/database/extensions/pg_net" },
+        { name: "web_search" },
+      ),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "web_search",
+        query: "https://supabase.com/docs/guides/database/extensions/pg_net",
+        pages: [{ url: "https://supabase.com/docs/guides/database/extensions/pg_net" }],
+      },
+    ]);
+    expect(result.calls[0].hasContent).toBeUndefined();
+  });
+
+  it("treats a search-term Codex web_search call as unknown content with no pages", () => {
+    const result = buildDocsResult([
+      toolCall("web_search", { query: "site:supabase.com/docs pg_cron schedule" }, { name: "web_search" }),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: "web_search",
+        query: "site:supabase.com/docs pg_cron schedule",
+        pages: [],
+      },
+    ]);
+    expect(result.calls[0].hasContent).toBeUndefined();
+  });
+
+  it("ignores WebFetch/WebSearch-shaped calls when the parser never normalized a canonical name", () => {
+    const result = buildDocsResult([
+      toolCall("WebFetch", { url: "https://supabase.com/docs/guides/auth" }, { url: "https://supabase.com/docs/guides/auth" }),
+    ]);
+
+    expect(result.calls).toEqual([]);
+  });
+
+  it("orders calls by when they actually happened, not grouped by channel", () => {
+    const result = buildDocsResult([
+      toolCall("web_search", { query: "https://supabase.com/changelog.md" }, { name: "web_search" }),
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "auth") { nodes { href } } }' },
+        { result: { searchDocs: { nodes: [{ href: "https://supabase.com/docs/guides/auth" }] } } },
+      ),
+    ]);
+
+    expect(result.calls.map((c) => c.source)).toEqual(["web_search", "search_docs"]);
+  });
+
+  it("keeps a page seen from two different calls in each call's own results, no cross-call dedup", () => {
+    const result = buildDocsResult([
+      toolCall("WebFetch", { url: "https://supabase.com/docs/guides/auth" }, { url: "https://supabase.com/docs/guides/auth", name: "web_fetch" }),
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "auth") { nodes { title href } } }' },
+        { result: { searchDocs: { nodes: [{ title: "Auth", href: "https://supabase.com/docs/guides/auth" }] } } },
+      ),
+    ]);
+
+    expect(result.calls).toHaveLength(2);
+    expect(result.calls[0].pages[0].url).toBe("https://supabase.com/docs/guides/auth");
+    expect(result.calls[1].pages[0].url).toBe("https://supabase.com/docs/guides/auth");
+  });
+});

--- a/packages/core/src/docs-results.test.ts
+++ b/packages/core/src/docs-results.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildDocsResult } from "./docs-results.js";
+import { describe, expect, it, vi } from "vitest";
+import { buildDocsResult, rehydrateTruncatedDocsResults } from "./docs-results.js";
 import type { ToolCallRecord } from "./index.js";
 
 /** Builds the minimal tool call record needed by docs-result tests. */
@@ -43,6 +43,7 @@ describe("buildDocsResult", () => {
             title: "Row Level Security",
           },
         ],
+        resultChars: expect.any(Number),
       },
     ]);
   });
@@ -62,6 +63,7 @@ describe("buildDocsResult", () => {
         query: '{ searchDocs(query: "rls") { nodes { title href content } } }',
         hasContent: true,
         pages: [],
+        resultChars: expect.any(Number),
       },
     ]);
   });
@@ -163,27 +165,40 @@ describe("buildDocsResult", () => {
         query: '{ searchDocs(query: "rls") { nodes { content } } }',
         hasContent: true,
         pages: [],
+        resultChars: expect.any(Number),
       },
     ]);
   });
 
-  it("takes a WebFetch call from its url arg, matched by canonical name not raw tool name, always counted as having content", () => {
+  it("takes a WebFetch call's query from its prompt arg, not the url, since the prompt is what actually varies the result", () => {
     const result = buildDocsResult([
       toolCall(
         "WebFetch",
-        { url: "https://supabase.com/docs/guides/auth", prompt: "summarize" },
-        { url: "https://supabase.com/docs/guides/auth", name: "web_fetch" },
+        { url: "https://supabase.com/changelog.md", prompt: "List breaking-change entries about self-hosting" },
+        { url: "https://supabase.com/changelog.md", name: "web_fetch" },
       ),
     ]);
 
     expect(result.calls).toEqual([
       {
         source: "web_fetch",
-        query: "https://supabase.com/docs/guides/auth",
+        query: "List breaking-change entries about self-hosting",
         hasContent: true,
-        pages: [{ url: "https://supabase.com/docs/guides/auth" }],
+        pages: [{ url: "https://supabase.com/changelog.md" }],
       },
     ]);
+  });
+
+  it("falls back to the url as the query when a WebFetch call has no prompt arg", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "WebFetch",
+        { url: "https://supabase.com/docs/guides/auth" },
+        { url: "https://supabase.com/docs/guides/auth", name: "web_fetch" },
+      ),
+    ]);
+
+    expect(result.calls[0].query).toBe("https://supabase.com/docs/guides/auth");
   });
 
   it("ignores a fetch call on a non-Supabase domain", () => {
@@ -215,6 +230,7 @@ describe("buildDocsResult", () => {
             title: "Row Level Security | Supabase Docs",
           },
         ],
+        resultChars: expect.any(Number),
       },
     ]);
   });
@@ -295,5 +311,78 @@ describe("buildDocsResult", () => {
     expect(result.calls).toHaveLength(2);
     expect(result.calls[0].pages[0].url).toBe("https://supabase.com/docs/guides/auth");
     expect(result.calls[1].pages[0].url).toBe("https://supabase.com/docs/guides/auth");
+  });
+
+  it("recovers resultChars from an exact-count truncation stub", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "rls") { nodes { href } } }' },
+        {
+          result:
+            "Error: result (65,754 characters across 1 line) exceeds maximum allowed tokens. " +
+            "Output has been saved to /home/node/.claude/projects/x/tool-results/y.txt.\nFormat: Plain text",
+        },
+      ),
+    ]);
+
+    expect(result.calls[0].resultChars).toBe(65754);
+  });
+
+  it("recovers resultChars from a KB-sized truncation stub", () => {
+    const result = buildDocsResult([
+      toolCall(
+        "search_docs",
+        { graphql_query: '{ searchDocs(query: "rls") { nodes { href } } }' },
+        {
+          result:
+            "<persisted-output>\nOutput too large (50.8KB). Full output saved to: " +
+            "/home/node/.claude/projects/x/tool-results/y.json\n\nPreview (first 2KB):\n[...",
+        },
+      ),
+    ]);
+
+    expect(result.calls[0].resultChars).toBe(Math.round(50.8 * 1024));
+  });
+});
+
+describe("rehydrateTruncatedDocsResults", () => {
+  it("replaces a truncated search_docs result with the file's real content, read before the sandbox is disposed", async () => {
+    const path = "/home/node/.claude/projects/x/tool-results/y.txt";
+    const realContent = JSON.stringify({ searchDocs: { nodes: [{ href: "https://supabase.com/docs/guides/auth" }] } });
+    const readFile = vi.fn().mockResolvedValue(realContent);
+
+    const call = toolCall(
+      "search_docs",
+      { graphql_query: '{ searchDocs(query: "rls") { nodes { href } } }' },
+      { result: `Error: result exceeds maximum allowed tokens. Output has been saved to ${path}.` },
+    );
+
+    await rehydrateTruncatedDocsResults({ readFile }, [call]);
+
+    expect(readFile).toHaveBeenCalledWith(path);
+    expect(call.result).toBe(realContent);
+  });
+
+  it("leaves the stub in place when the file can't be read", async () => {
+    const stub = "Error: result exceeds maximum allowed tokens. Output has been saved to /gone.txt.";
+    const call = toolCall("search_docs", {}, { result: stub });
+    const readFile = vi.fn().mockRejectedValue(new Error("no such file"));
+
+    await rehydrateTruncatedDocsResults({ readFile }, [call]);
+
+    expect(call.result).toBe(stub);
+  });
+
+  it("ignores calls that aren't truncated, and calls outside the docs channels", async () => {
+    const readFile = vi.fn();
+    const calls = [
+      toolCall("search_docs", {}, { result: { ok: true } }),
+      toolCall("Bash", {}, { result: "Output has been saved to /some/other/tool/output.txt." }),
+    ];
+
+    await rehydrateTruncatedDocsResults({ readFile }, calls);
+
+    expect(readFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/docs-results.ts
+++ b/packages/core/src/docs-results.ts
@@ -7,30 +7,22 @@ export interface DocsResultSandbox {
 }
 
 const URL_PATTERN = /^https?:\/\//i;
-// Claude Code persists a tool result to disk and hands back a short stub
-// instead, in one of two observed shapes:
+// Claude Code persists truncated results to disk, two observed stub shapes:
 //   "Error: result (65,754 characters across 1 line) exceeds maximum
-//   allowed tokens. Output has been saved to /path/to/file.txt.\n..."
+//   allowed tokens. Output has been saved to /path/to/file.txt."
 //   "<persisted-output>\nOutput too large (50.8KB). Full output saved
-//   to: /path/to/file.json\n\nPreview (first 2KB):\n..."
-// Both name the file's absolute in-container path, and it's still readable
-// as long as the sandbox hasn't been disposed yet.
+//   to: /path/to/file.json"
+// Both name the in-container path, readable until the sandbox disposes.
 const TRUNCATION_PATH_PATTERN = /(?:Output has been saved to|Full output saved to:)\s*(\S+)/;
 const TRUNCATION_EXACT_SIZE_PATTERN = /\(([\d,]+) characters/;
 const TRUNCATION_APPROX_SIZE_PATTERN = /Output too large \(([\d.]+)\s*(K|M)?B\)/i;
-// search_docs and Claude Code's WebSearch both return matches as
-// `{"title":"...","href|url":"..."}` pairs, title first, in that adjacency
-// (confirmed against a real search_docs response and a real WebSearch
-// transcript). Falls back to a bare href/url match when no adjacent title
-// survived (e.g. the agent's own query never selected `title`).
+// search_docs and Claude Code's WebSearch return matches as
+// `{"title":"...","href|url":"..."}`, title first. Falls back to a bare
+// href/url match when the query never selected `title`.
 const TITLED_PAGE_PATTERN = /"title":"([^"]*)"\s*,?\s*"(?:href|url)":"([^"]+)"/g;
 const HREF_PATTERN = /"(?:href|url)":"([^"]+)"/g;
 
-/**
- * The search_docs query arg, wherever the harness put it: flat on `body`
- * (ai-sdk, Claude Code) or nested under `body.arguments` (Codex reports the
- * whole raw MCP call record as `body`, args and all).
- */
+/** The search_docs query arg, flat on `body` or nested under `body.arguments` (Codex's shape). */
 function extractGraphqlQuery(body: Record<string, unknown>): string | undefined {
   if (typeof body.graphql_query === "string") return body.graphql_query;
   const args = body.arguments;
@@ -55,9 +47,8 @@ function isSupabaseUrl(value: string): boolean {
 function extractTruncatedResultPath(result: unknown): string | undefined {
   if (typeof result !== "string") return undefined;
   const match = result.match(TRUNCATION_PATH_PATTERN);
-  // Sentence punctuation sometimes lands right after the path with no
-  // separating space ("...file.txt.\nFormat: ..."); a real path never ends
-  // in a bare ".", so stripping trailing dots is always safe.
+  // Trailing punctuation sometimes glues onto the path ("file.txt.\nFormat:
+  // ..."); a real path never ends in ".", so stripping it is always safe.
   return match?.[1].replace(/\.+$/, "");
 }
 
@@ -86,14 +77,7 @@ function isDocsRelatedCall(call: ToolCallRecord): boolean {
   return call.endpoint.endsWith("search_docs") || call.name === "web_fetch" || call.name === "web_search";
 }
 
-/**
- * Fetches the real content back for any docs-related call the CLI truncated
- * and persisted to disk, replacing the stub in place. Must run before the
- * sandbox that produced the transcript is disposed, the file lives inside
- * that container and won't be reachable afterward. A read failure (file
- * already cleaned up, path parsed wrong) leaves the stub as-is; buildDocsResult
- * already treats an unresolvable result as an omission, not a fabrication.
- */
+/** Fetches a truncated docs call's real result back from disk. Must run before the sandbox disposes, the file lives inside that container. */
 export async function rehydrateTruncatedDocsResults(
   sandbox: DocsResultSandbox,
   toolCalls: ToolCallRecord[],
@@ -104,18 +88,11 @@ export async function rehydrateTruncatedDocsResults(
     if (!path) continue;
     try {
       call.result = await sandbox.readFile(path);
-    } catch {
-      // Leave the stub in place.
-    }
+    } catch {}
   }
 }
 
-/**
- * Whether a search_docs GraphQL query's field selection (not any quoted
- * search-term string it carries) asks for `content`. Checked against the
- * query text itself rather than the result, so it still works when the
- * result got truncated before a page's content could be recovered.
- */
+/** Whether a search_docs query's field selection asks for `content`, checked against the query text so it survives truncation. */
 function queryRequestsContent(graphqlQuery: string): boolean {
   return /\bcontent\b/.test(graphqlQuery.replace(/"[^"]*"/g, ""));
 }
@@ -123,10 +100,9 @@ function queryRequestsContent(graphqlQuery: string): boolean {
 /** Extracts `{url, title}` pairs from a tool result, however much of it survived truncation. */
 function extractPages(result: unknown): DocsCallPage[] {
   const raw = typeof result === "string" ? result : JSON.stringify(result ?? "");
-  // Some harnesses wrap the GraphQL response in a content-array whose `text`
-  // field is itself a JSON string (e.g. `[{"type":"text","text":"{\"href\":...}"}]`),
-  // so stringifying the outer value double-escapes the inner quotes. Unescape
-  // once so `\"href\":\"` still matches like plain `"href":"`.
+  // Some harnesses wrap the response in a content-array whose `text` is
+  // itself a JSON string, double-escaping inner quotes when stringified.
+  // Unescape once so `\"href\":\"` still matches plain `"href":"`.
   const text = raw.replace(/\\"/g, '"');
 
   const pages: DocsCallPage[] = [];
@@ -144,15 +120,7 @@ function extractPages(result: unknown): DocsCallPage[] {
   return pages;
 }
 
-/**
- * Builds the persisted docs activation summary for one eval run: one entry
- * per docs-related tool call (not per page), in the order the agent actually
- * made them. `search_docs` is matched by raw endpoint suffix (MCP namespacing
- * like `mcp__supabase-mcp__search_docs` isn't part of any canonical
- * vocabulary); the web channel matches on the harness's own normalized
- * `call.name`, so Claude Code's `WebSearch` and Codex's `web_search` share
- * one branch.
- */
+/** Builds the persisted docs activation summary for one eval run, one entry per docs-related tool call in the order they happened. */
 export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
   const calls: DocsCall[] = [];
 
@@ -174,12 +142,9 @@ export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
 
     if (call.name === "web_fetch") {
       if (!call.url || !isSupabaseUrl(call.url)) continue;
-      // WebFetch doesn't hand back the raw page: it runs the fetch through
-      // an extraction step guided by `prompt` and returns that. Two calls to
-      // the identical url can return very different amounts of text
-      // depending only on this, so it's the meaningful "what did the agent
-      // ask for" here, same role `query` plays for search_docs. The target
-      // url is still recorded, just in `pages` rather than the summary line.
+      // WebFetch runs the fetch through an LLM extraction step guided by
+      // `prompt`, so that's the meaningful "ask" here (same role `query`
+      // plays for search_docs), not the url. Url still recorded, in `pages`.
       const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
       calls.push({
         source: "web_fetch",
@@ -195,10 +160,8 @@ export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
       const query = typeof body.query === "string" ? body.query : undefined;
       if (!query) continue;
 
-      // Codex's web_search doubles as a fetch: when the model passes a URL
-      // as the query, it's a page visit, not a search term. No result
-      // payload is ever exposed on this tool (confirmed empirically), so
-      // whether content came back is genuinely unknown, not false.
+      // Codex's web_search doubles as a fetch when the query is a URL. No
+      // result payload is ever exposed on this tool, so content is unknown, not false.
       if (URL_PATTERN.test(query)) {
         if (!isSupabaseUrl(query)) continue;
         calls.push({ source: "web_search", query, pages: [{ url: query }], resultChars: resultCharCount(result) });

--- a/packages/core/src/docs-results.ts
+++ b/packages/core/src/docs-results.ts
@@ -1,7 +1,23 @@
 import type { DocsCall, DocsCallPage, DocsResult } from "./eval-metadata.js";
 import type { ToolCallRecord } from "./index.js";
 
+/** The subset of AgentSandbox rehydration needs; avoids a hard dependency on its full interface. */
+export interface DocsResultSandbox {
+  readFile(path: string): Promise<string>;
+}
+
 const URL_PATTERN = /^https?:\/\//i;
+// Claude Code persists a tool result to disk and hands back a short stub
+// instead, in one of two observed shapes:
+//   "Error: result (65,754 characters across 1 line) exceeds maximum
+//   allowed tokens. Output has been saved to /path/to/file.txt.\n..."
+//   "<persisted-output>\nOutput too large (50.8KB). Full output saved
+//   to: /path/to/file.json\n\nPreview (first 2KB):\n..."
+// Both name the file's absolute in-container path, and it's still readable
+// as long as the sandbox hasn't been disposed yet.
+const TRUNCATION_PATH_PATTERN = /(?:Output has been saved to|Full output saved to:)\s*(\S+)/;
+const TRUNCATION_EXACT_SIZE_PATTERN = /\(([\d,]+) characters/;
+const TRUNCATION_APPROX_SIZE_PATTERN = /Output too large \(([\d.]+)\s*(K|M)?B\)/i;
 // search_docs and Claude Code's WebSearch both return matches as
 // `{"title":"...","href|url":"..."}` pairs, title first, in that adjacency
 // (confirmed against a real search_docs response and a real WebSearch
@@ -32,6 +48,65 @@ function isSupabaseUrl(value: string): boolean {
     return hostname === "supabase.com" || hostname.endsWith(".supabase.com");
   } catch {
     return false;
+  }
+}
+
+/** The in-container path a truncated result was persisted to, if `result` is one of the known stub shapes. */
+function extractTruncatedResultPath(result: unknown): string | undefined {
+  if (typeof result !== "string") return undefined;
+  const match = result.match(TRUNCATION_PATH_PATTERN);
+  // Sentence punctuation sometimes lands right after the path with no
+  // separating space ("...file.txt.\nFormat: ..."); a real path never ends
+  // in a bare ".", so stripping trailing dots is always safe.
+  return match?.[1].replace(/\.+$/, "");
+}
+
+/** Best-effort size (in characters) a truncation stub reports about the result it's standing in for. */
+function extractTruncatedResultCharCount(result: string): number | undefined {
+  const exact = result.match(TRUNCATION_EXACT_SIZE_PATTERN);
+  if (exact) return Number(exact[1].replace(/,/g, ""));
+  const approx = result.match(TRUNCATION_APPROX_SIZE_PATTERN);
+  if (!approx) return undefined;
+  const unit = approx[2]?.toUpperCase();
+  const multiplier = unit === "M" ? 1024 * 1024 : unit === "K" ? 1024 : 1;
+  return Math.round(Number(approx[1]) * multiplier);
+}
+
+/** Approximate size of a tool result, in characters, favoring a truncation stub's own reported size when present. */
+function resultCharCount(result: unknown): number | undefined {
+  if (typeof result !== "string") {
+    if (result === undefined) return undefined;
+    return JSON.stringify(result).length;
+  }
+  return extractTruncatedResultCharCount(result) ?? result.length;
+}
+
+/** True when a tool call is one of the channels docs activation tracks (worth rehydrating if truncated). */
+function isDocsRelatedCall(call: ToolCallRecord): boolean {
+  return call.endpoint.endsWith("search_docs") || call.name === "web_fetch" || call.name === "web_search";
+}
+
+/**
+ * Fetches the real content back for any docs-related call the CLI truncated
+ * and persisted to disk, replacing the stub in place. Must run before the
+ * sandbox that produced the transcript is disposed, the file lives inside
+ * that container and won't be reachable afterward. A read failure (file
+ * already cleaned up, path parsed wrong) leaves the stub as-is; buildDocsResult
+ * already treats an unresolvable result as an omission, not a fabrication.
+ */
+export async function rehydrateTruncatedDocsResults(
+  sandbox: DocsResultSandbox,
+  toolCalls: ToolCallRecord[],
+): Promise<void> {
+  for (const call of toolCalls) {
+    if (!isDocsRelatedCall(call)) continue;
+    const path = extractTruncatedResultPath(call.result);
+    if (!path) continue;
+    try {
+      call.result = await sandbox.readFile(path);
+    } catch {
+      // Leave the stub in place.
+    }
   }
 }
 
@@ -92,13 +167,27 @@ export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
         query: graphqlQuery,
         hasContent: queryRequestsContent(graphqlQuery),
         pages: extractPages(result),
+        resultChars: resultCharCount(result),
       });
       continue;
     }
 
     if (call.name === "web_fetch") {
       if (!call.url || !isSupabaseUrl(call.url)) continue;
-      calls.push({ source: "web_fetch", query: call.url, hasContent: true, pages: [{ url: call.url }] });
+      // WebFetch doesn't hand back the raw page: it runs the fetch through
+      // an extraction step guided by `prompt` and returns that. Two calls to
+      // the identical url can return very different amounts of text
+      // depending only on this, so it's the meaningful "what did the agent
+      // ask for" here, same role `query` plays for search_docs. The target
+      // url is still recorded, just in `pages` rather than the summary line.
+      const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
+      calls.push({
+        source: "web_fetch",
+        query: prompt ?? call.url,
+        hasContent: true,
+        pages: [{ url: call.url }],
+        resultChars: resultCharCount(result),
+      });
       continue;
     }
 
@@ -112,7 +201,7 @@ export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
       // whether content came back is genuinely unknown, not false.
       if (URL_PATTERN.test(query)) {
         if (!isSupabaseUrl(query)) continue;
-        calls.push({ source: "web_search", query, pages: [{ url: query }] });
+        calls.push({ source: "web_search", query, pages: [{ url: query }], resultChars: resultCharCount(result) });
         continue;
       }
 
@@ -120,7 +209,13 @@ export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
       const pages = extractPages(result);
       // Claude Code's WebSearch result never carries page text, only
       // title/url per hit, so any pages found here are hits, not reads.
-      calls.push({ source: "web_search", query, hasContent: pages.length > 0 ? false : undefined, pages });
+      calls.push({
+        source: "web_search",
+        query,
+        hasContent: pages.length > 0 ? false : undefined,
+        pages,
+        resultChars: resultCharCount(result),
+      });
       continue;
     }
   }

--- a/packages/core/src/docs-results.ts
+++ b/packages/core/src/docs-results.ts
@@ -1,0 +1,129 @@
+import type { DocsCall, DocsCallPage, DocsResult } from "./eval-metadata.js";
+import type { ToolCallRecord } from "./index.js";
+
+const URL_PATTERN = /^https?:\/\//i;
+// search_docs and Claude Code's WebSearch both return matches as
+// `{"title":"...","href|url":"..."}` pairs, title first, in that adjacency
+// (confirmed against a real search_docs response and a real WebSearch
+// transcript). Falls back to a bare href/url match when no adjacent title
+// survived (e.g. the agent's own query never selected `title`).
+const TITLED_PAGE_PATTERN = /"title":"([^"]*)"\s*,?\s*"(?:href|url)":"([^"]+)"/g;
+const HREF_PATTERN = /"(?:href|url)":"([^"]+)"/g;
+
+/**
+ * The search_docs query arg, wherever the harness put it: flat on `body`
+ * (ai-sdk, Claude Code) or nested under `body.arguments` (Codex reports the
+ * whole raw MCP call record as `body`, args and all).
+ */
+function extractGraphqlQuery(body: Record<string, unknown>): string | undefined {
+  if (typeof body.graphql_query === "string") return body.graphql_query;
+  const args = body.arguments;
+  if (args && typeof args === "object" && "graphql_query" in args) {
+    const value = (args as Record<string, unknown>).graphql_query;
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+/** True when a URL string points at any supabase.com host. */
+function isSupabaseUrl(value: string): boolean {
+  try {
+    const { hostname } = new URL(value);
+    return hostname === "supabase.com" || hostname.endsWith(".supabase.com");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether a search_docs GraphQL query's field selection (not any quoted
+ * search-term string it carries) asks for `content`. Checked against the
+ * query text itself rather than the result, so it still works when the
+ * result got truncated before a page's content could be recovered.
+ */
+function queryRequestsContent(graphqlQuery: string): boolean {
+  return /\bcontent\b/.test(graphqlQuery.replace(/"[^"]*"/g, ""));
+}
+
+/** Extracts `{url, title}` pairs from a tool result, however much of it survived truncation. */
+function extractPages(result: unknown): DocsCallPage[] {
+  const raw = typeof result === "string" ? result : JSON.stringify(result ?? "");
+  // Some harnesses wrap the GraphQL response in a content-array whose `text`
+  // field is itself a JSON string (e.g. `[{"type":"text","text":"{\"href\":...}"}]`),
+  // so stringifying the outer value double-escapes the inner quotes. Unescape
+  // once so `\"href\":\"` still matches like plain `"href":"`.
+  const text = raw.replace(/\\"/g, '"');
+
+  const pages: DocsCallPage[] = [];
+  const seen = new Set<string>();
+  for (const [, title, url] of text.matchAll(TITLED_PAGE_PATTERN)) {
+    if (!isSupabaseUrl(url) || seen.has(url)) continue;
+    seen.add(url);
+    pages.push(title ? { url, title } : { url });
+  }
+  for (const [, url] of text.matchAll(HREF_PATTERN)) {
+    if (!isSupabaseUrl(url) || seen.has(url)) continue;
+    seen.add(url);
+    pages.push({ url });
+  }
+  return pages;
+}
+
+/**
+ * Builds the persisted docs activation summary for one eval run: one entry
+ * per docs-related tool call (not per page), in the order the agent actually
+ * made them. `search_docs` is matched by raw endpoint suffix (MCP namespacing
+ * like `mcp__supabase-mcp__search_docs` isn't part of any canonical
+ * vocabulary); the web channel matches on the harness's own normalized
+ * `call.name`, so Claude Code's `WebSearch` and Codex's `web_search` share
+ * one branch.
+ */
+export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
+  const calls: DocsCall[] = [];
+
+  for (const call of toolCalls) {
+    const { endpoint, body, result } = call;
+
+    if (endpoint.endsWith("search_docs")) {
+      const graphqlQuery = extractGraphqlQuery(body);
+      if (!graphqlQuery) continue;
+      calls.push({
+        source: "search_docs",
+        query: graphqlQuery,
+        hasContent: queryRequestsContent(graphqlQuery),
+        pages: extractPages(result),
+      });
+      continue;
+    }
+
+    if (call.name === "web_fetch") {
+      if (!call.url || !isSupabaseUrl(call.url)) continue;
+      calls.push({ source: "web_fetch", query: call.url, hasContent: true, pages: [{ url: call.url }] });
+      continue;
+    }
+
+    if (call.name === "web_search") {
+      const query = typeof body.query === "string" ? body.query : undefined;
+      if (!query) continue;
+
+      // Codex's web_search doubles as a fetch: when the model passes a URL
+      // as the query, it's a page visit, not a search term. No result
+      // payload is ever exposed on this tool (confirmed empirically), so
+      // whether content came back is genuinely unknown, not false.
+      if (URL_PATTERN.test(query)) {
+        if (!isSupabaseUrl(query)) continue;
+        calls.push({ source: "web_search", query, pages: [{ url: query }] });
+        continue;
+      }
+
+      if (!/supabase/i.test(query)) continue;
+      const pages = extractPages(result);
+      // Claude Code's WebSearch result never carries page text, only
+      // title/url per hit, so any pages found here are hits, not reads.
+      calls.push({ source: "web_search", query, hasContent: pages.length > 0 ? false : undefined, pages });
+      continue;
+    }
+  }
+
+  return { calls };
+}

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -229,6 +229,48 @@ export const skillResultSchema = z.object({
 });
 export type SkillResult = z.infer<typeof skillResultSchema>;
 
+// The tool that made a docs call. `search_docs` is matched by raw MCP
+// endpoint suffix (MCP tool identity isn't part of the harness's canonical
+// tool vocabulary). `web_fetch`/`web_search` are the harness's own normalized
+// name, so Claude Code's `WebSearch` and Codex's `web_search` (the same
+// action, spelled differently per harness) collapse into one value here.
+export const docsPageSourceSchema = z.enum(["search_docs", "web_fetch", "web_search"]);
+export type DocsPageSource = z.infer<typeof docsPageSourceSchema>;
+
+const docsCallPageSchema = z.object({
+  url: z.string(),
+  // Only present when the call's own data included it (search_docs and
+  // Claude Code's WebSearch return title alongside the url; a direct fetch or
+  // a Codex web_search used as a fetch don't).
+  title: z.string().optional(),
+});
+export type DocsCallPage = z.infer<typeof docsCallPageSchema>;
+
+// One tool call an agent made toward the docs: what it asked for (`query`,
+// the actual search term / GraphQL query / target URL, whichever applies)
+// and what came back (`pages`). This is the real unit of "an agent checking
+// docs", not an individual page, matching how the agent itself acts: it
+// issues one call and gets a batch of results back together.
+export const docsCallSchema = z.object({
+  source: docsPageSourceSchema,
+  query: z.string(),
+  // Whether the call's results included page text, not just a title/url hit.
+  // Known for search_docs (whether the agent's own GraphQL selection asked
+  // for `content`) and web_fetch (always true, that's what fetching is).
+  // False for Claude Code's WebSearch (its results never include page text,
+  // only title/url). Unknown (omitted) for a Codex web_search used as a
+  // fetch: no result payload is ever exposed on that tool.
+  hasContent: z.boolean().optional(),
+  pages: z.array(docsCallPageSchema),
+});
+export type DocsCall = z.infer<typeof docsCallSchema>;
+
+export const docsResultSchema = z.object({
+  // Every docs-related tool call, in the order the agent actually made them.
+  calls: z.array(docsCallSchema),
+});
+export type DocsResult = z.infer<typeof docsResultSchema>;
+
 // Every dimension that has an authoring enum is enforced against that same
 // enum here — the enum is the single source of truth for both authoring
 // (evalMetadataSchema) and results. Result files are gitignored, regenerated
@@ -251,6 +293,7 @@ const evalResultShape = {
   checks: z.array(checkResultSchema).optional(),
   attempts: z.number().optional(),
   skills: skillResultSchema.optional(),
+  docs: docsResultSchema.optional(),
 };
 
 // Raw result files may carry extra fields we don't model; tolerate them.

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -246,14 +246,9 @@ const docsCallPageSchema = z.object({
 });
 export type DocsCallPage = z.infer<typeof docsCallPageSchema>;
 
-// One tool call an agent made toward the docs: what it asked for (`query`,
-// the search term / GraphQL query / WebFetch's extraction prompt / target
-// URL, whichever is the meaningful "ask" for that source) and what came back
-// (`pages`). This is the real unit of "an agent checking docs", not an
-// individual page, matching how the agent itself acts: it issues one call
-// and gets a batch of results back together.
 export const docsCallSchema = z.object({
   source: docsPageSourceSchema,
+  // Whichever field is the meaningful "ask" for that source: search term, GraphQL query, WebFetch's extraction prompt, or target URL.
   query: z.string(),
   // Whether the call's results included page text, not just a title/url hit.
   // Known for search_docs (whether the agent's own GraphQL selection asked

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -247,10 +247,11 @@ const docsCallPageSchema = z.object({
 export type DocsCallPage = z.infer<typeof docsCallPageSchema>;
 
 // One tool call an agent made toward the docs: what it asked for (`query`,
-// the actual search term / GraphQL query / target URL, whichever applies)
-// and what came back (`pages`). This is the real unit of "an agent checking
-// docs", not an individual page, matching how the agent itself acts: it
-// issues one call and gets a batch of results back together.
+// the search term / GraphQL query / WebFetch's extraction prompt / target
+// URL, whichever is the meaningful "ask" for that source) and what came back
+// (`pages`). This is the real unit of "an agent checking docs", not an
+// individual page, matching how the agent itself acts: it issues one call
+// and gets a batch of results back together.
 export const docsCallSchema = z.object({
   source: docsPageSourceSchema,
   query: z.string(),
@@ -262,6 +263,14 @@ export const docsCallSchema = z.object({
   // fetch: no result payload is ever exposed on that tool.
   hasContent: z.boolean().optional(),
   pages: z.array(docsCallPageSchema),
+  // Size of the result the call actually produced, in characters, an
+  // approximation of how much text this call pulled into the agent's
+  // context (divide by ~4 for a rough token estimate). Recovered from the
+  // rehydrated file when the CLI truncated the result, or parsed out of the
+  // truncation message's own reported size when rehydration wasn't
+  // possible or wasn't attempted (e.g. no sandbox, ai-sdk/Codex which don't
+  // truncate this way). Omitted only when there's no result at all.
+  resultChars: z.number().optional(),
 });
 export type DocsCall = z.infer<typeof docsCallSchema>;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -186,12 +186,7 @@ export interface ToolCallRecord {
   path?: string;
   command?: string;
   url?: string;
-  /**
-   * Canonical tool category (e.g. `web_search` for both Claude Code's
-   * `WebSearch` and Codex's `web_search`), when the harness's parser
-   * normalized one. CLI agents always set this; ai-sdk tools keep their own
-   * name in `endpoint` with no normalization layer, so this stays unset.
-   */
+  /** Canonical tool category, set by CLI agent parsers; unset for ai-sdk tools which have no normalization layer. */
   name?: ToolName;
   /** Skill name loaded by this call, when the harness can identify one. */
   loadedSkill?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import type { ToolName } from "./transcript/types.js";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport as StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
@@ -87,9 +88,13 @@ export {
   rawEvalResultSchema,
   reasoningEffortSchema,
   skillResultSchema,
+  docsResultSchema,
+  docsCallSchema,
+  docsPageSourceSchema,
 } from "./eval-metadata.js";
 export { parseEvalMarkdown } from "./eval-markdown.js";
 export { buildSkillResult } from "./skill-results.js";
+export { buildDocsResult } from "./docs-results.js";
 // CLI agent harnesses (Claude Code, Codex, and the framework for adding more).
 export { createCliAgent } from "./agents/engine.js";
 export { claudeCodeAgent } from "./agents/claude-code/index.js";
@@ -127,6 +132,10 @@ export type {
   ParsedEvalMarkdown,
   ReasoningEffortLevel,
   SkillResult,
+  DocsResult,
+  DocsCall,
+  DocsCallPage,
+  DocsPageSource,
 } from "./eval-metadata.js";
 
 export interface ScoreResult {
@@ -176,6 +185,13 @@ export interface ToolCallRecord {
   path?: string;
   command?: string;
   url?: string;
+  /**
+   * Canonical tool category (e.g. `web_search` for both Claude Code's
+   * `WebSearch` and Codex's `web_search`), when the harness's parser
+   * normalized one. CLI agents always set this; ai-sdk tools keep their own
+   * name in `endpoint` with no normalization layer, so this stays unset.
+   */
+  name?: ToolName;
   /** Skill name loaded by this call, when the harness can identify one. */
   loadedSkill?: string;
   result?: unknown;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,7 +94,8 @@ export {
 } from "./eval-metadata.js";
 export { parseEvalMarkdown } from "./eval-markdown.js";
 export { buildSkillResult } from "./skill-results.js";
-export { buildDocsResult } from "./docs-results.js";
+export { buildDocsResult, rehydrateTruncatedDocsResults } from "./docs-results.js";
+export type { DocsResultSandbox } from "./docs-results.js";
 // CLI agent harnesses (Claude Code, Codex, and the framework for adding more).
 export { createCliAgent } from "./agents/engine.js";
 export { claudeCodeAgent } from "./agents/claude-code/index.js";

--- a/packages/core/src/parsers/adapt.ts
+++ b/packages/core/src/parsers/adapt.ts
@@ -62,6 +62,7 @@ export function adaptTranscript(events: TranscriptEvent[]): AdaptedTranscript {
         endpoint: event.tool.originalName,
         body,
         // Normalized views the parser extracted, for agent-agnostic scorers.
+        name: event.tool.name,
         path: event.tool.path,
         command: event.tool.command,
         url: event.tool.url,


### PR DESCRIPTION
Tracks which Supabase docs agents saw or visited during a run. This includes MCP `search_docs` usage as well as native harness tools like Claude's `WebFetch`/`WebSearch` or Codex's `web_search`.

These tools typically use a combination of some query mechanism, which may produce several matching pages. For MCP it might include only page titles/URLs or it may query the full `content` of each page. Note Claude's "WebFetch" is not purely a fetch, but also uses an LLM extraction step before returning context, so there is a `prompt` argument to track there.

This PR attempts to track + visualize all that in a new "Docs activity" UI section of results. Each search invocation appears in chronological order as a collapsible section, beneath which you can see individual pages that were witnessed or fully read by the agent. An approximate token count is included using a `chars / 4` [heuristic](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them).

Since Claude may truncate large tool outputs, this also rehydrates truncated results before the sandbox is disposed to retrieve the otherwise lost tool data.

<img width="609" height="488" alt="image" src="https://github.com/user-attachments/assets/0768f351-eb41-4f7f-871d-84299151da15" />

Note we'll need to re-run all evals to get docs results populated, for this PR I've refreshed only a single run. You can see it in action in the [vercel preview](https://evals-git-mattrossman-ai-901-docs-activation-in-014d68-supabase.vercel.app/) under the Sonnet 5 run of `deploy-self-hosting-001-docker-compose`.

Also fixes `eval-refresh.yml`: `actions/download-artifact` was silently dumping a single matched artifact's contents flat instead of nesting it under a named directory, breaking the per-experiment glob downstream, so the download step now names each artifact's destination directory explicitly.

Closes AI-901
