### PR TITLE
fix: `deploy-database-001-prometheus-metrics` file and MCP visibility

### DIFF
--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -820,12 +820,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape uses placeholder YOUR_PROJECT_REF rather than a real project ref, so it is not deployable as-is. Other required elements are present."
+        "judgeNotes": "Supabase scrape uses HTTPS, the correct metrics_path, Basic Auth with password_file, preserves the app job, and mounts the secrets directory. However, the target is still the placeholder `<PROJECT_REF>.supabase.co:443`, not a real project ref, so it is not deployable as-is."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes steps to set project ref, create a Supabase Secret API key, write it to the mounted secret file, start/reload the Compose stack, and verify via curl plus Prometheus targets."
+        "judgeNotes": "README includes live setup steps: create Supabase Secret API key, place it in the matching mounted secret file, replace project ref, and restart or hot-reload the Compose stack. It also provides concrete verification via curl plus Prometheus targets and PromQL up{job=\"supabase\"}. Auth endpoint and secret handling match the config, with no hardcoded secret."
       }
     ],
     "skills": {
@@ -841,16 +841,12 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"Prometheus metrics endpoint monitoring project\", limit: 6) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"Prometheus metrics endpoint observability project metrics\", limit: 6) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
-              "title": "Manual replication monitoring"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
@@ -863,9 +859,28 @@
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas",
+              "title": "Read Replicas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
             }
           ],
-          "resultChars": 27147
+          "resultChars": 33507
+        },
+        {
+          "source": "web_fetch",
+          "query": "What is the exact metrics endpoint URL, the authentication method (username/password), and how to configure Prometheus to scrape it? Include any scrape_config YAML example, basic_auth details, tls/scheme settings, and metric_relabel or honor_labels notes.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics.md"
+            }
+          ],
+          "resultChars": 1170
         }
       ]
     },
@@ -2188,12 +2203,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape uses the literal placeholder `<project-ref>.supabase.co:443` and label `<project-ref>`, so it is not deployable and does not resolve to a real project ref. Other wiring is present: HTTPS, correct metrics path, basic_auth with password_file, app job preserved, and docker-compose mounts the secrets directory."
+        "judgeNotes": "Supabase scrape is wired with HTTPS, correct metrics_path, basic_auth password_file, mounted secrets volume, and app job preserved, but the target uses placeholder REPLACE_WITH_PROJECT_REF.supabase.co rather than a real project ref, so it is not deployable as-is."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes required live setup: replace project ref, create Supabase Secret API key, place it in the mounted password_file path, and restart/reload the Compose/Prometheus stack. It also provides concrete verification via curl and Prometheus targets, plus Grafana dashboard import."
+        "judgeNotes": "README includes steps to set project ref, create/copy Secret API key, write it to the mounted secrets/supabase_metrics_key file, reload/restart the Compose stack, and verify via promtool, direct curl smoke test, and Prometheus targets."
       }
     ],
     "skills": {
@@ -2204,35 +2219,31 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"prometheus metrics endpoint project monitoring\", limit: 6) { nodes { title href content } } }",
+          "query": "{\n  searchDocs(query: \"Prometheus metrics endpoint observability\", limit: 5) {\n    nodes {\n      title\n      href\n      content\n    }\n  }\n}",
           "hasContent": true,
           "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
-              "title": "Manual replication monitoring"
-            },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
             },
             {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
               "url": "https://supabase.com/docs/guides/platform/read-replicas",
               "title": "Read Replicas"
             }
           ],
-          "resultChars": 36261
+          "resultChars": 32656
         }
       ]
     },
@@ -3682,12 +3693,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails because the Supabase scrape target is still the literal placeholder \"<project-ref>.supabase.co:443\" and does not resolve to a real project ref, so it is not deployable as required."
+        "judgeNotes": "Fails because the Supabase scrape target still uses the placeholder \"<project-ref>.supabase.co:443\" and label, so it is not deployable and does not resolve to a real project ref. HTTPS, metrics path, basic_auth password_file, app scrape preservation, and Compose secret wiring are otherwise present."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README.md does not itself explain the go-live steps. It lacks instructions to create the Supabase Secret API key, place it in observability/secrets/supabase_metrics_key, restart/reload the Compose stack, and verify the scrape via Prometheus targets/PromQL/Grafana. It only says the config needs a project ref and credential and links to another document."
+        "passed": true,
+        "judgeNotes": "README includes steps to create a Secret API key, place it in the configured Compose secret file, replace project placeholders, restart/recreate the Compose stack, and verify via Prometheus targets plus Grafana dashboards."
       }
     ],
     "skills": {
@@ -3728,34 +3739,6 @@
             }
           ],
           "resultChars": 27147
-        },
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"metrics customer privileged basic auth grafana\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/reports",
-              "title": "Reports"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
-              "title": "Envoy API Gateway"
-            }
-          ],
-          "resultChars": 73133
         }
       ]
     },
@@ -5028,12 +5011,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails because the Supabase scrape target uses the placeholder `<SUPABASE_PROJECT_REF>.supabase.co:443` rather than a real project ref, so it is not directly deployable. HTTPS, metrics path, basic_auth password_file, app job preservation, and Compose secret wiring are otherwise present."
+        "judgeNotes": "Supabase scrape uses placeholder target/label (`<project-ref>.supabase.co`) rather than a real project ref, so it is not deployable despite having HTTPS, correct metrics path, basic_auth password_file, app scrape preserved, and the secrets volume mounted."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": true,
-        "judgeNotes": "README includes concrete go-live steps: create Supabase Secret API key, populate the Docker secret file matching compose/password_file paths, replace project ref, restart or reload the Compose/Prometheus stack, and verify via Prometheus targets plus direct endpoint curl."
+        "passed": false,
+        "judgeNotes": "README.md does not include the required live setup steps: creating the Supabase Secret API key, placing the matching Prometheus secret file, restarting/reloading the Compose stack, and verifying via Prometheus targets/PromQL/Grafana. It only points to another document and leaves placeholders."
       }
     ],
     "skills": {
@@ -5044,24 +5027,24 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"prometheus metrics endpoint project\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"prometheus metrics endpoint project metrics\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
             },
             {
               "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
@@ -7882,12 +7865,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses inline basic_auth.password instead of password_file, docker-compose does not mount/provide that password file, and the target is still a placeholder rather than a real project ref. App scrape is preserved and endpoint/scheme are correct."
+        "judgeNotes": "Fails: Supabase scrape uses inline basic_auth password instead of password_file, docker-compose.yml does not mount any password_file/secret, and the target/project label still use placeholders rather than a real project ref. Existing app scrape is preserved and endpoint/scheme are correct."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README includes the correct Supabase metrics endpoint/auth, reload step, and Prometheus target verification, but it does not require placing the Secret API key in a matching secret file. It instructs users to put the key directly into prometheus.yml, so the required secret-file setup is missing/mismatched."
+        "judgeNotes": "README mentions the correct Supabase metrics endpoint/auth pattern and restarting/reloading Prometheus, but it does not require creating a Secret API key through Supabase, does not place a matching secret file or align with Compose secrets, and lacks concrete verification steps such as checking Prometheus targets, running PromQL, or confirming Grafana panels."
       }
     ],
     "skills": {
@@ -7902,232 +7885,27 @@
     "docs": {
       "calls": [
         {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"Supabase metrics Prometheus Grafana monitoring observability\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
-              "title": "What you can do with the Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
-              "title": "Additional resources"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
-              "title": "Choose your monitoring stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
-              "title": "4. Configure alerts (optional)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
-              "title": "Prerequisites"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#1-create-a-grafana-cloud-stack",
-              "title": "1. Create a Grafana Cloud stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#2-configure-the-supabase-integration",
-              "title": "2. Configure the Supabase integration"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#3-import-the-supabase-dashboard",
-              "title": "3. Import the Supabase dashboard"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
-              "title": "5. Troubleshooting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
-              "title": "1. Deploy Prometheus"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
-              "title": "Architecture"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#5-operating-tips",
-              "title": "5. Operating tips"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
-              "title": "4. Configure alerting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
-              "title": "3. Import Supabase dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#2-deploy-grafana",
-              "title": "2. Deploy Grafana"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management",
-              "title": "Connection management"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#capturing-historical-usage",
-              "title": "Capturing historical usage"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#monitoring-connections",
-              "title": "Monitoring connections"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#configuring-supavisors-pool-size",
-              "title": "Configuring Supavisor's pool size"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#connections",
-              "title": "Connections"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#observing-live-connections",
-              "title": "Observing live connections"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#grafana-dashboard",
-              "title": "Grafana Dashboard"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#dashboard-monitoring-charts",
-              "title": "Dashboard monitoring charts"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
-              "title": "How to View Database Metrics"
-            }
-          ],
-          "resultChars": 71826
+          "source": "web_search",
+          "query": "site:supabase.com/docs Supabase metrics Prometheus Grafana metrics export docs",
+          "pages": []
         },
         {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"metrics self-hosted Prometheus scrape interval basic auth supabase grafana self-hosted\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
-          "hasContent": true,
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
-              "title": "1. Deploy Prometheus"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
-              "title": "Architecture"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
-              "title": "3. Import Supabase dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
-              "title": "4. Configure alerting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#5-operating-tips",
-              "title": "5. Operating tips"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#2-deploy-grafana",
-              "title": "2. Deploy Grafana"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
-              "title": "4. Configure alerts (optional)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#3-import-the-supabase-dashboard",
-              "title": "3. Import the Supabase dashboard"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#2-configure-the-supabase-integration",
-              "title": "2. Configure the Supabase integration"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#1-create-a-grafana-cloud-stack",
-              "title": "1. Create a Grafana Cloud stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
-              "title": "Prerequisites"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
-              "title": "5. Troubleshooting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#3-downstream-dashboards",
-              "title": "3. Downstream dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#components",
-              "title": "Components"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#1-define-the-scrape-job",
-              "title": "1. Define the scrape job"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#collector-specific-notes",
-              "title": "Collector-specific notes"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#2-secure-the-credentials",
-              "title": "2. Secure the credentials"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#4-alerts-and-automation",
-              "title": "4. Alerts and automation"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#5-multi-project-setups",
-              "title": "5. Multi-project setups"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
-              "title": "Additional resources"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
-              "title": "Choose your monitoring stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
-              "title": "What you can do with the Metrics API"
+              "url": "https://supabase.com/changelog.md"
             }
-          ],
-          "resultChars": 93207
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md Supabase changelog md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md Supabase changelog md"
+            }
+          ]
         }
       ]
     },
