### PR TITLE
fix: publish scheduled regression results via PR

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -451,7 +451,7 @@ jobs:
           delete-branch: true
 
       - name: Merge scheduled results pull request
-        # No checks or reviews to wait on, so merge right away.
+        # The app is on the ruleset's bypass list, so no review is required.
         if: github.event_name == 'schedule' && steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -403,10 +403,11 @@ jobs:
 
       - name: Commit exported results to branch
         # PR runs commit to the PR head branch. Manual dispatch commits to the
-        # selected branch only when commit_to_branch is enabled.
+        # selected branch only when commit_to_branch is enabled. Scheduled runs
+        # go through a PR instead (see "Create results pull request" below):
+        # main's branch protection rejects a direct push.
         if: >-
           github.event_name == 'pull_request' ||
-          github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.commit_to_branch)
         shell: bash
         run: |
@@ -429,17 +430,35 @@ jobs:
           git push
 
       - name: Create results pull request
-        if: github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch
+        if: >-
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && !inputs.commit_to_branch)
+        id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
           add-paths: apps/web/src/data/*eval-results.json
           # Per-base head branch so a branch refresh PR can't collide with main's.
-          branch: chore/refresh-eval-results-${{ github.ref_name }}
+          # Scheduled runs always target main, so scope by run number instead.
+          branch: >-
+            ${{ github.event_name == 'schedule' &&
+              format('chore/refresh-regression-results-{0}', github.run_number) ||
+              format('chore/refresh-eval-results-{0}', github.ref_name) }}
           base: ${{ github.ref_name }}
           commit-message: "chore: refresh eval results"
           title: "chore: refresh eval results"
           body: |
             Refreshes `apps/web/src/data/eval-results.json` from the latest automated eval run.
-          draft: true
+          # Draft PRs can't be merged, and the scheduled path needs to merge
+          # unattended (branch protection requires a PR, not a review, and the
+          # bot is a bypass actor for the review/approval gate).
+          draft: ${{ github.event_name != 'schedule' }}
           delete-branch: true
+
+      - name: Merge scheduled results pull request
+        # Merge immediately rather than GitHub's built-in auto-merge: the bot
+        # bypasses the review gate outright, so there's nothing to wait on.
+        if: github.event_name == 'schedule' && steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --squash --delete-branch

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -438,20 +438,15 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           add-paths: apps/web/src/data/*eval-results.json
-          # Per-base head branch so a branch refresh PR can't collide with main's.
-          # Scheduled runs always target main, so scope by run number instead.
-          branch: >-
-            ${{ github.event_name == 'schedule' &&
-              format('chore/refresh-regression-results-{0}', github.run_number) ||
-              format('chore/refresh-eval-results-{0}', github.ref_name) }}
+          # Per-ref-and-event head branch so a branch refresh PR can't collide
+          # with another ref's, or with the scheduled run's.
+          branch: chore/refresh-eval-results-${{ github.ref_name }}-${{ github.event_name }}
           base: ${{ github.ref_name }}
           commit-message: "chore: refresh eval results"
           title: "chore: refresh eval results"
           body: |
             Refreshes `apps/web/src/data/eval-results.json` from the latest automated eval run.
-          # Draft PRs can't be merged, and the scheduled path needs to merge
-          # unattended (branch protection requires a PR, not a review, and the
-          # bot is a bypass actor for the review/approval gate).
+          # Draft PRs can't be merged, and the scheduled path merges itself.
           draft: ${{ github.event_name != 'schedule' }}
           delete-branch: true
 

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -451,8 +451,7 @@ jobs:
           delete-branch: true
 
       - name: Merge scheduled results pull request
-        # Merge immediately rather than GitHub's built-in auto-merge: the bot
-        # bypasses the review gate outright, so there's nothing to wait on.
+        # No checks or reviews to wait on, so merge right away.
         if: github.event_name == 'schedule' && steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Switches the refresh workflow path for scheduled regression runs to open a PR and merge it immediately instead of pushing `regression-eval-results.json` directly to `main`. Every scheduled run has failed since 2026-07-15 with `GH013: Repository rule violations found ... Changes must be made through a pull request.`, see [example run](https://github.com/supabase/evals/actions/runs/29899091698/job/88857727833).

This works around the default org-wide ruleset requiring changes be made via PRs. The `supabase-evals-releaser` app is already added as a bypass actor on the review/approval gate so it should be able to merge unattended. If there's a conflict for whatever reason, the `publish-results` step will fail.

<img width="1974" height="376" alt="CleanShot 2026-07-22 at 18 02 02@2x" src="https://github.com/user-attachments/assets/311909ea-3321-4e91-b029-2c30e5b14207" />


Ref AI-955
