### PR TITLE
Tune supabase-postgres-best-practices activation

### DIFF
--- a/packages/core/src/agents/claude-code/parser.test.ts
+++ b/packages/core/src/agents/claude-code/parser.test.ts
@@ -140,9 +140,9 @@ describe('claudeCodeParser', () => {
     const adapted = adaptTranscript(
       claudeCodeParser.parseTranscript(transcript).events
     );
-    expect(adapted.toolCalls[0].loadedSkill).toBe(
-      'supabase-postgres-best-practices'
-    );
+    expect(adapted.toolCalls[0].loadedSkills).toEqual([
+      'supabase-postgres-best-practices',
+    ]);
   });
 
   it('still emits the result text when it was never streamed as a message', () => {

--- a/packages/core/src/agents/claude-code/parser.ts
+++ b/packages/core/src/agents/claude-code/parser.ts
@@ -23,7 +23,7 @@ import {
 } from '../../parsers/shared/normalize.js';
 import {
   extractArgs,
-  extractLoadedSkillFromText,
+  extractLoadedSkillsFromText,
   type ArgFieldMap,
 } from '../../parsers/shared/extract.js';
 
@@ -148,20 +148,21 @@ function enrich(event: TranscriptEvent): TranscriptEvent {
   if (path) event.tool.path = path;
   if (command) event.tool.command = command;
   if (url) event.tool.url = url;
-  event.tool.loadedSkill = loadedSkillFromClaudeCodeCall(event.tool);
+  const loadedSkills = loadedSkillsFromClaudeCodeCall(event.tool);
+  if (loadedSkills.length > 0) event.tool.loadedSkills = loadedSkills;
   return event;
 }
 
 /** Identifies Claude Code skill loads from tool-specific args or file reads. */
-function loadedSkillFromClaudeCodeCall(
+function loadedSkillsFromClaudeCodeCall(
   tool: NonNullable<TranscriptEvent['tool']>
-): string | undefined {
+): string[] {
   if (tool.originalName === 'Skill' && typeof tool.args?.skill === 'string') {
-    return tool.args.skill;
+    return [tool.args.skill];
   }
-  if (tool.path) return extractLoadedSkillFromText(tool.path);
-  if (tool.command) return extractLoadedSkillFromText(tool.command);
-  return undefined;
+  if (tool.path) return extractLoadedSkillsFromText(tool.path);
+  if (tool.command) return extractLoadedSkillsFromText(tool.command);
+  return [];
 }
 
 function recordToEvents(data: Record<string, unknown>): TranscriptEvent[] {

--- a/packages/core/src/agents/codex/parser.test.ts
+++ b/packages/core/src/agents/codex/parser.test.ts
@@ -124,7 +124,7 @@ describe('codexParser', () => {
     });
 
     const adapted = adaptTranscript(codexParser.parseTranscript(stream).events);
-    expect(adapted.toolCalls[0].loadedSkill).toBe('supabase');
+    expect(adapted.toolCalls[0].loadedSkills).toEqual(['supabase']);
   });
 
   it('marks a non-zero exit code as a failed shell call (error surfaced via adapter)', () => {

--- a/packages/core/src/agents/codex/parser.ts
+++ b/packages/core/src/agents/codex/parser.ts
@@ -30,7 +30,7 @@ import {
 } from '../../parsers/shared/normalize.js';
 import {
   extractArgs,
-  extractLoadedSkillFromText,
+  extractLoadedSkillsFromText,
   type ArgFieldMap,
   type ExtractedArgs,
 } from '../../parsers/shared/extract.js';
@@ -108,7 +108,8 @@ function toolCallPair(
   if (normalized.path) tool.path = normalized.path;
   if (normalized.command) tool.command = normalized.command;
   if (normalized.url) tool.url = normalized.url;
-  tool.loadedSkill = loadedSkillFromCodexCall(tool);
+  const loadedSkills = loadedSkillsFromCodexCall(tool);
+  if (loadedSkills.length > 0) tool.loadedSkills = loadedSkills;
   return [
     { type: 'tool_call', tool },
     { type: 'tool_result', tool: { name, originalName, id, result, success } },
@@ -116,12 +117,12 @@ function toolCallPair(
 }
 
 /** Identifies Codex skill loads from normalized file paths or shell commands. */
-function loadedSkillFromCodexCall(
+function loadedSkillsFromCodexCall(
   tool: NonNullable<TranscriptEvent['tool']>
-): string | undefined {
-  if (tool.path) return extractLoadedSkillFromText(tool.path);
-  if (tool.command) return extractLoadedSkillFromText(tool.command);
-  return undefined;
+): string[] {
+  if (tool.path) return extractLoadedSkillsFromText(tool.path);
+  if (tool.command) return extractLoadedSkillsFromText(tool.command);
+  return [];
 }
 
 function itemToEvents(item: Record<string, unknown>): TranscriptEvent[] {

--- a/packages/core/src/agents/opencode/parser.test.ts
+++ b/packages/core/src/agents/opencode/parser.test.ts
@@ -161,9 +161,9 @@ describe('opencodeParser', () => {
     const adapted = adaptTranscript(
       opencodeParser.parseTranscript(stream).events
     );
-    expect(adapted.toolCalls.map((call) => call.loadedSkill)).toEqual([
-      'supabase',
-      'supabase-postgres-best-practices',
+    expect(adapted.toolCalls.map((call) => call.loadedSkills)).toEqual([
+      ['supabase'],
+      ['supabase-postgres-best-practices'],
     ]);
   });
 

--- a/packages/core/src/agents/opencode/parser.ts
+++ b/packages/core/src/agents/opencode/parser.ts
@@ -32,7 +32,7 @@ import {
 } from '../../parsers/shared/normalize.js';
 import {
   extractArgs,
-  extractLoadedSkillFromText,
+  extractLoadedSkillsFromText,
   type ArgFieldMap,
   type ExtractedArgs,
 } from '../../parsers/shared/extract.js';
@@ -151,7 +151,8 @@ function partToEvents(
       if (normalized.path) tool.path = normalized.path;
       if (normalized.command) tool.command = normalized.command;
       if (normalized.url) tool.url = normalized.url;
-      tool.loadedSkill = loadedSkillFromOpencodeCall(tool);
+      const loadedSkills = loadedSkillsFromOpencodeCall(tool);
+      if (loadedSkills.length > 0) tool.loadedSkills = loadedSkills;
 
       const events: TranscriptEvent[] = [
         { timestamp, type: 'tool_call', tool, raw },
@@ -184,16 +185,16 @@ function partToEvents(
  * skill name in its args; skills read manually surface as `skills/<name>/
  * SKILL.md` in a file path or shell command.
  */
-function loadedSkillFromOpencodeCall(
+function loadedSkillsFromOpencodeCall(
   tool: NonNullable<TranscriptEvent['tool']>
-): string | undefined {
+): string[] {
   if (tool.originalName.toLowerCase() === 'skill') {
     const name = tool.args?.name ?? tool.args?.skill;
-    if (typeof name === 'string') return name;
+    if (typeof name === 'string') return [name];
   }
-  if (tool.path) return extractLoadedSkillFromText(tool.path);
-  if (tool.command) return extractLoadedSkillFromText(tool.command);
-  return undefined;
+  if (tool.path) return extractLoadedSkillsFromText(tool.path);
+  if (tool.command) return extractLoadedSkillsFromText(tool.command);
+  return [];
 }
 
 function recordToEvents(data: Record<string, unknown>): TranscriptEvent[] {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,8 +192,8 @@ export interface ToolCallRecord {
   url?: string;
   /** Canonical tool category, set by CLI agent parsers; unset for ai-sdk tools which have no normalization layer. */
   name?: ToolName;
-  /** Skill name loaded by this call, when the harness can identify one. */
-  loadedSkill?: string;
+  /** Skill names loaded by this call, when the harness can identify any. */
+  loadedSkills?: string[];
   result?: unknown;
   error?: string;
   ts: number;
@@ -654,10 +654,10 @@ export function aiSdkAgent(options: {
             const input = isRecord(event.toolCall.input)
               ? event.toolCall.input
               : {};
-            const loadedSkill =
+            const loadedSkills =
               event.toolCall.toolName === 'load_skill' &&
               typeof input.name === 'string'
-                ? input.name
+                ? [input.name]
                 : undefined;
             const command =
               event.toolCall.toolName.toLowerCase() === 'bash' &&
@@ -668,7 +668,7 @@ export function aiSdkAgent(options: {
               endpoint: event.toolCall.toolName,
               body: input,
               command,
-              loadedSkill,
+              loadedSkills,
               result: event.output,
               ts: Date.now(),
             });

--- a/packages/core/src/parsers/adapt.ts
+++ b/packages/core/src/parsers/adapt.ts
@@ -71,7 +71,7 @@ export function adaptTranscript(events: TranscriptEvent[]): AdaptedTranscript {
         path: event.tool.path,
         command: event.tool.command,
         url: event.tool.url,
-        loadedSkill: event.tool.loadedSkill,
+        loadedSkills: event.tool.loadedSkills,
         result: resolved?.error === undefined ? resolved?.result : undefined,
         error: resolved?.error,
         ts: parseTs(event.timestamp),

--- a/packages/core/src/parsers/shared/extract.ts
+++ b/packages/core/src/parsers/shared/extract.ts
@@ -27,8 +27,10 @@ export interface ExtractedArgs {
 }
 
 // Skill reads can appear as bare paths or quoted shell args in tool-call logs.
+// Boundaries are lookarounds (non-consuming) so one command mentioning several
+// SKILL.md paths — e.g. a single `cat` of two skills — yields every skill.
 const SKILL_ENTRYPOINT_PATTERN =
-  /(?:^|[\s"'`])\S*skills\/([^\s"'`/]+)\/SKILL\.md(?:$|[\s"'`])/;
+  /(?<=^|[\s"'`])\S*skills\/([^\s"'`/]+)\/SKILL\.md(?=$|[\s"'`])/g;
 
 /**
  * First arg value among `keys` that is a string — or a string[] joined with
@@ -64,8 +66,11 @@ export function extractArgs(
   };
 }
 
-/** Extracts the loaded skill name from a SKILL.md path mention. */
-export function extractLoadedSkillFromText(text: string): string | undefined {
-  const match = SKILL_ENTRYPOINT_PATTERN.exec(text);
-  return match?.[1];
+/** Extracts every loaded skill name from SKILL.md path mentions. */
+export function extractLoadedSkillsFromText(text: string): string[] {
+  const names = new Set<string>();
+  for (const match of text.matchAll(SKILL_ENTRYPOINT_PATTERN)) {
+    names.add(match[1]);
+  }
+  return [...names];
 }

--- a/packages/core/src/parsers/shared/skills.test.ts
+++ b/packages/core/src/parsers/shared/skills.test.ts
@@ -1,24 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { extractLoadedSkillFromText } from './extract.js';
+import { extractLoadedSkillsFromText } from './extract.js';
 
-describe('extractLoadedSkillFromText', () => {
+describe('extractLoadedSkillsFromText', () => {
   it('extracts skill names from SKILL.md path mentions', () => {
     expect(
-      extractLoadedSkillFromText(
+      extractLoadedSkillsFromText(
         `/bin/zsh -lc "sed -n '1,220p' .agents/skills/supabase/SKILL.md"`
       )
-    ).toBe('supabase');
+    ).toEqual(['supabase']);
 
     expect(
-      extractLoadedSkillFromText(
+      extractLoadedSkillsFromText(
         '/tmp/sandbox/.claude/skills/supabase-postgres-best-practices/SKILL.md'
       )
-    ).toBe('supabase-postgres-best-practices');
+    ).toEqual(['supabase-postgres-best-practices']);
+  });
+
+  it('extracts every skill when one command reads several SKILL.md files', () => {
+    expect(
+      extractLoadedSkillsFromText(
+        'cat .claude/skills/supabase/SKILL.md 2>/dev/null; echo "---"; cat .claude/skills/supabase-postgres-best-practices/SKILL.md 2>/dev/null'
+      )
+    ).toEqual(['supabase', 'supabase-postgres-best-practices']);
+  });
+
+  it('extracts adjacent paths in a single cat command', () => {
+    expect(
+      extractLoadedSkillsFromText(
+        'cat .claude/skills/supabase/SKILL.md .claude/skills/supabase-postgres-best-practices/SKILL.md'
+      )
+    ).toEqual(['supabase', 'supabase-postgres-best-practices']);
+  });
+
+  it('dedupes repeated mentions of the same skill', () => {
+    expect(
+      extractLoadedSkillsFromText(
+        'cat skills/supabase/SKILL.md && cat skills/supabase/SKILL.md'
+      )
+    ).toEqual(['supabase']);
   });
 
   it('ignores paths that do not end at the skill entrypoint', () => {
     expect(
-      extractLoadedSkillFromText('.agents/skills/supabase/references/auth.md')
-    ).toBeUndefined();
+      extractLoadedSkillsFromText('.agents/skills/supabase/references/auth.md')
+    ).toEqual([]);
   });
 });

--- a/packages/core/src/skill-results.test.ts
+++ b/packages/core/src/skill-results.test.ts
@@ -23,7 +23,7 @@ describe('buildSkillResult', () => {
     const result = buildSkillResult(available, [
       {
         ...toolCall('load_skill', { name: 'supabase' }),
-        loadedSkill: 'supabase',
+        loadedSkills: ['supabase'],
       },
     ]);
 
@@ -33,13 +33,30 @@ describe('buildSkillResult', () => {
     });
   });
 
+  it('tracks several skills loaded by one call', () => {
+    const result = buildSkillResult(available, [
+      {
+        ...toolCall('bash', {
+          command:
+            'cat .claude/skills/supabase/SKILL.md .claude/skills/supabase-postgres-best-practices/SKILL.md',
+        }),
+        loadedSkills: ['supabase', 'supabase-postgres-best-practices'],
+      },
+    ]);
+
+    expect(result).toEqual({
+      available,
+      loaded: ['supabase', 'supabase-postgres-best-practices'],
+    });
+  });
+
   it('ignores skills that were not available in the run', () => {
     const result = buildSkillResult(
       ['supabase'],
       [
         {
           ...toolCall('load_skill', { name: 'unknown-skill' }),
-          loadedSkill: 'unknown-skill',
+          loadedSkills: ['unknown-skill'],
         },
       ]
     );

--- a/packages/core/src/skill-results.ts
+++ b/packages/core/src/skill-results.ts
@@ -7,8 +7,10 @@ export function buildSkillResult(
   toolCalls: ToolCallRecord[]
 ): SkillResult {
   const loadedSkills = new Set<string>();
-  for (const { loadedSkill } of toolCalls) {
-    if (loadedSkill) loadedSkills.add(loadedSkill);
+  for (const call of toolCalls) {
+    for (const skill of call.loadedSkills ?? []) {
+      loadedSkills.add(skill);
+    }
   }
   const loaded = available.filter((skill) => loadedSkills.has(skill));
 

--- a/packages/core/src/transcript/types.ts
+++ b/packages/core/src/transcript/types.ts
@@ -61,8 +61,8 @@ export interface TranscriptEvent {
     path?: string;
     command?: string;
     url?: string;
-    /** Skill name loaded by this call, when the parser can identify one. */
-    loadedSkill?: string;
+    /** Skill names loaded by this call, when the parser can identify any. */
+    loadedSkills?: string[];
     /** Tool result payload (for `tool_result`). */
     result?: unknown;
     /** Whether the tool call succeeded (for `tool_result`). */


### PR DESCRIPTION
Tweak `supabase-postgres-best-practices` description to improve its activation on postgres heavy scenarios (see list [here](https://linear.app/supabase/issue/AI-942/tune-supabase-postgres-best-practices-activation#which-scenarios-should-load-pg-best-practices-bebcc818).


## Test notes

Local sample, claude-code-sonnet-5 + codex-gpt-5.4-mini, new description:

| Eval | Expect pg-bp | sonnet-5 | codex-5.4-mini |
|---|---|---|---|
| resolve-performance-001-slow-query-cpu-spike | yes | ✅ both (2/2 runs) | ✅ both |
| build-rls-003-org-roles-permissions | yes | ✅ both | — |
| resolve-security-002-rls-cross-tenant-leak | yes | supabase only (2/2) | ✅ both |
| investigate-realtime-001-subscribed-no-events | no | ✅ supabase only | both (mild over-trigger, passed 6/6) |
| investigate-logs-001-top-error-function | no | no skills — identical at baseline | — |

Part of [AI-942](https://linear.app/supabase/issue/AI-942/tune-supabase-postgres-best-practices-activation).