@@ -11608,12 +11386,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails rubric: Supabase basic_auth uses `password` with an environment variable instead of required `password_file`, and docker-compose.yml does not mount that password file via a volume or Compose secret. The target is also parameterized rather than a concrete project ref."
+        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount the password file via a volume or Compose secret. The target is also templated rather than a concrete project ref."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README includes creating a Supabase Secret API key and restarting/reloading the stack, but it lacks concrete verification steps via Prometheus targets, PromQL, or Grafana. Secret placement is also vague and may not match the Compose setup."
+        "passed": true,
+        "judgeNotes": "README explains creating/copying a Supabase Secret API key, placing it via environment/.env next to the Compose file, restarting/reloading the stack, and verifying the scrape in Prometheus Targets. Endpoint and auth are concrete and no secret is hardcoded."
       }
     ],
     "skills": {
@@ -11624,16 +11402,16 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Prometheus metrics Supabase project metrics export\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on TroubleshootingGuide { title href content } ... on CLICommandReference { title href content } ... on ManagementApiReference { title href content } ... on ClientLibraryFunctionReference { title href content language methodName } } } }",
+          "query": "query { searchDocs(query: \"Supabase metrics Prometheus endpoint project metrics\", limit: 5) { edges { node { title href content } } totalCount } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
@@ -11642,9 +11420,46 @@
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas",
+              "title": "Read Replicas"
             }
           ],
-          "resultChars": 23680
+          "resultChars": 32766
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/docs/guides/telemetry/metrics Metrics API Supabase project ref service_role sb_secret_",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "Metrics API with Prometheus Grafana self-hosted Supabase",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com/docs/guides/telemetry/metrics service_role sb_secret Metrics API",
+          "pages": []
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/telemetry/metrics",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted"
+            }
+          ]
         }
       ]
     },
@@ -14069,12 +13884,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Meets requirements: app scrape preserved, Supabase HTTPS scrape uses /customer/v1/privileged/metrics with Basic Auth password_file, target is rendered to <project-ref>.supabase.co:443, and docker-compose mounts the password file as a Compose secret for Prometheus."
+        "judgeNotes": "Meets requirements: app scrape preserved; Supabase scrape uses HTTPS, correct metrics_path, Basic Auth with password_file, file_sd target generation for <project-ref>.supabase.co:443, and Compose mounts the matching secret for Prometheus."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes Secret API key creation, secret file placement, Compose deploy/redeploy, and concrete verification via direct curl, Prometheus targets API, and PromQL/Grafana."
+        "judgeNotes": "README includes steps to create/use a Supabase Secret API key, write it to the Compose secret file, start/recreate the Compose services after changes, and verify via Prometheus target health, PromQL, and curl. Endpoint/auth match the provided Prometheus config."
       }
     ],
     "skills": {
@@ -14082,13 +13897,15 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": []
+      "loaded": [
+        "supabase"
+      ]
     },
     "docs": {
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Supabase Prometheus metrics endpoint observability Grafana customer v1 privileged metrics authentication project ref service role\", limit: 8) { nodes { ... on Guide { title href content subsections { nodes { title href content } } } ... on TroubleshootingGuide { title href content } ... on CLICommandReference { title href content } } } }",
+          "query": "query { searchDocs(query: \"Supabase project metrics Prometheus endpoint observability Grafana authentication\", limit: 8) { nodes { __typename title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -14096,193 +13913,65 @@
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
-              "title": "Architecture"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
-              "title": "3. Import Supabase dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#2-deploy-grafana",
-              "title": "2. Deploy Grafana"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#5-operating-tips",
-              "title": "5. Operating tips"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
-              "title": "4. Configure alerting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
-              "title": "1. Deploy Prometheus"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#1-define-the-scrape-job",
-              "title": "1. Define the scrape job"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#collector-specific-notes",
-              "title": "Collector-specific notes"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#2-secure-the-credentials",
-              "title": "2. Secure the credentials"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#3-downstream-dashboards",
-              "title": "3. Downstream dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#4-alerts-and-automation",
-              "title": "4. Alerts and automation"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#5-multi-project-setups",
-              "title": "5. Multi-project setups"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#components",
-              "title": "Components"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
-              "title": "4. Configure alerts (optional)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
-              "title": "Prerequisites"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#1-create-a-grafana-cloud-stack",
-              "title": "1. Create a Grafana Cloud stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#2-configure-the-supabase-integration",
-              "title": "2. Configure the Supabase integration"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#3-import-the-supabase-dashboard",
-              "title": "3. Import the Supabase dashboard"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
-              "title": "5. Troubleshooting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
-              "title": "Additional resources"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
-              "title": "Choose your monitoring stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
-              "title": "What you can do with the Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas",
-              "title": "Read Replicas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#dedicated-connection-pool",
-              "title": "Dedicated connection pool"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#dedicated-endpoints",
-              "title": "Dedicated endpoints"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#features",
-              "title": "Features"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#about-read-replicas",
-              "title": "About Read Replicas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#pricing",
-              "title": "Pricing"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#centralized-configuration-management",
-              "title": "Centralized configuration management"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#metrics",
-              "title": "Metrics"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#logging",
-              "title": "Logging"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#querying-through-the-sql-editor",
-              "title": "Querying through the SQL editor"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#api-load-balancer",
-              "title": "API load balancer"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
             },
             {
               "url": "https://supabase.com/docs/guides/database/connection-management",
               "title": "Connection management"
             },
             {
-              "url": "https://supabase.com/docs/guides/database/connection-management#capturing-historical-usage",
-              "title": "Capturing historical usage"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#monitoring-connections",
-              "title": "Monitoring connections"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#configuring-supavisors-pool-size",
-              "title": "Configuring Supavisor's pool size"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#connections",
-              "title": "Connections"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#observing-live-connections",
-              "title": "Observing live connections"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#grafana-dashboard",
-              "title": "Grafana Dashboard"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management#dashboard-monitoring-charts",
-              "title": "Dashboard monitoring charts"
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
             },
             {
               "url": "https://supabase.com/docs/guides/troubleshooting/grafana-not-displaying-data-sXJrMj",
               "title": "Grafana not displaying data"
             }
           ],
