### PR TITLE
feat: bump Opus experiments to Claude Opus 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Run selected evals across multiple experiments:
 ```bash
 pnpm eval -- \
   --experiment claude-code-sonnet-5 \
-  --experiment claude-code-opus-4.8 \
+  --experiment claude-code-opus-5 \
   --eval resolve-dataapi-001-empty-results \
   --eval investigate-auth-001-deleted-user-access
 ```

--- a/experiments/claude-code-opus-5-no-skills.ts
+++ b/experiments/claude-code-opus-5-no-skills.ts
@@ -7,14 +7,14 @@ import {
 import { localStackRuntime } from '@supabase-evals/sandbox';
 
 export default defineExperiment({
-  suite: ['benchmark'],
+  suite: ['no-skills'],
   agent: claudeCodeAgent({
-    model: 'claude-opus-4-8',
+    model: 'claude-opus-5',
     reasoningEffort: 'high',
   }),
   runtime: platformLiteRuntime({
     mcpServers: [supabaseMcpServer()],
   }),
   localStack: localStackRuntime(),
-  skills: ['supabase', 'supabase-postgres-best-practices'],
+  skills: [],
 });

--- a/experiments/claude-code-opus-5.ts
+++ b/experiments/claude-code-opus-5.ts
@@ -7,14 +7,14 @@ import {
 import { localStackRuntime } from '@supabase-evals/sandbox';
 
 export default defineExperiment({
-  suite: ['no-skills'],
+  suite: ['benchmark'],
   agent: claudeCodeAgent({
-    model: 'claude-opus-4-8',
+    model: 'claude-opus-5',
     reasoningEffort: 'high',
   }),
   runtime: platformLiteRuntime({
     mcpServers: [supabaseMcpServer()],
   }),
   localStack: localStackRuntime(),
-  skills: [],
+  skills: ['supabase', 'supabase-postgres-best-practices'],
 });


### PR DESCRIPTION
Swaps the two Opus 4.8 experiments to [Opus 5](https://www.anthropic.com/news/claude-opus-5) and updates the matching README reference, mirroring the earlier [Sonnet 4.6 → Sonnet 5 bump](https://github.com/supabase/evals/pull/73).

According to [Claude models overview](https://platform.claude.com/docs/en/about-claude/models/overview) this is a stable ID:

> Every Claude model ID is a pinned snapshot. Models with a date in the ID (for example, 20250929) are fixed to that specific release. Starting with the Claude 4.6 generation, model IDs use a dateless format that is also a pinned snapshot, not an evergreen pointer

Pricing is unchanged from Opus 4.8 ($5/$25 per MTok), so this stays within the same GitHub Actions budget.

## Claude Code compatibility

Checked the [Claude Code changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) between our pinned CLI (`2.1.191`) and latest (`2.1.220`): no breaking changes to the `--output-format stream-json` transcript structure that `packages/core/src/agents/claude-code/parser.ts` depends on — only additive changes:
- `mcp_server_errors` on the init event in 2.1.219
-  opt-in `--forward-subagent-text` in 2.1.212. #137 adds support to capture subagents steps from the transcript

Claude Code added Opus 5 as its default Opus alias in 2.1.219, but the pinned 2.1.191 passes the explicit `claude-opus-5` ID through to the API fine (same as Sonnet 5 did in #73, which predated CLI-side Sonnet 5 support), so no CLI bump is needed.

Opus 5's only API breaking change vs 4.8 ([what's new](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5): `thinking: disabled` with effort `xhigh`/`max` now 400s) doesn't affect these experiments — they run `reasoningEffort: 'high'` with default thinking.

Note: `high` is also Claude Code's default effort for Opus 5 ([model config docs](https://code.claude.com/docs/en/model-config#adjust-effort-level).

## Testing

Sanity-checked `claude-code-opus-5` against `resolve-dataapi-001-empty-results`: **7/7 checks passed** (1 attempt, 230s, 43 tool calls, `stoppedReason: stop`, transcript parsed cleanly with skill-load detection working).

Closes AI-968
