### PR TITLE
fix: retry supabase start on transient registry errors

### DIFF
--- a/packages/sandbox/src/supabase.ts
+++ b/packages/sandbox/src/supabase.ts
@@ -29,15 +29,49 @@ export const SUPABASE_CLI_VERSION = '2.67.1';
 const SANDBOX_IMAGE_REPOSITORY = 'supabase-evals-sandbox';
 
 /**
- * Backoff schedule for retrying the sandbox image build. The build pulls
- * `node:22-slim` from Docker Hub, which intermittently answers 5xx/429 (and
- * once took out ~130 CI matrix jobs in a single blip); a short outage should
- * cost a delay, not the run. Every failure is retried — the transient
- * registry-error strings come from BuildKit/containerd internals with no
- * stable taxonomy to match against, and a deterministic failure (broken
- * Dockerfile, bad build-arg) merely wastes the ~95s schedule before failing.
+ * Backoff schedule for the registry-touching steps: the sandbox image build
+ * (pulls `node:22-slim`) and `supabase start` (pulls the stack's service
+ * images). Docker Hub intermittently answers 5xx/429 — a 502 blip once took
+ * out ~130 CI matrix jobs, and a wide `run-evals` fan-out can exhaust the
+ * runners' shared anonymous pull quota (`toomanyrequests`) all by itself. A
+ * short outage should cost a delay, not the run. Every failure is retried —
+ * the transient registry-error strings come from BuildKit/containerd/daemon
+ * internals with no stable taxonomy to match against, and a deterministic
+ * failure (broken Dockerfile, bad config) merely wastes the ~95s schedule
+ * before failing with the original error.
  */
