### PR TITLE
feat: serve web app under /evals base path

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD .",
+  "trailingSlash": false,
   "rewrites": [
     { "source": "/evals", "destination": "/" },
     { "source": "/evals/:path*", "destination": "/:path*" }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD ."
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD .",
+  "rewrites": [
+    { "source": "/evals", "destination": "/" },
+    { "source": "/evals/:path*", "destination": "/:path*" }
+  ]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,14 +4,14 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => ({
-  // Serve under /evals in production so the app works behind the
-  // supabase.com/evals rewrite (AI-826). Dev stays at the root.
-  base: mode === "production" ? "/evals/" : "/",
+export default defineConfig({
+  // Serve under /evals so the app works behind the supabase.com/evals
+  // rewrite (AI-826). The dev server redirects / to /evals/.
+  base: "/evals/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
   },
-}))
+})

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,11 +4,14 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  // Serve under /evals in production so the app works behind the
+  // supabase.com/evals rewrite (AI-826). Dev stays at the root.
+  base: mode === "production" ? "/evals/" : "/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
   },
-})
+}))

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,8 +5,7 @@ import { defineConfig } from "vite"
 
 // https://vite.dev/config/
 export default defineConfig({
-  // Serve under /evals so the app works behind the supabase.com/evals
-  // rewrite (AI-826). The dev server redirects / to /evals/.
+  // The app is served at supabase.com/evals
   base: "/evals/",
   plugins: [react(), tailwindcss()],
   resolve: {


### PR DESCRIPTION
Prep for serving the frontend at `supabase.com/evals` via a `www` rewrite.

Builds now use a `/evals/` base path.

E.g. before:

```html
<script src="/assets/index.js">
```
after:
```html
<script src="/evals/assets/index.js">
```

That way when the client tries accessing these resources from `supabase.com/evals` they don't mistakenly resolve to `supabase.com/assets/index.js`

`vercel.json` rewrites keep the app working at both `/` and `/evals` on our `*.vercel.app` domains (including preview deployments).

Dev server serves at `/evals/` too and redirects bare `localhost:5173` there. `trailingSlash: false` redirects `/evals/` to `/evals`, matching how supabase.com already handles trailing slashes.

<img width="364" height="111" alt="CleanShot 2026-07-24 at 16 20 35@2x" src="https://github.com/user-attachments/assets/1f2053b2-0b8b-40ae-b8e6-ca0201ae61ba" />
<img width="541" height="161" alt="CleanShot 2026-07-24 at 16 20 37@2x" src="https://github.com/user-attachments/assets/051fac3c-2d7f-490d-be8d-06ce9635c9fa" />

Verified the following paths work on preview:

- https://evals-git-feat-evals-base-path-supabase.vercel.app
- https://evals-git-feat-evals-base-path-supabase.vercel.app/
- https://evals-git-feat-evals-base-path-supabase.vercel.app/evals
- https://evals-git-feat-evals-base-path-supabase.vercel.app/evals/


Ref AI-826
