### PR TITLE
feat: medium reasoning for GPT-5.6 Sol

### DIFF
--- a/experiments/codex-gpt-5.6-no-skills.ts
+++ b/experiments/codex-gpt-5.6-no-skills.ts
@@ -10,7 +10,7 @@ export default defineExperiment({
   suite: ['no-skills'],
   agent: codexAgent({
     model: 'gpt-5.6-sol',
-    reasoningEffort: 'low',
+    reasoningEffort: 'medium',
   }),
   runtime: platformLiteRuntime({
     mcpServers: [supabaseMcpServer()],

--- a/experiments/codex-gpt-5.6.ts
+++ b/experiments/codex-gpt-5.6.ts
@@ -10,7 +10,7 @@ export default defineExperiment({
   suite: ['benchmark'],
   agent: codexAgent({
     model: 'gpt-5.6-sol',
-    reasoningEffort: 'low',
+    reasoningEffort: 'medium',
   }),
   runtime: platformLiteRuntime({
     mcpServers: [supabaseMcpServer()],


### PR DESCRIPTION
Switches GPT-5.6 Sol experiment configs from `low` to `medium` reasoning to align with ChatGPT subscription default.

Sanity checked `codex-gpt-5.6` against `resolve-dataapi-001-empty-results` ran and passed 7/7 checks, and the result recorded `reasoningEffort: "medium"`.

Deferring the full matrix refresh since we'll be doing that before announcement anyways.

Closes AI-977