-          "resultChars": 146707
+          "resultChars": 32827
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Metrics API hosted Supabase availability secret API key service_role 60 seconds\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
+              "title": "New API Keys and Asymmetric Authentication"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            }
+          ],
+          "resultChars": 67810
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.6/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -16405,12 +16094,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, basic_auth with password_file, preserves app job, and Compose wires a Docker secret to /run/secrets/supabase_secret_api_key. However the target in prometheus.yml is still __SUPABASE_PROJECT_REF__.supabase.co:443 rather than a concrete/render-verified project ref; the referenced render script is not included, so the target cannot be confirmed to resolve to a real Supabase project."
+        "judgeNotes": "Fail: the Supabase scrape is only in prometheus.supabase.yml and depends on /etc/prometheus/targets/supabase.yml, but no target file with a real <project-ref>.supabase.co or .supabase.red target is provided. The base prometheus.yml/docker-compose.yml also do not include the Supabase scrape or secret wiring directly."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes creating a Supabase Secret API key, writing it to the expected Docker secret file/path, setting project ref/env, recreating the Compose service, and verifying via Prometheus targets/API and Grafana/PromQL-equivalent Explore."
+        "judgeNotes": "README explains creating a Supabase secret API key, materializing the matching secret file, starting/updating the Compose stack with the overlay, and verifying via Prometheus targets and Grafana/PromQL. Endpoint, auth, and secret path match the configuration."
       }
     ],
     "skills": {
@@ -16421,35 +16110,39 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Supabase project Prometheus metrics endpoint customer metrics authentication service role scrape configuration\", limit: 8) { totalCount nodes { title href content } } }",
+          "query": "query { searchDocs(query: \"Prometheus metrics endpoint Supabase project metrics observability Grafana bearer token service role\", limit: 8) { nodes { __typename title href content } totalCount } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
             },
             {
-              "url": "https://supabase.com/docs/guides/security/security-testing",
-              "title": "Security testing of your Supabase projects"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management",
+              "title": "Connection management"
             },
             {
               "url": "https://supabase.com/docs/guides/platform/read-replicas",
               "title": "Read Replicas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
             }
           ],
-          "resultChars": 35485
+          "resultChars": 39563
         }
       ]
     },

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -811,7 +811,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -819,13 +819,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Supabase scrape uses HTTPS, the correct metrics_path, Basic Auth with password_file, preserves the app job, and mounts the secrets directory. However, the target is still the placeholder `<PROJECT_REF>.supabase.co:443`, not a real project ref, so it is not deployable as-is."
+        "passed": true,
+        "judgeNotes": "Meets all requirements: HTTPS Supabase metrics endpoint, correct metrics_path, Basic Auth with password_file, app job preserved, and docker-compose mounts the secrets directory containing the password file."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes live setup steps: create Supabase Secret API key, place it in the matching mounted secret file, replace project ref, and restart or hot-reload the Compose stack. It also provides concrete verification via curl plus Prometheus targets and PromQL up{job=\"supabase\"}. Auth endpoint and secret handling match the config, with no hardcoded secret."
+        "judgeNotes": "README includes Secret API key creation, matching secret file path, Compose start/reload steps, and concrete verification via curl and Prometheus targets. Endpoint/auth and secret setup match the Prometheus config."
       }
     ],
     "skills": {
@@ -841,24 +841,24 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"Prometheus metrics endpoint observability project metrics\", limit: 6) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"Prometheus metrics endpoint observability\", limit: 6) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
             },
             {
               "url": "https://supabase.com/docs/guides/platform/read-replicas",
@@ -870,23 +870,12 @@
             }
           ],
           "resultChars": 33507
-        },
-        {
-          "source": "web_fetch",
-          "query": "What is the exact metrics endpoint URL, the authentication method (username/password), and how to configure Prometheus to scrape it? Include any scrape_config YAML example, basic_auth details, tls/scheme settings, and metric_relabel or honor_labels notes.",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics.md"
-            }
-          ],
-          "resultChars": 1170
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-opus-4.8/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -2194,7 +2183,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -2202,13 +2191,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Supabase scrape is wired with HTTPS, correct metrics_path, basic_auth password_file, mounted secrets volume, and app job preserved, but the target uses placeholder REPLACE_WITH_PROJECT_REF.supabase.co rather than a real project ref, so it is not deployable as-is."
+        "passed": true,
+        "judgeNotes": "Supabase scrape is deployable: HTTPS target on a concrete project ref, correct metrics path, HTTP Basic Auth with password_file, app job preserved, and docker-compose mounts the secrets directory containing the password file."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes steps to set project ref, create/copy Secret API key, write it to the mounted secrets/supabase_metrics_key file, reload/restart the Compose stack, and verify via promtool, direct curl smoke test, and Prometheus targets."
+        "judgeNotes": "README includes live setup: mint Supabase Secret API key, write it to the mounted git-ignored secret file matching prometheus.yml, reload Prometheus, and verify via Prometheus targets plus direct metrics curl/Grafana option. Endpoint/auth and secret setup are consistent."
       }
     ],
     "skills": {
@@ -2219,7 +2208,7 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{\n  searchDocs(query: \"Prometheus metrics endpoint observability\", limit: 5) {\n    nodes {\n      title\n      href\n      content\n    }\n  }\n}",
+          "query": "{ searchDocs(query: \"Prometheus metrics endpoint project observability\", limit: 6) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -2231,12 +2220,12 @@
               "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
             },
             {
               "url": "https://supabase.com/docs/guides/platform/read-replicas",
@@ -2249,7 +2238,7 @@
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-opus-4.8-no-skills/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -3684,7 +3673,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -3692,13 +3681,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Fails because the Supabase scrape target still uses the placeholder \"<project-ref>.supabase.co:443\" and label, so it is not deployable and does not resolve to a real project ref. HTTPS, metrics path, basic_auth password_file, app scrape preservation, and Compose secret wiring are otherwise present."
+        "passed": true,
+        "judgeNotes": "Prometheus preserves the app scrape and adds a Supabase Metrics API scrape over HTTPS at /customer/v1/privileged/metrics for evalshostedprojectxy.supabase.co:443 using HTTP Basic Auth with password_file. docker-compose.yml mounts the referenced password file at the matching path."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes steps to create a Secret API key, place it in the configured Compose secret file, replace project placeholders, restart/recreate the Compose stack, and verify via Prometheus targets plus Grafana dashboards."
+        "judgeNotes": "README includes Secret API key creation, matching secret file placement, Prometheus restart/reload, and concrete verification via Prometheus targets."
       }
     ],
     "skills": {
@@ -3714,7 +3703,7 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"project metrics endpoint prometheus\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"project metrics prometheus endpoint\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -3744,7 +3733,7 @@
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "claude-code-sonnet-5/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -5002,7 +4991,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -5010,13 +4999,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Supabase scrape uses placeholder target/label (`<project-ref>.supabase.co`) rather than a real project ref, so it is not deployable despite having HTTPS, correct metrics path, basic_auth password_file, app scrape preserved, and the secrets volume mounted."
+        "passed": true,
+        "judgeNotes": "Supabase scrape is correctly configured with HTTPS, /customer/v1/privileged/metrics, Basic Auth using password_file, a project-ref supabase.co target, the app job is preserved, and docker-compose mounts the password file."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": false,
-        "judgeNotes": "README.md does not include the required live setup steps: creating the Supabase Secret API key, placing the matching Prometheus secret file, restarting/reloading the Compose stack, and verifying via Prometheus targets/PromQL/Grafana. It only points to another document and leaves placeholders."
+        "passed": true,
+        "judgeNotes": "README includes steps to create/copy a Supabase Secret API key, place it in the mounted observability/secrets/supabase_metrics_key file, recreate Prometheus via Docker Compose, and verify via Prometheus targets plus a direct curl test. Endpoint/auth and secret setup match the compose/prometheus config."
       }
     ],
     "skills": {
@@ -5027,7 +5016,7 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"prometheus metrics endpoint project metrics\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"platform metrics endpoint prometheus\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -5045,13 +5034,9 @@
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
-              "title": "Manual replication monitoring"
             }
           ],
-          "resultChars": 27147
+          "resultChars": 23542
         }
       ]
     },