-const IMAGE_BUILD_RETRY_DELAYS_MS = [5_000, 30_000, 60_000];
+const REGISTRY_RETRY_DELAYS_MS = [5_000, 30_000, 60_000];
+
+/**
+ * Run a registry-touching step to completion, retrying failed attempts on
+ * {@link REGISTRY_RETRY_DELAYS_MS} and returning the first ok result. On the
+ * final failure the call site's `buildError` is thrown, preserving each
+ * step's established error shape. `beforeRetry` runs between attempts for
+ * steps that must reset partial state first.
+ */
+async function withRegistryRetries<R extends { ok: boolean }>(
+  label: string,
+  run: () => Promise<R>,
+  options: {
+    buildError: (result: R) => Error;
+    beforeRetry?: () => Promise<void>;
+  }
+): Promise<R> {
+  for (let attempt = 0; ; attempt++) {
+    const result = await run();
+    if (result.ok) return result;
+
+    const delayMs = REGISTRY_RETRY_DELAYS_MS[attempt];
+    if (delayMs === undefined) throw options.buildError(result);
+    console.warn(
+      `[sandbox] ${label} failed ` +
+        `(attempt ${attempt + 1}/${REGISTRY_RETRY_DELAYS_MS.length + 1}), ` +
+        `retrying in ${delayMs / 1000}s`
+    );
+    await options.beforeRetry?.();
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
 
 /** The sandbox image definition lives in an actual Dockerfile for editability. */
 export const SANDBOX_DOCKERFILE_PATH = fileURLToPath(
@@ -58,31 +92,26 @@ export async function ensureSupabaseSandboxImage(): Promise<string> {
   if (existing.ok) return tag;
 
   const dockerfile = readFileSync(SANDBOX_DOCKERFILE_PATH, 'utf8');
-  for (let attempt = 0; ; attempt++) {
-    const build = await dockerCli(
-      [
-        'build',
-        '--build-arg',
-        `SKILLS_CLI_VERSION=${SKILLS_CLI_VERSION}`,
-        '--tag',
-        tag,
-        '-',
-      ],
-      { input: dockerfile }
-    );
-    if (build.ok) return tag;
-
-    const delayMs = IMAGE_BUILD_RETRY_DELAYS_MS[attempt];
-    if (delayMs === undefined) {
-      throw new Error(`failed to build sandbox image ${tag}: ${build.stderr}`);
+  await withRegistryRetries(
+    `build ${tag}`,
+    () =>
+      dockerCli(
+        [
+          'build',
+          '--build-arg',
+          `SKILLS_CLI_VERSION=${SKILLS_CLI_VERSION}`,
+          '--tag',
+          tag,
+          '-',
+        ],
+        { input: dockerfile }
+      ),
+    {
+      buildError: (build) =>
+        new Error(`failed to build sandbox image ${tag}: ${build.stderr}`),
     }
-    console.warn(
-      `[sandbox] failed to build ${tag} ` +
-        `(attempt ${attempt + 1}/${IMAGE_BUILD_RETRY_DELAYS_MS.length + 1}), ` +
-        `retrying in ${delayMs / 1000}s`
-    );
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
+  );
+  return tag;
 }
 
 /**
@@ -319,16 +348,35 @@ async function linkSandboxToHostedPlatform(
 /**
  * Start the local Supabase stack, excluding the services the session does not
  * need. Requires a workspace with supabase/config.toml.
+ *
+ * Retried on the shared registry backoff schedule: `supabase start` pulls the
+ * stack's service images, so it fails on the same transient Docker Hub
+ * 5xx/429s as the image build.
  */
 export async function startSupabaseProject(
   sandbox: DockerSandbox,
   includeServices?: readonly string[]
 ): Promise<void> {
-  await runOrThrow(
-    sandbox,
-    buildSupabaseStartCommand(includeServices),
-    'supabase start'
-  );
+  const command = buildSupabaseStartCommand(includeServices);
+  await withRegistryRetries('supabase start', () => sandbox.runShell(command), {
+    buildError: (result) =>
+      new Error(`[supabase start] failed: ${result.stderr || result.stdout}`),
+    // A failed start can leave a partial stack behind (some services pulled
+    // and running, others not); reset it so retries start clean. Best-effort,
+    // mirroring teardownSupabaseProject.
+    beforeRetry: async () => {
+      try {
+        await sandbox.runShell('supabase stop --no-backup', {
+          timeoutMs: 120_000,
+        });
+      } catch (err) {
+        console.warn(
+          '[sandbox] supabase stop between start retries failed (continuing):',
+          err instanceof Error ? err.message : err
+        );
+      }
+    },
+  });
 }
 
 /** `supabase start`, with the exclude flag when an include list is given. */

--- a/packages/sandbox/src/supabase.ts
+++ b/packages/sandbox/src/supabase.ts
@@ -43,18 +43,26 @@ const SANDBOX_IMAGE_REPOSITORY = 'supabase-evals-sandbox';
 const REGISTRY_RETRY_DELAYS_MS = [5_000, 30_000, 60_000];
 
 /**
- * Run a registry-touching step to completion, retrying failed attempts on
+ * Run a failure-prone step to completion, retrying failed attempts on
  * {@link REGISTRY_RETRY_DELAYS_MS} and returning the first ok result. On the
  * final failure the call site's `buildError` is thrown, preserving each
  * step's established error shape. `beforeRetry` runs between attempts for
  * steps that must reset partial state first.
+ *
+ * The name is deliberately generic: the schedule was sized for transient
+ * registry errors, but the helper retries *every* non-ok result, not just
+ * registry ones. A caller that can distinguish a terminal failure it should
+ * not keep re-running (e.g. a local-stack timeout, not a Docker Hub blip)
+ * passes `isTerminal` to bail out immediately instead of burning the whole
+ * backoff schedule on it.
  */
-async function withRegistryRetries<R extends { ok: boolean }>(
+async function withTransientRetries<R extends { ok: boolean }>(
   label: string,
   run: () => Promise<R>,
   options: {
     buildError: (result: R) => Error;
     beforeRetry?: () => Promise<void>;
+    isTerminal?: (result: R) => boolean;
   }
 ): Promise<R> {
   for (let attempt = 0; ; attempt++) {
@@ -62,14 +70,24 @@ async function withRegistryRetries<R extends { ok: boolean }>(
     if (result.ok) return result;
 
     const delayMs = REGISTRY_RETRY_DELAYS_MS[attempt];
-    if (delayMs === undefined) throw options.buildError(result);
+    if (delayMs === undefined || options.isTerminal?.(result)) {
+      throw options.buildError(result);
+    }
     console.warn(
       `[sandbox] ${label} failed ` +
         `(attempt ${attempt + 1}/${REGISTRY_RETRY_DELAYS_MS.length + 1}), ` +
         `retrying in ${delayMs / 1000}s`
     );
+    // Count `beforeRetry` against the backoff so the "retrying in Ns" above
+    // holds regardless of how long the reset (e.g. `supabase stop`) takes:
+    // the next attempt starts ~delayMs after this failure, not delayMs after
+    // the reset finishes.
+    const readyAt = Date.now() + delayMs;
     await options.beforeRetry?.();
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    const remainingMs = readyAt - Date.now();
+    if (remainingMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, remainingMs));
+    }
   }
 }
 
@@ -92,7 +110,7 @@ export async function ensureSupabaseSandboxImage(): Promise<string> {
   if (existing.ok) return tag;
 
   const dockerfile = readFileSync(SANDBOX_DOCKERFILE_PATH, 'utf8');
-  await withRegistryRetries(
+  await withTransientRetries(
     `build ${tag}`,
     () =>
       dockerCli(
@@ -351,32 +369,45 @@ async function linkSandboxToHostedPlatform(
  *
  * Retried on the shared registry backoff schedule: `supabase start` pulls the
  * stack's service images, so it fails on the same transient Docker Hub
- * 5xx/429s as the image build.
+ * 5xx/429s as the image build. A local-stack *timeout* is exempt (see
+ * `isTerminal`): it points at a wedged service, not a registry blip, so
+ * re-running it would just burn ~10 minutes per attempt (the CLI's own boot
+ * timeout) for nothing.
  */
 export async function startSupabaseProject(
   sandbox: DockerSandbox,
   includeServices?: readonly string[]
 ): Promise<void> {
   const command = buildSupabaseStartCommand(includeServices);
-  await withRegistryRetries('supabase start', () => sandbox.runShell(command), {
-    buildError: (result) =>
-      new Error(`[supabase start] failed: ${result.stderr || result.stdout}`),
-    // A failed start can leave a partial stack behind (some services pulled
-    // and running, others not); reset it so retries start clean. Best-effort,
-    // mirroring teardownSupabaseProject.
-    beforeRetry: async () => {
-      try {
-        await sandbox.runShell('supabase stop --no-backup', {
-          timeoutMs: 120_000,
-        });
-      } catch (err) {
-        console.warn(
-          '[sandbox] supabase stop between start retries failed (continuing):',
-          err instanceof Error ? err.message : err
-        );
-      }
-    },
-  });
+  await withTransientRetries(
+    'supabase start',
+    () => sandbox.runShell(command),
+    {
+      buildError: (result) =>
+        new Error(`[supabase start] failed: ${result.stderr || result.stdout}`),
+      // A boot timeout (coreutils `timeout` exits 124/137) means a service is
+      // wedged, not that a pull blipped — don't retry it. Each retry would wait
+      // out the full boot timeout again, so a persistently unhealthy stack could
+      // waste the whole backoff schedule (~47 min) before surfacing the failure.
+      isTerminal: (result) =>
+        result.exitCode === 124 || result.exitCode === 137,
+      // A failed start can leave a partial stack behind (some services pulled
+      // and running, others not); reset it so retries start clean. Best-effort,
+      // mirroring teardownSupabaseProject.
+      beforeRetry: async () => {
+        try {
+          await sandbox.runShell('supabase stop --no-backup', {
+            timeoutMs: 120_000,
+          });
+        } catch (err) {
+          console.warn(
+            '[sandbox] supabase stop between start retries failed (continuing):',
+            err instanceof Error ? err.message : err
+          );
+        }
+      },
+    }
+  );
 }
 
 /** `supabase start`, with the exclude flag when an include list is given. */

--- a/packages/sandbox/test/unit.test.ts
+++ b/packages/sandbox/test/unit.test.ts
@@ -196,9 +196,20 @@ describe('startSupabaseProject retries', () => {
     stderr:
       'failed to pull docker image: Error response from daemon: toomanyrequests: Rate exceeded',
   };
+  // A local-stack boot timeout: coreutils `timeout` exits 124 (TERM) or 137
+  // (KILL escalation). Points at a wedged service, not a registry blip.
+  const bootTimeout = {
+    ok: false,
+    exitCode: 124,
+    stdout: '',
+    stderr: 'starting...\n[command timed out after 600s and was terminated]',
+  };
 
-  /** A sandbox whose `supabase start` fails `failures` times, then succeeds. */
-  function fakeSandbox(failures: number) {
+  /**
+   * A sandbox whose `supabase start` returns `startResult` for the first
+   * `failures` starts, then succeeds. `failures` of Infinity fails forever.
+   */
+  function fakeSandbox(failures: number, startResult = pullLimited) {
     const commands: string[] = [];
     const sandbox = {
       runShell: async (command: string) => {
@@ -207,7 +218,7 @@ describe('startSupabaseProject retries', () => {
         const startsSoFar = commands.filter((c) =>
           c.startsWith('supabase start')
         ).length;
-        return startsSoFar <= failures ? pullLimited : ok;
+        return startsSoFar <= failures ? startResult : ok;
       },
     } as unknown as DockerSandbox;
     return { sandbox, commands };
@@ -261,6 +272,21 @@ describe('startSupabaseProject retries', () => {
     expect(
       commands.filter((c) => c === 'supabase stop --no-backup')
     ).toHaveLength(3);
+  });
+
+  it('does not retry a local-stack boot timeout', async () => {
+    const { sandbox, commands } = fakeSandbox(
+      Number.POSITIVE_INFINITY,
+      bootTimeout
+    );
+
+    await expect(startSupabaseProject(sandbox)).rejects.toThrow(
+      '[supabase start] failed:'
+    );
+    // A timeout means a service is wedged; re-running would waste the full
+    // boot timeout again, so it fails after the very first attempt with no
+    // stop/retry in between.
+    expect(commands).toEqual(['supabase start']);
   });
 });
 

--- a/packages/sandbox/test/unit.test.ts
+++ b/packages/sandbox/test/unit.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { parseEvalMarkdown } from '@supabase-evals/core/eval-markdown';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   resolveSandboxPath,
   truncateOutput,
@@ -12,7 +12,9 @@ import {
   buildServiceWrapperScript,
   buildSupabaseStartCommand,
   computeExcludedServices,
+  startSupabaseProject,
 } from '../src/supabase.js';
+import type { DockerSandbox } from '../src/docker-sandbox.js';
 import {
   SKILLS_CLI_VERSION,
   SKILLS_INSTALL_DIR,
@@ -182,6 +184,83 @@ describe('buildSupabaseStartCommand', () => {
     expect(excluded).not.toContain('kong');
     expect(excluded).not.toContain('postgrest');
     expect(excluded).toHaveLength(ALL_SUPABASE_SERVICES.length - 2);
+  });
+});
+
+describe('startSupabaseProject retries', () => {
+  const ok = { ok: true, exitCode: 0, stdout: '', stderr: '' };
+  const pullLimited = {
+    ok: false,
+    exitCode: 1,
+    stdout: '',
+    stderr:
+      'failed to pull docker image: Error response from daemon: toomanyrequests: Rate exceeded',
+  };
+
+  /** A sandbox whose `supabase start` fails `failures` times, then succeeds. */
+  function fakeSandbox(failures: number) {
+    const commands: string[] = [];
+    const sandbox = {
+      runShell: async (command: string) => {
+        commands.push(command);
+        if (!command.startsWith('supabase start')) return ok;
+        const startsSoFar = commands.filter((c) =>
+          c.startsWith('supabase start')
+        ).length;
+        return startsSoFar <= failures ? pullLimited : ok;
+      },
+    } as unknown as DockerSandbox;
+    return { sandbox, commands };
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns without retrying when the first start succeeds', async () => {
+    const { sandbox, commands } = fakeSandbox(0);
+    await startSupabaseProject(sandbox);
+    expect(commands).toEqual(['supabase start']);
+  });
+
+  it('stops the partial stack and retries on a transient pull failure', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { sandbox, commands } = fakeSandbox(1);
+
+    const started = startSupabaseProject(sandbox);
+    await vi.runAllTimersAsync();
+    await started;
+
+    expect(commands).toEqual([
+      'supabase start',
+      'supabase stop --no-backup',
+      'supabase start',
+    ]);
+  });
+
+  it('throws the original error once the backoff schedule is exhausted', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { sandbox, commands } = fakeSandbox(Number.POSITIVE_INFINITY);
+
+    const started = startSupabaseProject(sandbox);
+    // Surface the rejection before asserting so the timer loop can't race it.
+    const outcome = started.catch((err: unknown) => err);
+    await vi.runAllTimersAsync();
+    const err = await outcome;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('[supabase start] failed:');
+    expect((err as Error).message).toContain('toomanyrequests');
+    // 1 initial + 3 retries, with a stop between each pair of starts.
+    expect(commands.filter((c) => c.startsWith('supabase start'))).toHaveLength(
+      4
+    );
+    expect(
+      commands.filter((c) => c === 'supabase stop --no-backup')
+    ).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
Currently, eval CI jobs fail whenever `supabase start` hits a Docker Hub blip: during [this run](https://github.com/supabase/evals/actions/runs/30100969319), [this job](https://github.com/supabase/evals/actions/runs/30100969319/job/89507112649) failed pulling the stack's service images (`toomanyrequests: Rate exceeded`)

#103 made the sandbox image build retry these errors, but `supabase start`, which pulls far more images, still failed on the first one.

This PR extends the same retry-with-backoff system (5s/30s/60s) to `supabase start`, so a transient registry error costs a delay instead of the run.