### PR TITLE
fix(framework): resolve vite/vitest from apps/framework, not repo root

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -312,7 +312,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: raw-results-${{ matrix.experiment }}__${{ matrix.eval_id }}
-          path: results/${{ matrix.experiment }}/
+          path: |
+            results/${{ matrix.experiment }}/
+            !results/**/node_modules/**
           retention-days: 3
 
   publish-results:

--- a/apps/framework/harness/project-runner.ts
+++ b/apps/framework/harness/project-runner.ts
@@ -1,13 +1,28 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import type { CommandResult, VitestResult } from '@supabase-evals/core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = join(__dirname, '..', '..', '..');
+const ROOT = join(__dirname, '..');
+
+// Vite/vitest resolve their own package (and the workspace's deps, e.g. react)
+// by walking up from the workspace looking for a node_modules dir. Workspaces
+// live under results/, outside ROOT, so link ROOT's node_modules in directly.
+function linkNodeModules(workspace: string) {
+  const link = join(workspace, 'node_modules');
+  if (!existsSync(link)) symlinkSync(join(ROOT, 'node_modules'), link, 'dir');
+}
 
 export async function viteBuild(workspace: string): Promise<CommandResult> {
+  linkNodeModules(workspace);
   return runNodeBin(
     join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js'),
     ['build'],
@@ -16,6 +31,7 @@ export async function viteBuild(workspace: string): Promise<CommandResult> {
 }
 
 export async function vitestRun(workspace: string): Promise<VitestResult> {
+  linkNodeModules(workspace);
   const reportPath = join(workspace, 'vitest-report.json');
   const configPath = join(workspace, 'vitest.evals.config.ts');
   const setupDir = join(workspace, '.evals');


### PR DESCRIPTION
Solves the lingering failed framework smoke test that was erroring because `project-runner.ts` looked for `vite`/`vitest` in the monorepo root's `node_modules` instead of `apps/framework`'s, where pnpm actually installs them.

**Note:** no CI workflow runs `pnpm check`/`typecheck` (only `biome format:check` does), so this failure never surfaced in Actions — only locally, and silently, since the smoke script's error output is suppressed unless run with `--debug`.

**Repro on main:**
```
pnpm --filter @supabase-evals/framework test:framework -- --debug
```
Fails with `Cannot find module '.../node_modules/vite/bin/vite.js'`.