@@ -7864,13 +7849,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses inline basic_auth password instead of password_file, docker-compose.yml does not mount any password_file/secret, and the target/project label still use placeholders rather than a real project ref. Existing app scrape is preserved and endpoint/scheme are correct."
+        "passed": true,
+        "judgeNotes": "Meets requirements: app scrape preserved, Supabase scrape uses HTTPS, correct metrics path, Basic Auth with password_file, and the password file is wired via a Compose secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README mentions the correct Supabase metrics endpoint/auth pattern and restarting/reloading Prometheus, but it does not require creating a Secret API key through Supabase, does not place a matching secret file or align with Compose secrets, and lacks concrete verification steps such as checking Prometheus targets, running PromQL, or confirming Grafana panels."
+        "judgeNotes": "README includes the secret file path, Compose startup, correct endpoint/auth, and Prometheus targets verification, but it does not provide actual steps to create a Supabase Secret API key. The rubric explicitly requires steps to create the Secret API key."
       }
     ],
     "skills": {
@@ -7885,27 +7870,32 @@
     "docs": {
       "calls": [
         {
-          "source": "web_search",
-          "query": "site:supabase.com/docs Supabase metrics Prometheus Grafana metrics export docs",
-          "pages": []
-        },
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/changelog.md",
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"metrics observability prometheus postgres exporter self hosted supabase\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on CLICommandReference { title href content } ... on ManagementApiReference { title href content } ... on ClientLibraryFunctionReference { title href content language methodName } ... on TroubleshootingGuide { title href content } } totalCount } }",
+          "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ]
-        },
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/changelog.md Supabase changelog md",
-          "pages": [
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
             {
-              "url": "https://supabase.com/changelog.md Supabase changelog md"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management",
+              "title": "Connection management"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
             }
-          ]
+          ],
+          "resultChars": 24376
         }
       ]
     },
@@ -11386,12 +11376,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with an environment variable instead of basic_auth.password_file, and docker-compose.yml does not mount the password file via a volume or Compose secret. The target is also templated rather than a concrete project ref."
+        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password with an environment-rendered secret instead of basic_auth.password_file, and docker-compose.yml does not mount a password_file via a volume or Compose secret. This is missing the required secret wiring and risks rendering the secret into prometheus.yml. The app scrape is preserved and endpoint/path/scheme are otherwise correct."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": true,
-        "judgeNotes": "README explains creating/copying a Supabase Secret API key, placing it via environment/.env next to the Compose file, restarting/reloading the stack, and verifying the scrape in Prometheus Targets. Endpoint and auth are concrete and no secret is hardcoded."
+        "passed": false,
+        "judgeNotes": "README includes creating a Supabase Secret API key, restarting Prometheus, and verifying via Prometheus Targets, but it does not require placing the matching secret file and instead documents environment variables/deployment secret manager. This fails the required secret-file setup."
       }
     ],
     "skills": {
@@ -11402,16 +11392,16 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Supabase metrics Prometheus endpoint project metrics\", limit: 5) { edges { node { title href content } } totalCount } }",
+          "query": "query { searchDocs(query: \"metrics endpoint project observability Prometheus Supabase\", limit: 5) { nodes { ... on Guide { title href content } ... on CLICommandReference { title href content } ... on ManagementApiReference { title href content } ... on TroubleshootingGuide { title href content } } } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
@@ -11426,40 +11416,7 @@
               "title": "Read Replicas"
             }
           ],
-          "resultChars": 32766
-        },
-        {
-          "source": "web_search",
-          "query": "site:supabase.com/docs/guides/telemetry/metrics Metrics API Supabase project ref service_role sb_secret_",
-          "pages": []
-        },
-        {
-          "source": "web_search",
-          "query": "Metrics API with Prometheus Grafana self-hosted Supabase",
-          "pages": []
-        },
-        {
-          "source": "web_search",
-          "query": "site:supabase.com/docs/guides/telemetry/metrics service_role sb_secret Metrics API",
-          "pages": []
-        },
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/telemetry/metrics",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics"
-            }
-          ]
-        },
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted"
-            }
-          ]
+          "resultChars": 32694
         }
       ]
     },
@@ -13884,12 +13841,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Meets requirements: app scrape preserved; Supabase scrape uses HTTPS, correct metrics_path, Basic Auth with password_file, file_sd target generation for <project-ref>.supabase.co:443, and Compose mounts the matching secret for Prometheus."
+        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase metrics scrape at /customer/v1/privileged/metrics using Basic Auth with password_file, targets <project-ref>.supabase.co via required env substitution, and wires the password file through a Compose secret mounted at /run/secrets/supabase_metrics_secret."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes steps to create/use a Supabase Secret API key, write it to the Compose secret file, start/recreate the Compose services after changes, and verify via Prometheus target health, PromQL, and curl. Endpoint/auth match the provided Prometheus config."
+        "judgeNotes": "README includes creating a Supabase Secret API key, writing it to the expected Compose secret file, recreating the Compose services to make the config live, and concrete verification via Prometheus targets, PromQL, and Grafana."
       }
     ],
     "skills": {
@@ -13905,73 +13862,45 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Supabase project metrics Prometheus endpoint observability Grafana authentication\", limit: 8) { nodes { __typename title href content } } }",
+          "query": "query { searchDocs(query: \"Prometheus metrics endpoint project metrics authentication service_role /customer/v1/privileged/metrics\", limit: 8) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
+              "url": "https://supabase.com/docs/guides/security/security-testing",
+              "title": "Security testing of your Supabase projects"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
+              "url": "https://supabase.com/docs/guides/database/extensions/pgaudit",
+              "title": "PGAudit: Postgres Auditing"
             },
             {
-              "url": "https://supabase.com/docs/guides/database/connection-management",
-              "title": "Connection management"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
-              "title": "How to View Database Metrics"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/troubleshooting/grafana-not-displaying-data-sXJrMj",
-              "title": "Grafana not displaying data"
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
+              "title": "Envoy API Gateway"
             }
           ],
-          "resultChars": 32827
-        },
-        {
-          "source": "search_docs",
-          "query": "query { searchDocs(query: \"Metrics API hosted Supabase availability secret API key service_role 60 seconds\", limit: 5) { nodes { __typename title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
-              "title": "New API Keys and Asymmetric Authentication"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/auth/signing-keys",
-              "title": "JWT Signing Keys"
-            }
-          ],
-          "resultChars": 67810
+          "resultChars": 67558
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.6/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -16085,7 +16014,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": false,
+    "passed": true,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -16093,13 +16022,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": false,
-        "judgeNotes": "Fail: the Supabase scrape is only in prometheus.supabase.yml and depends on /etc/prometheus/targets/supabase.yml, but no target file with a real <project-ref>.supabase.co or .supabase.red target is provided. The base prometheus.yml/docker-compose.yml also do not include the Supabase scrape or secret wiring directly."
+        "passed": true,
+        "judgeNotes": "Prometheus preserves the app scrape and adds a deployable Supabase scrape over HTTPS to /customer/v1/privileged/metrics with HTTP Basic Auth using password_file. docker-compose wires the same secret file into Prometheus via Compose secrets."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README explains creating a Supabase secret API key, materializing the matching secret file, starting/updating the Compose stack with the overlay, and verifying via Prometheus targets and Grafana/PromQL. Endpoint, auth, and secret path match the configuration."
+        "judgeNotes": "README includes Secret API key creation, matching Compose secret file path, stack recreation/reload, and concrete verification via Prometheus targets and PromQL. No hardcoded real secret or mismatched setup detected."
       }
     ],
     "skills": {
@@ -16110,12 +16039,16 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Prometheus metrics endpoint Supabase project metrics observability Grafana bearer token service role\", limit: 8) { nodes { __typename title href content } totalCount } }",
+          "query": "query { searchDocs(query: \"metrics Prometheus Supabase project observability endpoint authentication\", limit: 8) { nodes { __typename title href content } } }",
           "hasContent": true,
           "pages": [
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
@@ -16126,29 +16059,53 @@
               "title": "Metrics API with Grafana Cloud"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/connection-management",
-              "title": "Connection management"
+              "url": "https://supabase.com/docs/guides/auth/oauth-server/oauth-flows",
+              "title": "OAuth 2.1 Flows"
             },
             {
               "url": "https://supabase.com/docs/guides/platform/read-replicas",
               "title": "Read Replicas"
             },
             {
-              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
-              "title": "How to View Database Metrics"
+              "url": "https://supabase.com/docs/guides/auth/rate-limits",
+              "title": "Rate limits"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/why-do-i-see-auth--api-requests-in-the-dashboard-my-app-has-no-users-CyadiO",
+              "title": "Why do I see Auth & API requests in the dashboard? My app has no users"
             }
           ],
