### PR TITLE
Deep link into sheet

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,8 +25,8 @@ export function App() {
           <>
             <SiteHeader />
             <SiteHero />
-            {/* Pulled up so the table overlaps the hero's bottom edge. */}
-            <PageContainer className="relative z-20 -mt-10 pb-8 md:-mt-16 md:pb-10">
+            {/* Overlap the table with the hero while preserving its content spacing. */}
+            <PageContainer className="relative z-20 -mt-6 pb-8 md:-mt-8 md:pb-10">
               <ResultsTable
                 sourceResults={suiteResults}
                 groupBy={groupBy}

--- a/apps/web/src/components/results/results-table.tsx
+++ b/apps/web/src/components/results/results-table.tsx
@@ -19,6 +19,7 @@ import {
   DIMENSIONS,
   GROUP_BY_OPTIONS,
   dimensionShortTitle,
+  tableSelection,
   type Dimension,
   type GroupBy,
   type TableSelection,
@@ -115,8 +116,12 @@ export function ResultsTable({
   const [selection, setSelection] = useState<TableSelection | null>(null)
   const [hoveredColumn, setHoveredColumn] = useState<string | null>(null)
 
-  const select = (dimension: Dimension, key: string) => {
-    setSelection({ dimension: dimension.id, key })
+  const select = (
+    dimension: Dimension,
+    key: string,
+    cellRuns?: ParsedResult[]
+  ) => {
+    setSelection(tableSelection(dimension, key, cellRuns))
   }
 
   return (
@@ -242,23 +247,36 @@ export function ResultsTable({
                         </TableHeaderLabel>
                       </th>
                       {columnKeys.map((columnKey) => {
-                        const summary = scoreResults(
-                          columnDimension.filter(columnKey, rowResults)
+                        const cellRuns = columnDimension.filter(
+                          columnKey,
+                          rowResults
                         )
+                        const summary = scoreResults(cellRuns)
 
                         return (
                           <td
                             key={columnKey}
                             className={cn(
-                              "border-r border-b border-border px-2.5 py-2 transition-colors",
+                              "border-r border-b border-border p-0 transition-colors",
                               hoveredColumn === columnKey &&
                                 columnHighlightClassName
                             )}
                           >
-                            <ScoreCell
-                              passed={summary.passed}
-                              total={summary.total}
-                            />
+                            <button
+                              type="button"
+                              aria-label={`Open ${columnDimension.title(columnKey)} results for ${rowDimension.title(rowKey)}`}
+                              className="block w-full cursor-pointer px-2.5 py-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                select(rowDimension, rowKey, cellRuns)
+                              }}
+                              onKeyDown={(event) => event.stopPropagation()}
+                            >
+                              <ScoreCell
+                                passed={summary.passed}
+                                total={summary.total}
+                              />
+                            </button>
                           </td>
                         )
                       })}

--- a/apps/web/src/components/results/selection-sheet.tsx
+++ b/apps/web/src/components/results/selection-sheet.tsx
@@ -26,10 +26,6 @@ import {
 import { scoreResults, type ParsedResult } from "@/lib/eval-results"
 import { cn } from "@/lib/utils"
 
-function runKey(result: ParsedResult) {
-  return `${result.experiment}::${result.eval}`
-}
-
 /**
  * Detail view for a clicked row or column, listing the runs behind it. Every
  * axis the selection leaves open becomes a column, so a model selection lists
@@ -50,7 +46,9 @@ export function SelectionSheet({
   const orderedRuns = orderRuns(runs, columns, sourceResults)
   const { passed, total } = scoreResults(runs)
   const passRate = total ? Math.round((passed / total) * 100) : null
-  const [expandedRun, setExpandedRun] = useState<string | null>(null)
+  const [expandedRun, setExpandedRun] = useState<string | null>(
+    selection.expandedRun ?? null
+  )
 
   const toggleRun = (key: string) => {
     setExpandedRun((current) => (current === key ? null : key))
@@ -110,7 +108,7 @@ export function SelectionSheet({
             </thead>
             <tbody>
               {orderedRuns.map((run) => {
-                const key = runKey(run)
+                const key = run.sourcePath
                 const expanded = expandedRun === key
 
                 return (

--- a/apps/web/src/components/site-hero.tsx
+++ b/apps/web/src/components/site-hero.tsx
@@ -3,23 +3,23 @@ import { PageContainer } from "@/components/page-container"
 export function SiteHero() {
   return (
     <header className="border-b border-border">
-      <div className="w-full pt-24 pb-20 sm:pb-24 md:pb-28 lg:pb-28">
-        <PageContainer className="flex flex-col gap-10 md:gap-12 lg:flex-row lg:items-end lg:justify-between lg:gap-16">
-          <div className="flex max-w-2xl min-w-0 flex-col gap-8 sm:gap-10">
-            <h1 className="font-heading text-4xl font-medium tracking-normal sm:text-5xl sm:leading-none">
+      <PageContainer className="relative pt-12 pb-16 md:pt-40! md:pb-24">
+        <div className="flex flex-col gap-6 lg:gap-8">
+          <div className="grid grid-cols-1 items-end gap-4 lg:grid-cols-2">
+            <h1 className="font-heading text-3xl font-medium tracking-normal sm:text-5xl sm:leading-none">
               <span className="block text-foreground">Evaluating agents</span>
               <span className="block text-muted-foreground">
                 across Supabase
               </span>
             </h1>
+            <p className="text-sm text-muted-foreground lg:text-base">
+              We evaluate model experiments across the Supabase developer
+              journey, from building and deploying to investigating and
+              resolving production issues, with real project context.
+            </p>
           </div>
-          <p className="max-w-md text-base leading-6 text-pretty text-muted-foreground lg:flex-none lg:pb-1">
-            We evaluate model experiments across the Supabase developer journey,
-            from building and deploying to investigating and resolving
-            production issues, with real project context.
-          </p>
-        </PageContainer>
-      </div>
+        </div>
+      </PageContainer>
     </header>
   )
 }

--- a/apps/web/src/lib/dimensions.test.ts
+++ b/apps/web/src/lib/dimensions.test.ts
@@ -7,6 +7,7 @@ import {
   dimensionCell,
   dimensionShortTitle,
   orderRuns,
+  tableSelection,
   type GroupBy,
 } from "@/lib/dimensions"
 import { makeResult } from "@/lib/eval-results.fixture"
@@ -114,6 +115,40 @@ describe("dimensionShortTitle", () => {
 
   it("falls back to the full title for an axis with no compact form", () => {
     expect(dimensionShortTitle(DIMENSIONS.stage, "build")).toBe("Build")
+  })
+})
+
+describe("tableSelection", () => {
+  it("deep-links a score cell when its dimensions identify one run", () => {
+    const run = makeResult({
+      eval: "build-cli-001-bootstrap-app",
+      sourcePath: "claude-code-sonnet-5/build-cli-001-bootstrap-app.json",
+    })
+
+    expect(tableSelection(DIMENSIONS.eval, run.eval, [run])).toEqual({
+      dimension: "eval",
+      key: run.eval,
+      expandedRun: run.sourcePath,
+    })
+  })
+
+  it("leaves aggregate cells at the sheet level", () => {
+    const runs = [
+      makeResult({ eval: "a", sourcePath: "model/a.json" }),
+      makeResult({ eval: "b", sourcePath: "model/b.json" }),
+    ]
+
+    expect(tableSelection(DIMENSIONS.stage, "build", runs)).toEqual({
+      dimension: "stage",
+      key: "build",
+    })
+  })
+
+  it("leaves row and column selections at the sheet level", () => {
+    expect(tableSelection(DIMENSIONS.model, "model-a")).toEqual({
+      dimension: "model",
+      key: "model-a",
+    })
   })
 })
 

--- a/apps/web/src/lib/dimensions.ts
+++ b/apps/web/src/lib/dimensions.ts
@@ -24,8 +24,15 @@ import {
 
 export type GroupBy = "model" | "stage" | "product" | "eval"
 
-/** What the user clicked: a key on one of the axes, whichever axis it came from. */
-export type TableSelection = { dimension: GroupBy; key: string }
+/**
+ * What the user clicked: a key on one of the axes, whichever axis it came
+ * from, and optionally the single run identified by a score cell.
+ */
+export type TableSelection = {
+  dimension: GroupBy
+  key: string
+  expandedRun?: string
+}
 
 const experimentLabel = new Map(
   getVisibleExperiments(sortedResults).map((experiment) => [
@@ -160,6 +167,23 @@ export function dimensionCell(dimension: Dimension, result: ParsedResult) {
 
 export function dimensionShortTitle(dimension: Dimension, key: string) {
   return dimension.shortTitle?.(key) ?? dimension.title(key)
+}
+
+/**
+ * Builds a sheet selection from any table axis. A score cell only points all
+ * the way to a run when its row/column intersection is unambiguous; aggregate
+ * cells still open the row's complete sheet.
+ */
+export function tableSelection(
+  dimension: Dimension,
+  key: string,
+  cellRuns: ParsedResult[] = []
+): TableSelection {
+  return {
+    dimension: dimension.id,
+    key,
+    ...(cellRuns.length === 1 ? { expandedRun: cellRuns[0].sourcePath } : {}),
+  }
 }
 
 /**


### PR DESCRIPTION
Makes it so you can deep link into the detail sheet when clicking on cells. e.g. View evals grouping -> click a model cell -> see that model row expanded to show results.