### PR TITLE
feat: vercel web analytics

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@fontsource-variable/source-code-pro": "5.3.0",
     "@supabase-evals/core": "workspace:*",
     "@tailwindcss/vite": "^4.2.1",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { NuqsAdapter } from "nuqs/adapters/react"
+import { Analytics } from "@vercel/analytics/react"
 
 import "./index.css"
 import App from "./App.tsx"
@@ -11,6 +12,16 @@ createRoot(document.getElementById("root")!).render(
     <NuqsAdapter>
       <ThemeProvider>
         <App />
+        {/*
+         * Manually prefixed so requests survive the supabase.com/evals rewrite, which proxies /evals/* paths.
+         * https://vercel.com/docs/analytics/troubleshooting#web-analytics-is-not-working-with-a-proxy-e.g.-cloudflare
+         * https://vercel.com/docs/analytics/package
+         */}
+        <Analytics
+          scriptSrc="/evals/_vercel/insights/script.js"
+          eventEndpoint="/evals/_vercel/insights/event"
+          viewEndpoint="/evals/_vercel/insights/view"
+        />
       </ThemeProvider>
     </NuqsAdapter>
   </StrictMode>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,20 +7,23 @@ import "./index.css"
 import App from "./App.tsx"
 import { ThemeProvider } from "@/components/theme-provider.tsx"
 
+const analyticsPrefix =
+  window.location.hostname === "supabase.com" ? "/evals" : ""
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <NuqsAdapter>
       <ThemeProvider>
         <App />
         {/*
-         * Manually prefixed so requests survive the supabase.com/evals rewrite, which proxies /evals/* paths.
+         * On supabase.com, the /_vercel/insights/* routes only exist behind the /evals/* rewrite.
+         * On the raw *.vercel.app deployments, only the unprefixed routes resolve.
          * https://vercel.com/docs/analytics/troubleshooting#web-analytics-is-not-working-with-a-proxy-e.g.-cloudflare
-         * https://vercel.com/docs/analytics/package
          */}
         <Analytics
-          scriptSrc="/evals/_vercel/insights/script.js"
-          eventEndpoint="/evals/_vercel/insights/event"
-          viewEndpoint="/evals/_vercel/insights/view"
+          scriptSrc={`${analyticsPrefix}/_vercel/insights/script.js`}
+          eventEndpoint={`${analyticsPrefix}/_vercel/insights/event`}
+          viewEndpoint={`${analyticsPrefix}/_vercel/insights/view`}
         />
       </ThemeProvider>
     </NuqsAdapter>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.3.0(vite@7.3.5(@types/node@22.19.20)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.7)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2374,6 +2377,35 @@ packages:
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/detect-agent@1.2.3':
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
@@ -6535,6 +6567,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
+
+  '@vercel/analytics@2.0.1(react@19.2.7)':
+    optionalDependencies:
+      react: 19.2.7
 
   '@vercel/detect-agent@1.2.3': {}
 


### PR DESCRIPTION
Adds [Vercel Web Analytics](https://vercel.com/docs/analytics) to the frontend.

This feature is already enabled on the Vercel dashboard end. Enabling the features adds a few `/_vercel/insights/*` endpoints to the project.

I use a dynamic `analyticsPrefix` in the props so that it works for preview builds as well as through our supabase.com proxy.

When visiting from supabase.com/evals:
- Hostname is `supabase.com` so we add an `/evals` prefix on analytics script request
- Client requests `supabase.com/evals/_vercel/insights/script.js:`
- `www` rewrites request to `supabase-evals.vercel.app/_vercel/insights/script.js` -> OK

When visiting from `*.vercel.app` builds:
- Hostname is not `supabase.com` so prefix is left empty
- Client requests `*.vercel.app/evals/_vercel/insights/script.js` -> OK

Verified the script loads on preview build and populates the analytics dashboard:

<img width="1336" height="344" alt="CleanShot 2026-07-30 at 13 28 22@2x" src="https://github.com/user-attachments/assets/06c1f7f7-a378-4b99-833c-d893a3724270" />

<img width="2928" height="1920" alt="CleanShot 2026-07-30 at 13 28 54@2x" src="https://github.com/user-attachments/assets/21dca021-5b89-44f2-bf42-590851b54422" />

Closes AI-999