-          "resultChars": 39563
+          "resultChars": 79858
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Prometheus metrics API password_file secret API key service_role scrape config project ref\", limit: 5) { nodes { __typename title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            }
+          ],
+          "resultChars": 23680
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 2,
+    "attempts": 1,
     "sourcePath": "codex-gpt-5.6-no-skills/deploy-database-001-prometheus-metrics.json"
   },
   {

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -811,7 +811,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -819,13 +819,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets requirements: preserves app scrape, adds Supabase HTTPS scrape with correct metrics_path, Basic Auth using password_file, project target on <project-ref>.supabase.co:443, and docker-compose mounts the secrets directory containing the password file read-only."
+        "passed": false,
+        "judgeNotes": "Supabase scrape uses placeholder YOUR_PROJECT_REF rather than a real project ref, so it is not deployable as-is. Other required elements are present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes concrete live setup steps: replace project ref, create a Supabase Secret API key, write it to the expected secret file mounted by Compose, and reload/start the Compose stack. It also provides verification via curl, Prometheus targets, and PromQL/Grafana guidance. No hardcoded real secret or mismatched setup detected."
+        "judgeNotes": "README includes steps to set project ref, create a Supabase Secret API key, write it to the mounted secret file, start/reload the Compose stack, and verify via curl plus Prometheus targets."
       }
     ],
     "skills": {
@@ -841,48 +841,37 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"Prometheus metrics endpoint observability Grafana integration\", limit: 6) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"Prometheus metrics endpoint monitoring project\", limit: 6) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
+              "title": "Manual replication monitoring"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
             },
             {
-              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
-              "title": "How to View Database Metrics"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
             }
           ],
-          "resultChars": 24393
-        },
-        {
-          "source": "web_fetch",
-          "query": "What is the exact Supabase project metrics endpoint URL, what authentication does it use (username/password), what is the recommended Prometheus scrape config (job, scrape_interval, metrics_path, basic_auth, scheme), and any Grafana dashboard details? Quote exact config snippets.",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics.md"
-            }
-          ],
-          "resultChars": 1190
+          "resultChars": 27147
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-opus-4.8/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -2190,7 +2179,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -2198,13 +2187,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase metrics scrape with correct path, Basic Auth using password_file, project target on supabase.co, and docker-compose mounts the secrets directory containing the password file."
+        "passed": false,
+        "judgeNotes": "Supabase scrape uses the literal placeholder `<project-ref>.supabase.co:443` and label `<project-ref>`, so it is not deployable and does not resolve to a real project ref. Other wiring is present: HTTPS, correct metrics path, basic_auth with password_file, app job preserved, and docker-compose mounts the secrets directory."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes concrete steps to replace project ref, create a Supabase Secret API key, place it in the mounted secrets/supabase_metrics_key file, reload/start the Compose stack, and verify via curl plus Prometheus targets."
+        "judgeNotes": "README includes required live setup: replace project ref, create Supabase Secret API key, place it in the mounted password_file path, and restart/reload the Compose/Prometheus stack. It also provides concrete verification via curl and Prometheus targets, plus Grafana dashboard import."
       }
     ],
     "skills": {
@@ -2215,12 +2204,16 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"Prometheus metrics endpoint scrape project monitoring\", limit: 6) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"prometheus metrics endpoint project monitoring\", limit: 6) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
+              "title": "Manual replication monitoring"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
@@ -2233,15 +2226,19 @@
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas",
+              "title": "Read Replicas"
             }
           ],
-          "resultChars": 23542
+          "resultChars": 36261
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-opus-4.8-no-skills/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -3676,7 +3673,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -3684,13 +3681,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, Basic Auth with password_file, preserves the app job, and docker-compose mounts the secrets directory containing the password_file."
+        "passed": false,
+        "judgeNotes": "Fails because the Supabase scrape target is still the literal placeholder \"<project-ref>.supabase.co:443\" and does not resolve to a real project ref, so it is not deployable as required."
       },
       {
         "name": "documented live deployment and verification steps",
-        "passed": true,
-        "judgeNotes": "README includes Secret API key creation, matching secret file placement, Prometheus reload, and concrete verification via Prometheus targets, PromQL, and Grafana."
+        "passed": false,
+        "judgeNotes": "README.md does not itself explain the go-live steps. It lacks instructions to create the Supabase Secret API key, place it in observability/secrets/supabase_metrics_key, restart/reload the Compose stack, and verify the scrape via Prometheus targets/PromQL/Grafana. It only says the config needs a project ref and credential and links to another document."
       }
     ],
     "skills": {
@@ -3734,37 +3731,37 @@
         },
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"metrics customer/v1/privileged/metrics\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"metrics customer privileged basic auth grafana\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/reports",
-              "title": "Reports"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
+              "url": "https://supabase.com/docs/guides/telemetry/reports",
+              "title": "Reports"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-envoy",
+              "title": "Envoy API Gateway"
             }
           ],
-          "resultChars": 54724
+          "resultChars": 73133
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "claude-code-sonnet-5/deploy-database-001-prometheus-metrics.json"
   },
   {
@@ -5022,7 +5019,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -5030,13 +5027,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets requirements: preserves app scrape, adds HTTPS Supabase metrics endpoint with correct path and project target, uses HTTP Basic Auth with password_file, and docker-compose mounts the secrets directory containing that password file."
+        "passed": false,
+        "judgeNotes": "Fails because the Supabase scrape target uses the placeholder `<SUPABASE_PROJECT_REF>.supabase.co:443` rather than a real project ref, so it is not directly deployable. HTTPS, metrics path, basic_auth password_file, app job preservation, and Compose secret wiring are otherwise present."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes required live setup steps: create Secret API key, place it in the mounted secret file, replace project ref, and restart/reload Compose/Prometheus. It also provides concrete verification via Prometheus Targets, direct curl, and Grafana dashboard."
+        "judgeNotes": "README includes concrete go-live steps: create Supabase Secret API key, populate the Docker secret file matching compose/password_file paths, replace project ref, restart or reload the Compose/Prometheus stack, and verify via Prometheus targets plus direct endpoint curl."
       }
     ],
     "skills": {
@@ -5047,7 +5044,7 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"project metrics endpoint prometheus\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"prometheus metrics endpoint project\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -5059,12 +5056,12 @@
               "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
             },
             {
               "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
@@ -7885,12 +7882,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails because the Supabase scrape uses basic_auth.password with an injected Secret API key instead of basic_auth.password_file, and docker-compose.yml does not mount that password_file via a volume or Compose secret. The app scrape is preserved and endpoint/HTTPS target are otherwise correct."
+        "judgeNotes": "Fails: Supabase scrape uses inline basic_auth.password instead of password_file, docker-compose does not mount/provide that password file, and the target is still a placeholder rather than a real project ref. App scrape is preserved and endpoint/scheme are correct."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README mentions creating a Supabase Secret API key and setting env vars, but it does not instruct placing a matching secret file, lacks a concrete compose restart/reload command, and does not include concrete verification via Prometheus targets, PromQL, Grafana, or equivalent."
+        "judgeNotes": "README includes the correct Supabase metrics endpoint/auth, reload step, and Prometheus target verification, but it does not require placing the Secret API key in a matching secret file. It instructs users to put the key directly into prometheus.yml, so the required secret-file setup is missing/mismatched."
       }
     ],
     "skills": {
@@ -7906,7 +7903,123 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"metrics prometheus supabase project metrics endpoint observability\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on CLICommandReference { title href content } ... on ClientLibraryFunctionReference { title href content } ... on ManagementApiReference { title href content } ... on TroubleshootingGuide { title href content } } } }",
+          "query": "{ searchDocs(query: \"Supabase metrics Prometheus Grafana monitoring observability\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
+              "title": "What you can do with the Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
+              "title": "Choose your monitoring stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
+              "title": "4. Configure alerts (optional)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
+              "title": "Prerequisites"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#1-create-a-grafana-cloud-stack",
+              "title": "1. Create a Grafana Cloud stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#2-configure-the-supabase-integration",
+              "title": "2. Configure the Supabase integration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#3-import-the-supabase-dashboard",
+              "title": "3. Import the Supabase dashboard"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
+              "title": "5. Troubleshooting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
+              "title": "1. Deploy Prometheus"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
+              "title": "Architecture"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#5-operating-tips",
+              "title": "5. Operating tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
+              "title": "4. Configure alerting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
+              "title": "3. Import Supabase dashboards"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#2-deploy-grafana",
+              "title": "2. Deploy Grafana"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management",
+              "title": "Connection management"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#capturing-historical-usage",
+              "title": "Capturing historical usage"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#monitoring-connections",
+              "title": "Monitoring connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#configuring-supavisors-pool-size",
+              "title": "Configuring Supavisor's pool size"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#connections",
+              "title": "Connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#observing-live-connections",
+              "title": "Observing live connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#grafana-dashboard",
+              "title": "Grafana Dashboard"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#dashboard-monitoring-charts",
+              "title": "Dashboard monitoring charts"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
+              "title": "How to View Database Metrics"
+            }
+          ],
+          "resultChars": 71826
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"metrics self-hosted Prometheus scrape interval basic auth supabase grafana self-hosted\", limit: 5) { nodes { title href content ... on Guide { subsections { nodes { title href content } } } } } }",
           "hasContent": true,
           "pages": [
             {
@@ -7914,23 +8027,107 @@
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
+              "title": "1. Deploy Prometheus"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
+              "title": "Architecture"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
+              "title": "3. Import Supabase dashboards"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
+              "title": "4. Configure alerting"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#5-operating-tips",
+              "title": "5. Operating tips"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#2-deploy-grafana",
+              "title": "2. Deploy Grafana"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
             },
             {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
+              "title": "4. Configure alerts (optional)"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#3-import-the-supabase-dashboard",
+              "title": "3. Import the Supabase dashboard"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#2-configure-the-supabase-integration",
+              "title": "2. Configure the Supabase integration"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#1-create-a-grafana-cloud-stack",
+              "title": "1. Create a Grafana Cloud stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
+              "title": "Prerequisites"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
+              "title": "5. Troubleshooting"
+            },
+            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
             },
             {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas",
-              "title": "Read Replicas"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#3-downstream-dashboards",
+              "title": "3. Downstream dashboards"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#components",
+              "title": "Components"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#1-define-the-scrape-job",
+              "title": "1. Define the scrape job"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#collector-specific-notes",
+              "title": "Collector-specific notes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#2-secure-the-credentials",
+              "title": "2. Secure the credentials"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#4-alerts-and-automation",
+              "title": "4. Alerts and automation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#5-multi-project-setups",
+              "title": "5. Multi-project setups"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
+              "title": "Additional resources"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
+              "title": "Choose your monitoring stack"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
+              "title": "What you can do with the Metrics API"
             }
           ],
