### PR TITLE
fix: retry sandbox image build on transient registry errors

### DIFF
--- a/packages/sandbox/src/supabase.ts
+++ b/packages/sandbox/src/supabase.ts
@@ -32,21 +32,12 @@ const SANDBOX_IMAGE_REPOSITORY = "supabase-evals-sandbox";
  * Backoff schedule for retrying the sandbox image build. The build pulls
  * `node:22-slim` from Docker Hub, which intermittently answers 5xx/429 (and
  * once took out ~130 CI matrix jobs in a single blip); a short outage should
- * cost a delay, not the run. Delays total ~100s — well under the job timeout.
+ * cost a delay, not the run. Every failure is retried — the transient
+ * registry-error strings come from BuildKit/containerd internals with no
+ * stable taxonomy to match against, and a deterministic failure (broken
+ * Dockerfile, bad build-arg) merely wastes the ~95s schedule before failing.
  */
 const IMAGE_BUILD_RETRY_DELAYS_MS = [5_000, 30_000, 60_000];
-
-/**
- * Registry/network failure signatures worth retrying. Anything else (a broken
- * Dockerfile, a bad build-arg) is deterministic and fails fast instead.
- */
-const TRANSIENT_IMAGE_BUILD_ERROR =
-  /unexpected status[^\n]*\b(429|5\d{2})\b|bad gateway|service unavailable|too many requests|timed? ?out|connection (reset|refused)|tls handshake|temporary failure|i\/o timeout|EOF/i;
-
-/** Whether a failed `docker build`'s stderr looks like a transient registry/network error. */
-export function isTransientImageBuildError(stderr: string): boolean {
-  return TRANSIENT_IMAGE_BUILD_ERROR.test(stderr);
-}
 
 /** The sandbox image definition lives in an actual Dockerfile for editability. */
 export const SANDBOX_DOCKERFILE_PATH = fileURLToPath(
@@ -82,11 +73,11 @@ export async function ensureSupabaseSandboxImage(): Promise<string> {
     if (build.ok) return tag;
 
     const delayMs = IMAGE_BUILD_RETRY_DELAYS_MS[attempt];
-    if (delayMs === undefined || !isTransientImageBuildError(build.stderr)) {
+    if (delayMs === undefined) {
       throw new Error(`failed to build sandbox image ${tag}: ${build.stderr}`);
     }
     console.warn(
-      `[sandbox] transient registry error building ${tag} ` +
+      `[sandbox] failed to build ${tag} ` +
         `(attempt ${attempt + 1}/${IMAGE_BUILD_RETRY_DELAYS_MS.length + 1}), ` +
         `retrying in ${delayMs / 1000}s`,
     );

--- a/packages/sandbox/src/supabase.ts
+++ b/packages/sandbox/src/supabase.ts
@@ -28,6 +28,26 @@ export const SUPABASE_CLI_VERSION = "2.67.1";
 
 const SANDBOX_IMAGE_REPOSITORY = "supabase-evals-sandbox";
 
+/**
+ * Backoff schedule for retrying the sandbox image build. The build pulls
+ * `node:22-slim` from Docker Hub, which intermittently answers 5xx/429 (and
+ * once took out ~130 CI matrix jobs in a single blip); a short outage should
+ * cost a delay, not the run. Delays total ~100s — well under the job timeout.
+ */
+const IMAGE_BUILD_RETRY_DELAYS_MS = [5_000, 30_000, 60_000];
+
+/**
+ * Registry/network failure signatures worth retrying. Anything else (a broken
+ * Dockerfile, a bad build-arg) is deterministic and fails fast instead.
+ */
+const TRANSIENT_IMAGE_BUILD_ERROR =
+  /unexpected status[^\n]*\b(429|5\d{2})\b|bad gateway|service unavailable|too many requests|timed? ?out|connection (reset|refused)|tls handshake|temporary failure|i\/o timeout|EOF/i;
+
+/** Whether a failed `docker build`'s stderr looks like a transient registry/network error. */
+export function isTransientImageBuildError(stderr: string): boolean {
+  return TRANSIENT_IMAGE_BUILD_ERROR.test(stderr);
+}
+
 /** The sandbox image definition lives in an actual Dockerfile for editability. */
 export const SANDBOX_DOCKERFILE_PATH = fileURLToPath(
   new URL("../Dockerfile", import.meta.url),
@@ -46,21 +66,32 @@ export async function ensureSupabaseSandboxImage(): Promise<string> {
   const existing = await dockerCli(["image", "inspect", tag]);
   if (existing.ok) return tag;
 
-  const build = await dockerCli(
-    [
-      "build",
-      "--build-arg",
-      `SKILLS_CLI_VERSION=${SKILLS_CLI_VERSION}`,
-      "--tag",
-      tag,
-      "-",
-    ],
-    { input: readFileSync(SANDBOX_DOCKERFILE_PATH, "utf8") },
-  );
-  if (!build.ok) {
-    throw new Error(`failed to build sandbox image ${tag}: ${build.stderr}`);
+  const dockerfile = readFileSync(SANDBOX_DOCKERFILE_PATH, "utf8");
+  for (let attempt = 0; ; attempt++) {
+    const build = await dockerCli(
+      [
+        "build",
+        "--build-arg",
+        `SKILLS_CLI_VERSION=${SKILLS_CLI_VERSION}`,
+        "--tag",
+        tag,
+        "-",
+      ],
+      { input: dockerfile },
+    );
+    if (build.ok) return tag;
+
+    const delayMs = IMAGE_BUILD_RETRY_DELAYS_MS[attempt];
+    if (delayMs === undefined || !isTransientImageBuildError(build.stderr)) {
+      throw new Error(`failed to build sandbox image ${tag}: ${build.stderr}`);
+    }
+    console.warn(
+      `[sandbox] transient registry error building ${tag} ` +
+        `(attempt ${attempt + 1}/${IMAGE_BUILD_RETRY_DELAYS_MS.length + 1}), ` +
+        `retrying in ${delayMs / 1000}s`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
-  return tag;
 }
 
 /**

--- a/packages/sandbox/test/unit.test.ts
+++ b/packages/sandbox/test/unit.test.ts
@@ -12,7 +12,6 @@ import {
   buildServiceWrapperScript,
   buildSupabaseStartCommand,
   computeExcludedServices,
-  isTransientImageBuildError,
 } from "../src/supabase.js";
 import {
   SKILLS_CLI_VERSION,
@@ -45,57 +44,6 @@ describe("sandbox Dockerfile", () => {
   it("pins the Supabase CLI version installed at setup time", () => {
     // The pin moved out of the Dockerfile into installSupabaseCli.
     expect(SUPABASE_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
-  });
-});
-
-describe("isTransientImageBuildError", () => {
-  it("matches the Docker Hub outage signatures seen in CI", () => {
-    // Verbatim (truncated) stderr from run 29926252232 — the same blip failed
-    // jobs at three different stages of the base-image pull.
-    expect(
-      isTransientImageBuildError(
-        "ERROR: failed to build: failed to solve: node:22-slim: failed to resolve source metadata for docker.io/library/node:22-slim: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/22-slim: 502 Bad Gateway",
-      ),
-    ).toBe(true);
-    expect(
-      isTransientImageBuildError(
-        "#3 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/node/blobs/sha256:bd16: 502 Bad Gateway",
-      ),
-    ).toBe(true);
-    expect(
-      isTransientImageBuildError(
-        "#3 ERROR: failed to authorize: failed to fetch oauth token: unexpected status from POST request to https://auth.docker.io/token: 502 Bad Gateway: error code: 502",
-      ),
-    ).toBe(true);
-  });
-
-  it("matches rate limits and common network failures", () => {
-    expect(
-      isTransientImageBuildError(
-        "unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/22-slim: 429 Too Many Requests",
-      ),
-    ).toBe(true);
-    expect(isTransientImageBuildError("read tcp 1.2.3.4: i/o timeout")).toBe(true);
-    expect(isTransientImageBuildError("net/http: TLS handshake timeout")).toBe(true);
-    expect(isTransientImageBuildError("connection reset by peer")).toBe(true);
-  });
-
-  it("does not match deterministic build failures", () => {
-    expect(
-      isTransientImageBuildError(
-        "ERROR: failed to build: dockerfile parse error on line 5: unknown instruction: FORM",
-      ),
-    ).toBe(false);
-    expect(
-      isTransientImageBuildError(
-        'ERROR: process "/bin/sh -c apt-get install nonexistent-package" did not complete successfully: exit code: 100',
-      ),
-    ).toBe(false);
-    expect(
-      isTransientImageBuildError(
-        "unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/22-slim: 401 Unauthorized",
-      ),
-    ).toBe(false);
   });
 });
 

--- a/packages/sandbox/test/unit.test.ts
+++ b/packages/sandbox/test/unit.test.ts
@@ -12,6 +12,7 @@ import {
   buildServiceWrapperScript,
   buildSupabaseStartCommand,
   computeExcludedServices,
+  isTransientImageBuildError,
 } from "../src/supabase.js";
 import {
   SKILLS_CLI_VERSION,
@@ -44,6 +45,57 @@ describe("sandbox Dockerfile", () => {
   it("pins the Supabase CLI version installed at setup time", () => {
     // The pin moved out of the Dockerfile into installSupabaseCli.
     expect(SUPABASE_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+describe("isTransientImageBuildError", () => {
+  it("matches the Docker Hub outage signatures seen in CI", () => {
+    // Verbatim (truncated) stderr from run 29926252232 — the same blip failed
+    // jobs at three different stages of the base-image pull.
+    expect(
+      isTransientImageBuildError(
+        "ERROR: failed to build: failed to solve: node:22-slim: failed to resolve source metadata for docker.io/library/node:22-slim: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/22-slim: 502 Bad Gateway",
+      ),
+    ).toBe(true);
+    expect(
+      isTransientImageBuildError(
+        "#3 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/node/blobs/sha256:bd16: 502 Bad Gateway",
+      ),
+    ).toBe(true);
+    expect(
+      isTransientImageBuildError(
+        "#3 ERROR: failed to authorize: failed to fetch oauth token: unexpected status from POST request to https://auth.docker.io/token: 502 Bad Gateway: error code: 502",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches rate limits and common network failures", () => {
+    expect(
+      isTransientImageBuildError(
+        "unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/22-slim: 429 Too Many Requests",
+      ),
+    ).toBe(true);
+    expect(isTransientImageBuildError("read tcp 1.2.3.4: i/o timeout")).toBe(true);
+    expect(isTransientImageBuildError("net/http: TLS handshake timeout")).toBe(true);
+    expect(isTransientImageBuildError("connection reset by peer")).toBe(true);
+  });
+
+  it("does not match deterministic build failures", () => {
+    expect(
+      isTransientImageBuildError(
+        "ERROR: failed to build: dockerfile parse error on line 5: unknown instruction: FORM",
+      ),
+    ).toBe(false);
+    expect(
+      isTransientImageBuildError(
+        'ERROR: process "/bin/sh -c apt-get install nonexistent-package" did not complete successfully: exit code: 100',
+      ),
+    ).toBe(false);
+    expect(
+      isTransientImageBuildError(
+        "unexpected status from HEAD request to https://registry-1.docker.io/v2/library/node/manifests/22-slim: 401 Unauthorized",
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
Currently, eval CI jobs fail whenever Docker Hub has a blip: during [this run](https://github.com/supabase/evals/actions/runs/29926252232) Docker Hub returned 502 and 7 jobs failed. e.g. [this job](https://github.com/supabase/evals/actions/runs/29926252232/job/88944704724):

This PR adds a retry with backoff system (5s/30s/60s) that should prevent run failures caused by transient Docker Hub outages/rate limits. Every build failure is retried — the registry-error strings come from BuildKit/containerd internals with no stable taxonomy to classify against, so a deterministic failure just wastes the ~95s schedule before failing.