### PR TITLE
feat(web): add posthog analytics

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
     "nuqs": "^2.9.2",
+    "posthog-js": "^1.408.1",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -3,6 +3,7 @@ import { CheckIcon, CopyIcon } from "lucide-react"
 
 import { PageContainer } from "@/components/page-container"
 import { Button } from "@/components/ui/button"
+import { track } from "@/lib/analytics"
 import { CLI_COMMAND, DOCS_URL, WEBSITE_URL } from "@/lib/links"
 
 const COPY_FEEDBACK_MS = 2000
@@ -72,6 +73,7 @@ function CopyCommandButton() {
 
   const copyCommand = () => {
     void navigator.clipboard.writeText(CLI_COMMAND)
+    track("evals_cli_command_copied")
     setCopied(true)
 
     if (resetTimeoutRef.current !== null) {
@@ -117,7 +119,12 @@ export function SiteHeader() {
         <div className="hidden items-center gap-2 sm:flex">
           <CopyCommandButton />
           <Button variant="secondary" asChild>
-            <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">
+            <a
+              href={DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => track("evals_ai_tools_clicked")}
+            >
               AI Tools
             </a>
           </Button>

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -12,8 +12,12 @@ export function initAnalytics() {
     persistence: "memory",
     person_profiles: "identified_only",
     autocapture: false,
-    capture_pageview: true,
+    capture_pageview: "history_change",
     capture_pageleave: true,
+    capture_heatmaps: false,
+    capture_dead_clicks: false,
+    capture_exceptions: false,
+    capture_performance: false,
     disable_session_recording: true,
   })
 }

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -9,7 +9,7 @@ export function initAnalytics() {
     api_host: POSTHOG_API_HOST,
     ui_host: POSTHOG_UI_HOST,
     defaults: "2026-01-30",
-    persistence: "memory",
+    persistence: "localStorage",
     person_profiles: "identified_only",
     autocapture: false,
     capture_pageview: "history_change",

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -5,6 +5,8 @@ const POSTHOG_API_HOST = "https://ph.supabase.com"
 const POSTHOG_UI_HOST = "https://eu.posthog.com"
 
 export function initAnalytics() {
+  if (!import.meta.env.PROD) return
+
   posthog.init(POSTHOG_PUBLIC_KEY, {
     api_host: POSTHOG_API_HOST,
     ui_host: POSTHOG_UI_HOST,
@@ -20,4 +22,10 @@ export function initAnalytics() {
     capture_performance: false,
     disable_session_recording: true,
   })
+}
+
+export function track(event: string, properties?: Record<string, unknown>) {
+  if (!import.meta.env.PROD) return
+
+  posthog.capture(event, properties)
 }

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -1,0 +1,19 @@
+import posthog from "posthog-js"
+
+const POSTHOG_PUBLIC_KEY = "phc_q2wUqNSr9AsKvH56PBbg9RX5dGKypQZi1gxk3cuSXJ5"
+const POSTHOG_API_HOST = "https://ph.supabase.com"
+const POSTHOG_UI_HOST = "https://eu.posthog.com"
+
+export function initAnalytics() {
+  posthog.init(POSTHOG_PUBLIC_KEY, {
+    api_host: POSTHOG_API_HOST,
+    ui_host: POSTHOG_UI_HOST,
+    defaults: "2026-01-30",
+    persistence: "memory",
+    person_profiles: "identified_only",
+    autocapture: false,
+    capture_pageview: true,
+    capture_pageleave: true,
+    disable_session_recording: true,
+  })
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -15,3 +15,9 @@ createRoot(document.getElementById("root")!).render(
     </NuqsAdapter>
   </StrictMode>
 )
+
+if (import.meta.env.PROD) {
+  void import("@/lib/posthog")
+    .then(({ initAnalytics }) => initAnalytics())
+    .catch(() => {})
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { NuqsAdapter } from "nuqs/adapters/react"
 import "./index.css"
 import App from "./App.tsx"
 import { ThemeProvider } from "@/components/theme-provider.tsx"
+import { initAnalytics } from "@/lib/analytics.ts"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
@@ -16,8 +17,4 @@ createRoot(document.getElementById("root")!).render(
   </StrictMode>
 )
 
-if (import.meta.env.PROD) {
-  void import("@/lib/analytics")
-    .then(({ initAnalytics }) => initAnalytics())
-    .catch(() => console.warn("analytics failed to load"))
-}
+initAnalytics()

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -17,7 +17,7 @@ createRoot(document.getElementById("root")!).render(
 )
 
 if (import.meta.env.PROD) {
-  void import("@/lib/posthog")
+  void import("@/lib/analytics")
     .then(({ initAnalytics }) => initAnalytics())
-    .catch(() => {})
+    .catch(() => console.warn("analytics failed to load"))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       nuqs:
         specifier: ^2.9.2
         version: 2.9.2(react@19.2.7)
+      posthog-js:
+        specifier: ^1.408.1
+        version: 1.408.1
       radix-ui:
         specifier: ^1.4.3
         version: 1.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1157,6 +1160,15 @@ packages:
 
   '@pgsql/types@17.6.2':
     resolution: {integrity: sha512-1UtbELdbqNdyOShhrVfSz3a1gDi0s9XXiQemx+6QqtsrXe62a6zOGU+vjb2GRfG5jeEokI1zBBcfD42enRv0Rw==}
+
+  '@posthog/browser-common@0.2.4':
+    resolution: {integrity: sha512-/xI4sIVNiZMJButhNdQFdCHtOcB6v8xM8vtJKznqqB7SMbpYwUNok68iPxGNZHPDwUYM6GAqM/AbMiS80UNyMw==}
+
+  '@posthog/core@1.45.2':
+    resolution: {integrity: sha512-OhEHkojFkqEFbtm/wUtLYgomN1gFNU9IyufvNsuZvpIOh8TZ9tnAvI81Sej/2zu+vyDExs9JroQB5SW3y5QyOw==}
+
+  '@posthog/types@1.399.0':
+    resolution: {integrity: sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2307,6 +2319,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
@@ -2664,6 +2679,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -2756,6 +2774,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -3019,6 +3040,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -3846,9 +3870,20 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.408.1:
+    resolution: {integrity: sha512-WsZ2mL38jbKZz1YiobAWGNru5YVJkmOzdBGXrqbcwhByA0TapQeqXXQgdulaMRPjEg797PY64R2y28fSUHsaIg==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3937,6 +3972,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4446,6 +4484,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -5261,6 +5302,17 @@ snapshots:
       - supports-color
 
   '@pgsql/types@17.6.2': {}
+
+  '@posthog/browser-common@0.2.4':
+    dependencies:
+      '@posthog/core': 1.45.2
+      '@posthog/types': 1.399.0
+
+  '@posthog/core@1.45.2':
+    dependencies:
+      '@posthog/types': 1.399.0
+
+  '@posthog/types@1.399.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -6437,6 +6489,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
@@ -6810,6 +6865,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.49.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -6872,6 +6929,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.4.2: {}
 
@@ -7223,6 +7284,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.4.9: {}
 
   figures@6.1.0:
     dependencies:
@@ -7929,7 +7992,23 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.408.1:
+    dependencies:
+      '@posthog/browser-common': 0.2.4
+      '@posthog/core': 1.45.2
+      '@posthog/types': 1.399.0
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      fflate: 0.4.9
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   powershell-utils@0.1.0: {}
+
+  preact@10.29.7: {}
 
   prelude-ls@1.2.1: {}
 
@@ -7964,6 +8043,8 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -8556,6 +8637,8 @@ snapshots:
       - msw
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.3.0: {}
 
   whatwg-mimetype@3.0.0: {}
 


### PR DESCRIPTION
Adds PostHog analytics to the evals site ahead of the announcement: pageviews plus click tracking on the two header actions. Events flow to the existing production PostHog project through the `ph.supabase.com` ingest proxy, so traffic is queryable alongside our other sites (PostHog and the warehouse) with no pipeline work.

Persistence matches our other standalone sites (multigres.com): `persistence: "localStorage"` keeps a stable anonymous per-browser ID without writing any cookies, so unique-visitor and returning-visitor counts are real. Events stay anonymous-class (`person_profiles: "identified_only"`, no `identify()` calls anywhere). PostHog's `cookieless_mode` was deliberately skipped: it requires enabling server hash mode on the shared production project (currently off), a project-wide ingestion change out of scope for this PR.

**Changed:**
- `apps/web/src/lib/analytics.ts`: posthog-js init plus a `track()` helper, both no-ops outside production builds. Config: localStorage persistence, anonymous events only, `$pageview` on load and on real pathname changes only (`"history_change"` ignores query-param updates, so nuqs filter clicks don't inflate counts), `$pageleave` on exit, and a fully pinned capture surface (autocapture, heatmaps, dead clicks, exceptions, performance, session recording all off) so this site's scope can't drift when shared-project settings change
- `apps/web/src/components/site-header.tsx`: `evals_cli_command_copied` on the copy-command button, `evals_ai_tools_clicked` on the AI Tools link (site-prefixed names following the multigres precedent)
- `apps/web/src/main.tsx`: initializes analytics after first render
- The token is PostHog's public client key (the same one every supabase.com page ships), so analytics works on merge with no env-var setup

Note: `pnpm --filter @supabase-evals/web test` has one pre-existing failure on `main` in `eval-results.test.ts` (experiment-consistency check), unrelated to this change.

Tested on:
- [x] typecheck, lint, build, and format:check green locally
- [x] Local production build in a real browser: single `$pageview` per load, `distinct_id` stable across reloads, zero cookies, no extra events from filter clicks, console clean
- [x] Vercel preview (this branch): browser run plus a PostHog ingestion query confirming `$pageview`, `$pageleave`, `evals_cli_command_copied`, and `evals_ai_tools_clicked` all arrive under the preview host, 1:1 with clicks

fixes GROWTH-1065