-          "resultChars": 32819
+          "resultChars": 93207
         }
       ]
     },
@@ -11411,12 +11608,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": false,
-        "judgeNotes": "Fails: Supabase scrape uses basic_auth.password instead of password_file, docker-compose.yml does not mount the password file via volume or Compose secret, and README instructs replacing the value with a Secret API key in prometheus.yml. Existing app scrape and HTTPS metrics path are present."
+        "judgeNotes": "Fails rubric: Supabase basic_auth uses `password` with an environment variable instead of required `password_file`, and docker-compose.yml does not mount that password file via a volume or Compose secret. The target is also parameterized rather than a concrete project ref."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": false,
-        "judgeNotes": "README gives basic Supabase scrape setup and restart guidance, but fails required criteria: it instructs replacing the password inline rather than placing a matching secret file, does not configure/use a secret file, and lacks concrete verification steps via Prometheus targets, PromQL/Grafana, or equivalent."
+        "judgeNotes": "README includes creating a Supabase Secret API key and restarting/reloading the stack, but it lacks concrete verification steps via Prometheus targets, PromQL, or Grafana. Secret placement is also vague and may not match the Compose setup."
       }
     ],
     "skills": {
@@ -11427,7 +11624,7 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"metrics Prometheus project metrics\", limit: 10) { edges { node { __typename title href content } } } }",
+          "query": "query { searchDocs(query: \"Prometheus metrics Supabase project metrics export\", limit: 5) { nodes { __typename ... on Guide { title href content } ... on TroubleshootingGuide { title href content } ... on CLICommandReference { title href content } ... on ManagementApiReference { title href content } ... on ClientLibraryFunctionReference { title href content language methodName } } } }",
           "hasContent": true,
           "pages": [
             {
@@ -11445,21 +11642,9 @@
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/replication/manual-replication-monitoring",
-              "title": "Manual replication monitoring"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/postgres/data-deletion",
-              "title": "Deleting data and dropping objects safely"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/troubleshooting/how-to-view-database-metrics-uqf2z_",
-              "title": "How to View Database Metrics"
             }
           ],
-          "resultChars": 35779
+          "resultChars": 23680
         }
       ]
     },
@@ -13884,12 +14069,12 @@
       {
         "name": "configured the Supabase Metrics API scrape correctly",
         "passed": true,
-        "judgeNotes": "Meets all requirements: preserves app scrape, adds HTTPS Supabase Metrics API scrape at /customer/v1/privileged/metrics for <project-ref>.supabase.co, uses basic_auth with password_file, and wires the password file via a Compose secret."
+        "judgeNotes": "Meets requirements: app scrape preserved, Supabase HTTPS scrape uses /customer/v1/privileged/metrics with Basic Auth password_file, target is rendered to <project-ref>.supabase.co:443, and docker-compose mounts the password file as a Compose secret for Prometheus."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes required live setup steps: project ref, creating/copying a Supabase Secret API key, placing it in the Compose secret file, restarting the Compose stack, and concrete verification via Prometheus targets and PromQL/Grafana."
+        "judgeNotes": "README includes Secret API key creation, secret file placement, Compose deploy/redeploy, and concrete verification via direct curl, Prometheus targets API, and PromQL/Grafana."
       }
     ],
     "skills": {
@@ -13897,33 +14082,15 @@
         "supabase",
         "supabase-postgres-best-practices"
       ],
-      "loaded": [
-        "supabase"
-      ]
+      "loaded": []
     },
     "docs": {
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Supabase project metrics Prometheus endpoint authentication service role metrics\", limit: 5) { nodes { ... on Guide { title href content subsections { nodes { title href content } } } ... on ManagementApiReference { title href content } ... on TroubleshootingGuide { title href content } } } }",
+          "query": "query { searchDocs(query: \"Supabase Prometheus metrics endpoint observability Grafana customer v1 privileged metrics authentication project ref service role\", limit: 8) { nodes { ... on Guide { title href content subsections { nodes { title href content } } } ... on TroubleshootingGuide { title href content } ... on CLICommandReference { title href content } } } }",
           "hasContent": true,
           "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics",
-              "title": "Metrics API"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
-              "title": "Additional resources"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
-              "title": "Choose your monitoring stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
-              "title": "What you can do with the Metrics API"
-            },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
               "title": "Metrics API with Prometheus & Grafana (self-hosted)"
@@ -13931,10 +14098,6 @@
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
               "title": "Architecture"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
-              "title": "4. Configure alerting"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
@@ -13949,16 +14112,52 @@
               "title": "5. Operating tips"
             },
             {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
+              "title": "4. Configure alerting"
+            },
+            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
               "title": "1. Deploy Prometheus"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
+              "title": "Vendor-agnostic Metrics API setup"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#1-define-the-scrape-job",
+              "title": "1. Define the scrape job"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#collector-specific-notes",
+              "title": "Collector-specific notes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#2-secure-the-credentials",
+              "title": "2. Secure the credentials"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#3-downstream-dashboards",
+              "title": "3. Downstream dashboards"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#4-alerts-and-automation",
+              "title": "4. Alerts and automation"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#5-multi-project-setups",
+              "title": "5. Multi-project setups"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#components",
+              "title": "Components"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
               "title": "Metrics API with Grafana Cloud"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
-              "title": "5. Troubleshooting"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
+              "title": "4. Configure alerts (optional)"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
@@ -13977,44 +14176,44 @@
               "title": "3. Import the Supabase dashboard"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
-              "title": "4. Configure alerts (optional)"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
+              "title": "5. Troubleshooting"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
-              "title": "Vendor-agnostic Metrics API setup"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics",
+              "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#5-multi-project-setups",
-              "title": "5. Multi-project setups"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
+              "title": "Additional resources"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#3-downstream-dashboards",
-              "title": "3. Downstream dashboards"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
+              "title": "Choose your monitoring stack"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#2-secure-the-credentials",
-              "title": "2. Secure the credentials"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#collector-specific-notes",
-              "title": "Collector-specific notes"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#1-define-the-scrape-job",
-              "title": "1. Define the scrape job"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#components",
-              "title": "Components"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#4-alerts-and-automation",
-              "title": "4. Alerts and automation"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
+              "title": "What you can do with the Metrics API"
             },
             {
               "url": "https://supabase.com/docs/guides/platform/read-replicas",
               "title": "Read Replicas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas#dedicated-connection-pool",
+              "title": "Dedicated connection pool"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas#dedicated-endpoints",
+              "title": "Dedicated endpoints"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas#features",
+              "title": "Features"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/read-replicas#about-read-replicas",
+              "title": "About Read Replicas"
             },
             {
               "url": "https://supabase.com/docs/guides/platform/read-replicas#pricing",
@@ -14041,23 +14240,43 @@
               "title": "API load balancer"
             },
             {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#dedicated-connection-pool",
-              "title": "Dedicated connection pool"
+              "url": "https://supabase.com/docs/guides/database/connection-management",
+              "title": "Connection management"
             },
             {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#dedicated-endpoints",
-              "title": "Dedicated endpoints"
+              "url": "https://supabase.com/docs/guides/database/connection-management#capturing-historical-usage",
+              "title": "Capturing historical usage"
             },
             {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#features",
-              "title": "Features"
+              "url": "https://supabase.com/docs/guides/database/connection-management#monitoring-connections",
+              "title": "Monitoring connections"
             },
             {
-              "url": "https://supabase.com/docs/guides/platform/read-replicas#about-read-replicas",
-              "title": "About Read Replicas"
+              "url": "https://supabase.com/docs/guides/database/connection-management#configuring-supavisors-pool-size",
+              "title": "Configuring Supavisor's pool size"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#connections",
+              "title": "Connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#observing-live-connections",
+              "title": "Observing live connections"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#grafana-dashboard",
+              "title": "Grafana Dashboard"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/connection-management#dashboard-monitoring-charts",
+              "title": "Dashboard monitoring charts"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/grafana-not-displaying-data-sXJrMj",
+              "title": "Grafana not displaying data"
             }
           ],
-          "resultChars": 96198
+          "resultChars": 146707
         }
       ]
     },
@@ -16177,7 +16396,7 @@
       "observability"
     ],
     "suite": "benchmark",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "preserved existing app scrape job",
@@ -16185,13 +16404,13 @@
       },
       {
         "name": "configured the Supabase Metrics API scrape correctly",
-        "passed": true,
-        "judgeNotes": "Meets all requirements: preserves app scrape, adds HTTPS Supabase Metrics API scrape at the correct path and project host, uses basic_auth with password_file, and wires the password file via a Docker Compose secret."
+        "passed": false,
+        "judgeNotes": "Supabase scrape uses HTTPS, correct metrics path, basic_auth with password_file, preserves app job, and Compose wires a Docker secret to /run/secrets/supabase_secret_api_key. However the target in prometheus.yml is still __SUPABASE_PROJECT_REF__.supabase.co:443 rather than a concrete/render-verified project ref; the referenced render script is not included, so the target cannot be confirmed to resolve to a real Supabase project."
       },
       {
         "name": "documented live deployment and verification steps",
         "passed": true,
-        "judgeNotes": "README includes creating a Supabase Secret API key, writing it to the expected secret file, starting/recreating the Compose stack, and verifying via curl, Prometheus targets, and Grafana/PromQL."
+        "judgeNotes": "README includes creating a Supabase Secret API key, writing it to the expected Docker secret file/path, setting project ref/env, recreating the Compose service, and verifying via Prometheus targets/API and Grafana/PromQL-equivalent Explore."
       }
     ],
     "skills": {
@@ -16202,125 +16421,41 @@
       "calls": [
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"Prometheus metrics endpoint customer v1 privileged metrics service_role basic auth Grafana\", limit: 8) { nodes { __typename title href content ... on Guide { subsections { nodes { title href content } } } } } }",
+          "query": "query { searchDocs(query: \"Supabase project Prometheus metrics endpoint customer metrics authentication service role scrape configuration\", limit: 8) { totalCount nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
-              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#5-operating-tips",
-              "title": "5. Operating tips"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#4-configure-alerting",
-              "title": "4. Configure alerting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#3-import-supabase-dashboards",
-              "title": "3. Import Supabase dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#2-deploy-grafana",
-              "title": "2. Deploy Grafana"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#1-deploy-prometheus",
-              "title": "1. Deploy Prometheus"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted#architecture",
-              "title": "Architecture"
-            },
-            {
               "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic",
               "title": "Vendor-agnostic Metrics API setup"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#5-multi-project-setups",
-              "title": "5. Multi-project setups"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#components",
-              "title": "Components"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#1-define-the-scrape-job",
-              "title": "1. Define the scrape job"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#collector-specific-notes",
-              "title": "Collector-specific notes"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#2-secure-the-credentials",
-              "title": "2. Secure the credentials"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#3-downstream-dashboards",
-              "title": "3. Downstream dashboards"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/vendor-agnostic#4-alerts-and-automation",
-              "title": "4. Alerts and automation"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
-              "title": "Metrics API with Grafana Cloud"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#prerequisites",
-              "title": "Prerequisites"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#1-create-a-grafana-cloud-stack",
-              "title": "1. Create a Grafana Cloud stack"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#2-configure-the-supabase-integration",
-              "title": "2. Configure the Supabase integration"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#5-troubleshooting",
-              "title": "5. Troubleshooting"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#4-configure-alerts-optional",
-              "title": "4. Configure alerts (optional)"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud#3-import-the-supabase-dashboard",
-              "title": "3. Import the Supabase dashboard"
             },
             {
               "url": "https://supabase.com/docs/guides/telemetry/metrics",
               "title": "Metrics API"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#what-you-can-do-with-the-metrics-api",
-              "title": "What you can do with the Metrics API"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-self-hosted",
+              "title": "Metrics API with Prometheus & Grafana (self-hosted)"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#choose-your-monitoring-stack",
-              "title": "Choose your monitoring stack"
+              "url": "https://supabase.com/docs/guides/telemetry/metrics/grafana-cloud",
+              "title": "Metrics API with Grafana Cloud"
             },
             {
-              "url": "https://supabase.com/docs/guides/telemetry/metrics#additional-resources",
-              "title": "Additional resources"
+              "url": "https://supabase.com/docs/guides/security/security-testing",
+              "title": "Security testing of your Supabase projects"
             },
             {
-              "url": "https://supabase.com/docs/guides/troubleshooting/grafana-not-displaying-data-sXJrMj",
-              "title": "Grafana not displaying data"
+              "url": "https://supabase.com/docs/guides/platform/read-replicas",
+              "title": "Read Replicas"
             }
           ],
-          "resultChars": 128863
+          "resultChars": 35485
         }
       ]
     },
     "prompt": "Can you wire my Supabase project metrics into our existing observability stack and document\nwhat we need to do to make the config live?",
     "promptSourcePath": "evals/deploy-database-001-prometheus-metrics/PROMPT.md",
-    "attempts": 1,
+    "attempts": 2,
     "sourcePath": "codex-gpt-5.6-no-skills/deploy-database-001-prometheus-metrics.json"
   },
   {

--- a/evals/deploy-database-001-prometheus-metrics/EVAL.ts
+++ b/evals/deploy-database-001-prometheus-metrics/EVAL.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   judge,
@@ -7,14 +7,30 @@ import {
 } from "@supabase-evals/core";
 import { stripIndent } from "common-tags";
 
-const PROMETHEUS_PATH = "observability/prometheus.yml";
-const COMPOSE_PATH = "observability/docker-compose.yml";
-const README_PATH = "observability/README.md";
+const OBSERVABILITY_DIR = "observability";
+const PROMETHEUS_PATH = join(OBSERVABILITY_DIR, "prometheus.yml");
+const COMPOSE_PATH = join(OBSERVABILITY_DIR, "docker-compose.yml");
+const README_PATH = join(OBSERVABILITY_DIR, "README.md");
 
 const scorer: LocalStackScorer = async (ctx) => {
   const prometheus = readWorkspaceFile(ctx.hostWorkspace, PROMETHEUS_PATH);
   const compose = readWorkspaceFile(ctx.hostWorkspace, COMPOSE_PATH);
   const readme = readWorkspaceFile(ctx.hostWorkspace, README_PATH);
+
+  // Agents sometimes split scrape targets into a separate file (e.g. referenced
+  // via Prometheus file_sd_configs) instead of inlining them in prometheus.yml.
+  // Sweep any other yaml under observability/ so that pattern isn't judged blind.
+  const extraConfigs = collectAdditionalYamlFiles(
+    ctx.hostWorkspace,
+    OBSERVABILITY_DIR,
+    new Set([PROMETHEUS_PATH, COMPOSE_PATH]),
+  );
+  const extraConfigsBlock = extraConfigs
+    .map(
+      ({ path, content }) => `\n${path}:\n\`\`\`yaml\n${content}\n\`\`\`\n`,
+    )
+    .join("");
+
   const input = stripIndent`
     ${PROMETHEUS_PATH}:
     \`\`\`yaml
@@ -25,7 +41,7 @@ const scorer: LocalStackScorer = async (ctx) => {
     \`\`\`yaml
     ${compose}
     \`\`\`
-
+    ${extraConfigsBlock}
     ${README_PATH}:
     \`\`\`md
     ${readme}
@@ -38,6 +54,7 @@ const scorer: LocalStackScorer = async (ctx) => {
       rubric: stripIndent`
         Pass if prometheus.yml adds a deployable Supabase Metrics API scrape for <project-ref>.supabase.co or <project-ref>.supabase.red.
         Require HTTPS, /customer/v1/privileged/metrics, HTTP Basic Auth with password_file, the existing app scrape preserved, and docker-compose.yml mounting that password_file via a volume or Compose secret.
+        The scrape target may be inlined in prometheus.yml or split into a separate file referenced via file_sd_configs (included above if present); either is acceptable as long as the target resolves to a real project ref.
         Fail for bearer auth, hardcoded Secret API keys, missing/mismatched secret wiring, wrong endpoint, missing project target, or removing the app job.
       `,
     }),
@@ -80,6 +97,31 @@ const scorer: LocalStackScorer = async (ctx) => {
 function readWorkspaceFile(workspace: string, path: string): string {
   const fullPath = join(workspace, path);
   return existsSync(fullPath) ? readFileSync(fullPath, "utf8") : "";
+}
+
+/** Recursively finds yaml files under `dir` (skipping `secrets/`) not already in `exclude`, so referenced config like a file_sd_configs target file gets included even though it lives outside the fixed set of judged paths. */
+function collectAdditionalYamlFiles(
+  workspace: string,
+  dir: string,
+  exclude: Set<string>,
+): Array<{ path: string; content: string }> {
+  const dirPath = join(workspace, dir);
+  if (!existsSync(dirPath)) return [];
+
+  const results: Array<{ path: string; content: string }> = [];
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    if (entry.name === "secrets") continue;
+    const relPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectAdditionalYamlFiles(workspace, relPath, exclude));
+    } else if (/\.ya?ml$/i.test(entry.name) && !exclude.has(relPath)) {
+      results.push({
+        path: relPath,
+        content: readFileSync(join(workspace, relPath), "utf8"),
+      });
+    }
+  }
+  return results;
 }
 
 export default scorer;

--- a/evals/deploy-database-001-prometheus-metrics/EVAL.ts
+++ b/evals/deploy-database-001-prometheus-metrics/EVAL.ts
@@ -9,39 +9,21 @@ import { stripIndent } from "common-tags";
 
 const OBSERVABILITY_DIR = "observability";
 const PROMETHEUS_PATH = join(OBSERVABILITY_DIR, "prometheus.yml");
-const COMPOSE_PATH = join(OBSERVABILITY_DIR, "docker-compose.yml");
 const README_PATH = join(OBSERVABILITY_DIR, "README.md");
 
 const scorer: LocalStackScorer = async (ctx) => {
-  const prometheus = readWorkspaceFile(ctx.hostWorkspace, PROMETHEUS_PATH);
-  const compose = readWorkspaceFile(ctx.hostWorkspace, COMPOSE_PATH);
+  // Agents sometimes split scrape targets into a separate file (e.g. referenced
+  // via Prometheus file_sd_configs) instead of inlining them in prometheus.yml,
+  // so read every yaml file under observability/ rather than a fixed set of paths.
+  const yamlFiles = collectYamlFiles(ctx.hostWorkspace, OBSERVABILITY_DIR);
+  const prometheus =
+    yamlFiles.find((f) => f.path === PROMETHEUS_PATH)?.content ?? "";
   const readme = readWorkspaceFile(ctx.hostWorkspace, README_PATH);
 
-  // Agents sometimes split scrape targets into a separate file (e.g. referenced
-  // via Prometheus file_sd_configs) instead of inlining them in prometheus.yml.
-  // Sweep any other yaml under observability/ so that pattern isn't judged blind.
-  const extraConfigs = collectAdditionalYamlFiles(
-    ctx.hostWorkspace,
-    OBSERVABILITY_DIR,
-    new Set([PROMETHEUS_PATH, COMPOSE_PATH]),
-  );
-  const extraConfigsBlock = extraConfigs
-    .map(
-      ({ path, content }) => `\n${path}:\n\`\`\`yaml\n${content}\n\`\`\`\n`,
-    )
-    .join("");
-
   const input = stripIndent`
-    ${PROMETHEUS_PATH}:
-    \`\`\`yaml
-    ${prometheus}
-    \`\`\`
-
-    ${COMPOSE_PATH}:
-    \`\`\`yaml
-    ${compose}
-    \`\`\`
-    ${extraConfigsBlock}
+    ${yamlFiles
+      .map(({ path, content }) => `${path}:\n\`\`\`yaml\n${content}\n\`\`\`\n`)
+      .join("\n")}
     ${README_PATH}:
     \`\`\`md
     ${readme}
@@ -99,29 +81,18 @@ function readWorkspaceFile(workspace: string, path: string): string {
   return existsSync(fullPath) ? readFileSync(fullPath, "utf8") : "";
 }
 
-/** Recursively finds yaml files under `dir` (skipping `secrets/`) not already in `exclude`, so referenced config like a file_sd_configs target file gets included even though it lives outside the fixed set of judged paths. */
-function collectAdditionalYamlFiles(
+/** Reads every yaml file directly under `dir`, so a scrape target split into its own file (e.g. a file_sd_configs target) is judged instead of missed. */
+function collectYamlFiles(
   workspace: string,
   dir: string,
-  exclude: Set<string>,
 ): Array<{ path: string; content: string }> {
   const dirPath = join(workspace, dir);
   if (!existsSync(dirPath)) return [];
 
-  const results: Array<{ path: string; content: string }> = [];
-  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
-    if (entry.name === "secrets") continue;
-    const relPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...collectAdditionalYamlFiles(workspace, relPath, exclude));
-    } else if (/\.ya?ml$/i.test(entry.name) && !exclude.has(relPath)) {
-      results.push({
-        path: relPath,
-        content: readFileSync(join(workspace, relPath), "utf8"),
-      });
-    }
-  }
-  return results;
+  return readdirSync(dirPath)
+    .filter((name) => /\.ya?ml$/i.test(name))
+    .map((name) => join(dir, name))
+    .map((path) => ({ path, content: readFileSync(join(workspace, path), "utf8") }));
 }
 
 export default scorer;

--- a/evals/deploy-database-001-prometheus-metrics/PROMPT.md
+++ b/evals/deploy-database-001-prometheus-metrics/PROMPT.md
@@ -6,6 +6,7 @@ product:
 topic:
   - observability
 motivation: AI-817
+hostedProject: true
 projectRunning: false
 ---
 


### PR DESCRIPTION
Reduces result instability in `deploy-database-001-prometheus-metrics`'s scorer due to file-visibility gap.

The judge only read 3 hardcoded paths (`prometheus.yml`, `docker-compose.yml`, `README.md`), so a valid [`file_sd_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config)-based scrape target split into its own yaml file (e.g. `supabase-targets.yml`) was invisible to the judge and got auto-failed as unverifiable. Scorer now reads every yaml file under `observability/` instead of a fixed set of hardcoded paths, with a test for the yaml collector to confirm it finds split target files and leaves `secrets/` and non-yaml files alone

Verified against the real GH Actions transcript from run https://github.com/supabase/evals/actions/runs/29531871411: the judge's "target wiring cannot be verified" note is gone, replaced with a substantive verdict on the actual placeholder value.

The eval was also missing `hostedProject: true`, so agents had no real hosted project to discover a project ref from and fell back to placeholders (`<project-ref>`, `__SUPABASE_PROJECT_REF__`), which the judge correctly failed as undeployable. That was the actual cause behind most of the placeholder-ref failures, not judge non-determinism. Added it and refreshed results again: 6/8 experiments now pass with real project refs resolved. The 2 remaining failures (`codex-gpt-5.4-mini`, `codex-gpt-5.4-mini-no-skills`) are genuine model mistakes, missing Secret API key creation steps in the README, and one using inline `basic_auth.password` instead of `password_file`. Not an eval bug.

Closes AI-911

