### PR TITLE
feat(evals): skill-trigger suite

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -5,26 +5,28 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { jsonSchema, tool, type ToolSet } from 'ai';
+import type { ModelMessage } from 'ai';
 import { parseEvalMarkdown } from '@supabase-evals/core/eval-markdown';
-import {
-  createBareSandbox,
-  frontmatterDescription,
-  stripFrontmatter,
-} from '@supabase-evals/sandbox';
+import { createBareSandbox } from '@supabase-evals/sandbox';
 import {
   normalizeExperimentName,
   readExperimentSuiteFilters,
   readRepeatedFlag,
   readSuiteFilters,
 } from '../lib/cli-args.js';
+import {
+  buildLoadSkillTool,
+  buildSystemPrompt,
+  buildToolsSkillsPrompt,
+  loadToolsSkills,
+  resolveSkillSources,
+} from '../lib/tools-skills.js';
 import { bootPlatformBackend } from './platform-backend.js';
 import { viteBuild, vitestRun } from './project-runner.js';
 import {
@@ -77,6 +79,55 @@ const TIMEOUT_SEC = Number(readFlag('timeout-sec') ?? 720);
 const CONCURRENCY = Number(readFlag('concurrency') ?? 1);
 const STOP_ON_PASS = !args.has('--run-all-attempts');
 const DEBUG = args.has('--debug');
+
+// ── Noisy context (trigger suite) ──────────────────────────────────────────
+// `--noisy-context[=name]` injects a simulated prior conversation before the
+// user prompt so trigger-quality is measured against a half-full, noisy
+// context window. With a name, that specific distractor template is used; bare
+// `--noisy-context` draws a random one. Templates live in
+// evals/trigger/contexts.ts — the only consumer for now; generalize if a
+// second suite needs noisy context. Resolved lazily in main() via dynamic
+// import so the harness stays decoupled from any one eval suite at load time.
+type NoisyContext = {
+  name: string;
+  messages: { role: 'user' | 'assistant'; content: string }[];
+};
+let NOISY_CONTEXT: NoisyContext | null = null;
+
+function parseNoisyContextFlag(): string | null {
+  const inline = rawArgs.find((a) => a.startsWith('--noisy-context='));
+  if (inline) {
+    const v = inline.slice('--noisy-context='.length);
+    return v === '' ? '' : v; // '' = random
+  }
+  if (args.has('--noisy-context')) {
+    const idx = rawArgs.indexOf('--noisy-context');
+    const next = rawArgs[idx + 1];
+    return next && !next.startsWith('--') ? next : '';
+  }
+  return null; // not set
+}
+
+const NOISY_CONTEXT_NAME = parseNoisyContextFlag();
+
+/** Context messages → ai-sdk ModelMessage turns (user/assistant, string content). */
+function toModelMessages(messages: NoisyContext['messages']): ModelMessage[] {
+  return messages.map((m) =>
+    m.role === 'assistant'
+      ? { role: 'assistant', content: m.content }
+      : { role: 'user', content: m.content }
+  );
+}
+
+/** Context messages → a single text block for one-shot (CLI) agents. */
+function formatContextAsText(ctx: NoisyContext): string {
+  const header =
+    'Prior conversation (context only — do not act on it; answer the request that follows):';
+  const body = ctx.messages
+    .map((m) => `${m.role.toUpperCase()}: ${m.content}`)
+    .join('\n\n');
+  return `${header}\n${body}`;
+}
 
 async function loadExperiments() {
   const dir = join(ROOT, 'experiments');
@@ -133,6 +184,9 @@ function discoverEvals(): EvalManifest[] {
     const localDir = join(evalDir, 'local');
     const promptPath = join(evalDir, 'PROMPT.md');
     const evalPath = join(evalDir, 'EVAL.ts');
+    // Skip dirs that aren't evals (e.g. evals/trigger/ holds the trigger
+    // suite's prompts.ts/golden.ts/contexts.ts data, with no PROMPT.md).
+    if (!existsSync(promptPath)) continue;
     const metadata = parseEvalMarkdown(
       readFileSync(promptPath, 'utf8'),
       `evals/${id}/PROMPT.md`
@@ -155,118 +209,6 @@ function discoverEvals(): EvalManifest[] {
     });
   }
   return out;
-}
-
-type ToolsSkill = { name: string; description: string; body: string };
-
-/**
- * Tools-mode skills, read from the host `skills/` dir. Unlike local-stack
- * (where skills are installed into the sandbox and the agent reads SKILL.md
- * with its file tools), a tools-mode agent has no filesystem — so only each
- * skill's name+description is advertised in the prompt and a `load_skill` tool
- * returns the full body on demand. Same lazy/progressive-disclosure property,
- * different load mechanism. Missing skills are skipped with a warning.
- */
-function loadToolsSkills(skillNames: string[]): ToolsSkill[] {
-  const skills: ToolsSkill[] = [];
-  for (const name of skillNames) {
-    const p = join(ROOT, 'skills', name, 'SKILL.md');
-    if (!existsSync(p)) {
-      console.warn(
-        `SKILL ${name} not found at skills/${name} — ensure the submodule is initialised (\`git submodule update --init\`); skipping`
-      );
-      continue;
-    }
-    const md = readFileSync(p, 'utf8');
-    skills.push({
-      name,
-      description: frontmatterDescription(md),
-      body: stripFrontmatter(md),
-    });
-  }
-  return skills;
-}
-
-/**
- * Discovery listing for the tools-mode system prompt: only names+descriptions,
- * so the agent knows when a skill is relevant without its full text in context.
- * Empty when there are no skills.
- */
-function buildToolsSkillsPrompt(skills: readonly ToolsSkill[]): string {
-  if (skills.length === 0) return '';
-  return [
-    '## Available skills',
-    '',
-    'The following agent skills are available. Only their names and descriptions are shown — ' +
-      'the full instructions are not loaded yet. When a task matches a skill, call the `load_skill` ' +
-      'tool with its name to load its full instructions.',
-    '',
-    ...skills.map((s) => `- ${s.name}: ${s.description}`),
-  ].join('\n');
-}
-
-/**
- * The agent-invoked `load_skill` tool: given a skill name it returns that
- * skill's full instructions. This is how tools-mode evals load a skill lazily
- * (the local-stack equivalent is the agent reading SKILL.md with files_read).
- * Empty toolset when there are no skills.
- */
-function buildLoadSkillTool(skills: readonly ToolsSkill[]): ToolSet {
-  if (skills.length === 0) return {};
-  const byName = new Map(skills.map((s) => [s.name, s]));
-  return {
-    load_skill: tool({
-      description:
-        "Load an agent skill's full instructions by name. Available skills are listed in the system prompt.",
-      inputSchema: jsonSchema({
-        type: 'object',
-        properties: {
-          name: {
-            type: 'string',
-            description:
-              'The skill name to load (as listed under Available skills).',
-            enum: skills.map((s) => s.name),
-          },
-        },
-        required: ['name'],
-      }),
-      execute: async (input) => {
-        const name = String((input as { name?: unknown })?.name ?? '');
-        const entry = byName.get(name);
-        if (!entry) {
-          throw new Error(
-            `unknown skill "${name}"; available: ${skills.map((s) => s.name).join(', ')}`
-          );
-        }
-        return { instructions: entry.body };
-      },
-    }),
-  };
-}
-
-/**
- * Local-stack skill sources: resolve each skill name to its host directory so
- * the sandbox can install it with Vercel's `skills` CLI; the agent then
- * discovers each skill by reading its SKILL.md with its file tools. The
- * `skills/` entries are symlinks into the agent-skills submodule; realpath them
- * so `docker cp` copies real files, not dangling links. Missing skills are
- * skipped with a warning.
- */
-function resolveSkillSources(
-  skillNames: string[]
-): Array<{ name: string; dir: string }> {
-  const sources: Array<{ name: string; dir: string }> = [];
-  for (const name of skillNames) {
-    const dir = join(ROOT, 'skills', name);
-    if (!existsSync(dir)) {
-      console.warn(
-        `SKILL ${name} not found at skills/${name} — ensure the submodule is initialised (\`git submodule update --init\`); skipping`
-      );
-      continue;
-    }
-    sources.push({ name, dir: realpathSync(dir) });
-  }
-  return sources;
 }
 
 function resultPath(modelName: string, ev: Pick<EvalManifest, 'id' | 'mode'>) {
@@ -306,31 +248,6 @@ function readSessionSeedArgs(ev: EvalManifest) {
   };
 }
 
-function basePromptFor(mode: EvalMode): string {
-  if (mode === 'local-stack') {
-    return (
-      'You are an agent solving a Supabase eval task in a Linux workspace. ' +
-      'Use the provided tools to inspect and modify the workspace and run commands. ' +
-      'When you are done, end your turn with a short summary of what you did.'
-    );
-  }
-  return (
-    'You are an agent solving a Supabase eval task. ' +
-    'Use the provided tools to inspect and modify the project. ' +
-    'When you are done, end your turn with a short summary of what you did ' +
-    '(or for audit tasks, your findings).'
-  );
-}
-
-function buildSystemPrompt(
-  mode: EvalMode,
-  addendum?: string,
-  skillContext?: string
-): string {
-  const blocks = [basePromptFor(mode), addendum, skillContext].filter(Boolean);
-  return blocks.join('\n\n');
-}
-
 /**
  * Adapt a `{ close() }` resource to `AsyncDisposable` so it can be bound with
  * `await using` — cleanup then runs on scope exit (normal fall-through, `continue`,
@@ -366,16 +283,23 @@ async function runOne(
     readFileSync(ev.promptPath, 'utf8'),
     ev.promptPath
   ).body;
+  // Noisy-context (trigger suite): CLI/sandbox agents are one-shot, so the
+  // distractor conversation is prepended as a text block into the prompt.
+  // In-process (ai-sdk) agents instead receive it as `priorMessages` (true
+  // multi-turn) — wired in the tools path below.
+  const noisyUserPrompt = NOISY_CONTEXT
+    ? `${formatContextAsText(NOISY_CONTEXT)}\n\n---\n\n${prompt}`
+    : prompt;
   // A CLI agent always runs in a sandbox and reads skills from disk with its
   // file tools (both modes). An in-process (ai-sdk) agent has no sandbox, so in
   // tools mode its skills are advertised in the prompt and loaded via the
   // load_skill tool. Skill sources (name+dir) are shared by both paths.
   const agentRunsInSandbox = exp.agent.runsInSandbox ?? false;
-  const skillSources = resolveSkillSources(exp.skills);
+  const skillSources = resolveSkillSources(ROOT, exp.skills);
   const availableSkills = skillSources.map((skill) => skill.name);
   const toolsSkills =
     ev.mode === 'tools' && !agentRunsInSandbox
-      ? loadToolsSkills(exp.skills)
+      ? loadToolsSkills(ROOT, exp.skills)
       : [];
   const scorer = (await import(pathToFileURL(ev.evalPath).href)).default as
     | ToolScorer
@@ -444,7 +368,7 @@ async function runOne(
 
       const run = await exp.agent.run({
         systemPrompt: buildSystemPrompt('local-stack', session.promptAddendum),
-        userPrompt: prompt,
+        userPrompt: noisyUserPrompt,
         tools: session.tools,
         sandbox: session.sandbox,
         mcpServers: session.mcpServers,
@@ -530,7 +454,14 @@ async function runOne(
     );
     const run = await exp.agent.run({
       systemPrompt,
-      userPrompt: prompt,
+      userPrompt: agentRunsInSandbox ? noisyUserPrompt : prompt,
+      // In-process (ai-sdk) agents get the distractor conversation as real
+      // prior turns; sandbox (CLI) agents get it folded into userPrompt above.
+      priorMessages: agentRunsInSandbox
+        ? undefined
+        : NOISY_CONTEXT
+          ? toModelMessages(NOISY_CONTEXT.messages)
+          : undefined,
       tools: agentRunsInSandbox ? undefined : buildLoadSkillTool(toolsSkills),
       mcpServers: session.mcpServers,
       sandbox: cliSandbox?.sandbox,
@@ -714,6 +645,20 @@ async function main() {
   // Suppress noisy supabase-js logs from expected failures; --debug keeps them visible.
   const stderr = console.error;
   if (!DEBUG) console.error = () => undefined;
+
+  // Resolve the noisy-context template (trigger suite) if requested. Done
+  // here, once, via dynamic import so the harness stays decoupled from any
+  // single eval suite's data at module load.
+  if (NOISY_CONTEXT_NAME !== null) {
+    const { contexts, pickContext } = await import(
+      pathToFileURL(join(ROOT, 'evals', 'trigger', 'contexts.ts')).href
+    );
+    const ctx = pickContext(NOISY_CONTEXT_NAME || undefined);
+    NOISY_CONTEXT = ctx;
+    console.log(`noisy-context: ${ctx.name}`);
+    // Touch `contexts` so the import isn't elided/tree-shaken in some bundlers.
+    void contexts;
+  }
 
   console.log(
     `${experiments.length} experiment(s), ${suiteFiltered.length} eval(s), ` +

--- a/apps/framework/lib/tools-skills.ts
+++ b/apps/framework/lib/tools-skills.ts
@@ -1,0 +1,137 @@
+/**
+ * Tools-mode skill loading: shared by the eval harness (`run-eval.ts`) and the
+ * standalone `test-skill-triggers.ts` script. A tools-mode agent has no
+ * filesystem, so each skill's name+description is advertised in the system
+ * prompt and its full body is pulled on demand via the `load_skill` tool
+ * (progressive disclosure, same property as local-stack's SKILL.md reads).
+ */
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { jsonSchema, tool, type ToolSet } from 'ai';
+import {
+  frontmatterDescription,
+  stripFrontmatter,
+} from '@supabase-evals/sandbox';
+
+export type ToolsSkill = { name: string; description: string; body: string };
+
+/** Reads skills from the host `skills/` dir. Missing skills are skipped with a warning. */
+export function loadToolsSkills(
+  root: string,
+  skillNames: string[]
+): ToolsSkill[] {
+  const skills: ToolsSkill[] = [];
+  for (const name of skillNames) {
+    const p = join(root, 'skills', name, 'SKILL.md');
+    if (!existsSync(p)) {
+      console.warn(
+        `SKILL ${name} not found at skills/${name} — ensure the submodule is initialised (\`git submodule update --init\`); skipping`
+      );
+      continue;
+    }
+    const md = readFileSync(p, 'utf8');
+    skills.push({
+      name,
+      description: frontmatterDescription(md),
+      body: stripFrontmatter(md),
+    });
+  }
+  return skills;
+}
+
+/** Discovery listing for the tools-mode system prompt. Empty when there are no skills. */
+export function buildToolsSkillsPrompt(skills: readonly ToolsSkill[]): string {
+  if (skills.length === 0) return '';
+  return [
+    '## Available skills',
+    '',
+    'The following agent skills are available. Only their names and descriptions are shown — ' +
+      'the full instructions are not loaded yet. When a task matches a skill, call the `load_skill` ' +
+      'tool with its name to load its full instructions.',
+    '',
+    ...skills.map((s) => `- ${s.name}: ${s.description}`),
+  ].join('\n');
+}
+
+/** The agent-invoked `load_skill` tool. Empty toolset when there are no skills. */
+export function buildLoadSkillTool(skills: readonly ToolsSkill[]): ToolSet {
+  if (skills.length === 0) return {};
+  const byName = new Map(skills.map((s) => [s.name, s]));
+  return {
+    load_skill: tool({
+      description:
+        "Load an agent skill's full instructions by name. Available skills are listed in the system prompt.",
+      inputSchema: jsonSchema({
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description:
+              'The skill name to load (as listed under Available skills).',
+            enum: skills.map((s) => s.name),
+          },
+        },
+        required: ['name'],
+      }),
+      execute: async (input) => {
+        const name = String((input as { name?: unknown })?.name ?? '');
+        const entry = byName.get(name);
+        if (!entry) {
+          throw new Error(
+            `unknown skill "${name}"; available: ${skills.map((s) => s.name).join(', ')}`
+          );
+        }
+        return { instructions: entry.body };
+      },
+    }),
+  };
+}
+
+/**
+ * Local-stack skill sources: resolve each skill name to its host directory.
+ * The `skills/` entries are symlinks into the agent-skills submodule; realpath
+ * them so `docker cp` copies real files, not dangling links. Missing skills
+ * are skipped with a warning.
+ */
+export function resolveSkillSources(
+  root: string,
+  skillNames: string[]
+): Array<{ name: string; dir: string }> {
+  const sources: Array<{ name: string; dir: string }> = [];
+  for (const name of skillNames) {
+    const dir = join(root, 'skills', name);
+    if (!existsSync(dir)) {
+      console.warn(
+        `SKILL ${name} not found at skills/${name} — ensure the submodule is initialised (\`git submodule update --init\`); skipping`
+      );
+      continue;
+    }
+    sources.push({ name, dir: realpathSync(dir) });
+  }
+  return sources;
+}
+
+function basePromptFor(mode: 'local-stack' | 'tools'): string {
+  if (mode === 'local-stack') {
+    return (
+      'You are an agent solving a Supabase eval task in a Linux workspace. ' +
+      'Use the provided tools to inspect and modify the workspace and run commands. ' +
+      'When you are done, end your turn with a short summary of what you did.'
+    );
+  }
+  return (
+    'You are an agent solving a Supabase eval task. ' +
+    'Use the provided tools to inspect and modify the project. ' +
+    'When you are done, end your turn with a short summary of what you did ' +
+    '(or for audit tasks, your findings).'
+  );
+}
+
+export function buildSystemPrompt(
+  mode: 'local-stack' | 'tools',
+  addendum?: string,
+  skillContext?: string
+): string {
+  const blocks = [basePromptFor(mode), addendum, skillContext].filter(Boolean);
+  return blocks.join('\n\n');
+}

--- a/apps/framework/package.json
+++ b/apps/framework/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "test:framework": "node --env-file-if-exists=../../.env --import tsx/esm scripts/smoke-framework.ts",
     "export-results": "node --import tsx/esm scripts/export-results.ts",
+    "test-skill-triggers": "node --env-file=../../.env --import tsx/esm scripts/test-skill-triggers.ts",
     "demo:mcp": "node --env-file=../../.env --import tsx/esm scripts/mcp-demo.ts",
     "demo:executor": "node --env-file=../../.env --import tsx/esm scripts/executor-demo.ts"
   },

--- a/apps/framework/scripts/build-golden.ts
+++ b/apps/framework/scripts/build-golden.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env tsx
+/**
+ * Hand-editable golden table → generated code. The golden mapping (which
+ * skills should fire on which prompt) is a judgment call, not something to
+ * infer automatically — so the source of truth is a TSV anyone can open in a
+ * spreadsheet/editor and tick 1/0 in, not a hand-typed TS literal array.
+ *
+ * Reads evals/trigger/golden-<suite>.tsv:
+ *   idx  sourceEval  category  <skill1>  <skill2>  ...
+ * (one column per skill in the closed set; 1 = expected, 0 = not expected)
+ *
+ * Writes evals/trigger/golden-<suite>.ts with the same `GoldenEntry[]` shape
+ * the rest of the pipeline (gen-*-evals.ts, trigger-report.ts) already
+ * consumes — editing the TSV and re-running this is the whole workflow.
+ *
+ *   cd apps/framework && node --import tsx/esm scripts/build-golden.ts <suite>
+ *   e.g. node --import tsx/esm scripts/build-golden.ts triage
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..', '..');
+const TRIGGER_DIR = join(ROOT, 'evals', 'trigger');
+
+const suite = process.argv[2];
+if (!suite) {
+  console.error(
+    'usage: build-golden.ts <suite>  (reads evals/trigger/golden-<suite>.tsv)'
+  );
+  process.exit(1);
+}
+
+const tsvPath = join(TRIGGER_DIR, `golden-${suite}.tsv`);
+const rows = readFileSync(tsvPath, 'utf8').trim().split('\n');
+const header = rows[0].split('\t');
+const FIXED_COLS = ['idx', 'sourceEval', 'category'];
+const skillCols = header.slice(FIXED_COLS.length);
+if (header.slice(0, FIXED_COLS.length).join(',') !== FIXED_COLS.join(',')) {
+  throw new Error(
+    `${tsvPath}: expected header to start with ${FIXED_COLS.join('\\t')}`
+  );
+}
+
+type Entry = {
+  promptIndex: number;
+  category: string;
+  expectedSkills: string[];
+  sourceEval: string;
+};
+
+const entries: Entry[] = rows.slice(1).map((line, i) => {
+  const cols = line.split('\t');
+  if (cols.length !== header.length) {
+    throw new Error(
+      `${tsvPath}:${i + 2}: expected ${header.length} columns, got ${cols.length}`
+    );
+  }
+  const [idxStr, sourceEval, category, ...flags] = cols;
+  const promptIndex = Number(idxStr);
+  if (promptIndex !== i) {
+    throw new Error(
+      `${tsvPath}:${i + 2}: idx=${idxStr}, expected ${i} (rows must be in order, 0-based)`
+    );
+  }
+  const expectedSkills = skillCols.filter((_, j) => {
+    const v = flags[j]?.trim();
+    if (v !== '0' && v !== '1') {
+      throw new Error(
+        `${tsvPath}:${i + 2}: column "${skillCols[j]}" must be 0 or 1, got "${flags[j]}"`
+      );
+    }
+    return v === '1';
+  });
+  return { promptIndex, category, expectedSkills, sourceEval };
+});
+
+const varName = `golden${suite[0].toUpperCase()}${suite.slice(1)}`;
+const lines = [
+  '/**',
+  ` * GENERATED from golden-${suite}.tsv by build-golden.ts — do not hand-edit.`,
+  ' * To change an expectation: edit the TSV (1/0 per skill column), then run:',
+  ` *   cd apps/framework && node --import tsx/esm scripts/build-golden.ts ${suite}`,
+  ' */',
+  "import type { Category } from './prompts.js';",
+  "import type { GoldenEntry } from './golden.js';",
+  '',
+  `export const ${suite.toUpperCase()}_SKILLS = [${skillCols.map((s) => `'${s}'`).join(', ')}] as const;`,
+  '',
+  `export const ${varName}: GoldenEntry[] = [`,
+  ...entries.map(
+    (e) =>
+      `  { promptIndex: ${e.promptIndex}, category: ${JSON.stringify(e.category)} as Category, expectedSkills: [${e.expectedSkills.map((s) => `'${s}'`).join(', ')}], sourceEval: ${JSON.stringify(e.sourceEval)} },`
+  ),
+  '];',
+  '',
+];
+
+const outPath = join(TRIGGER_DIR, `golden-${suite}.ts`);
+writeFileSync(outPath, lines.join('\n'));
+
+const counts = skillCols.map(
+  (s) => `${s}=${entries.filter((e) => e.expectedSkills.includes(s)).length}`
+);
+console.log(
+  `wrote ${entries.length} entries to golden-${suite}.ts (${counts.join(', ')})`
+);

--- a/apps/framework/scripts/gen-trigger-evals.ts
+++ b/apps/framework/scripts/gen-trigger-evals.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot codegen for the skill-trigger suite. Reads the 97 prompts
+ * (`evals/trigger/prompts.ts`) and their hand-authored ground truth
+ * (`evals/trigger/golden.ts`), and emits one self-contained eval dir per
+ * prompt:
+ *
+ *   evals/investigate-trigger-<category>-<nn>/{PROMPT.md, EVAL.ts}
+ *
+ *   - <category>  the prompt's category (schema, security, …)
+ *   - <nn>        the GLOBAL prompt index, zero-padded to 2 digits (00–96),
+ *                 so a dir name maps 1:1 to a `golden` entry's promptIndex.
+ *
+ * PROMPT.md frontmatter: stage=investigate, suite=trigger, interface=mcp,
+ * product=[database], topic mapped from category. EVAL.ts is a one-liner over
+ * `createSkillTriggerScorer` (deterministic; no LLM, no sandbox, no DB) — the
+ * expected-skill set and the closed skill set are inlined as literals so each
+ * eval dir is standalone and does not import the trigger data files at runtime.
+ *
+ * Run once and commit the output (reviewers see real eval dirs, not runtime
+ * codegen). Re-running overwrites the same files idempotently.
+ *
+ *   cd apps/framework && node --import tsx/esm scripts/gen-trigger-evals.ts
+ */
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { prompts, type Category } from '../../../evals/trigger/prompts.js';
+import {
+  golden,
+  assertGoldenCoversAll,
+} from '../../../evals/trigger/golden.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..', '..');
+const EVALS_DIR = join(ROOT, 'evals');
+
+// Closed skill set — inlined into every generated EVAL.ts. Canonical home:
+// evals/trigger/golden.ts (TRIGGER_SKILLS). Kept in sync by the invariant test
+// in trigger-report (assertGoldenCoversAll + a literal equality check).
+// Multi-line form matches biome's formatter so re-runs are clean.
+const TRIGGER_SKILLS_LITERAL = `[
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const`;
+
+/** Map a prompt category to the frontmatter `topic` benchmark dimension. */
+function topicFor(category: Category): string {
+  switch (category) {
+    case 'security':
+      return 'rls';
+    case 'schema':
+    case 'performance':
+    case 'data-ops':
+      return 'sql';
+    case 'monitoring':
+    case 'general':
+      return 'observability';
+  }
+}
+
+/** Quote a skill name as a TypeScript string literal. */
+const q = (s: string): string => `'${s}'`;
+
+function promptMarkdown(text: string, category: Category): string {
+  return `---
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - ${topicFor(category)}
+---
+
+${text}
+`;
+}
+
+function evalTs(expectedSkills: readonly string[]): string {
+  const expected = `[${expectedSkills.map(q).join(', ')}]`;
+  return `import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = ${TRIGGER_SKILLS_LITERAL};
+
+export default createSkillTriggerScorer(${expected}, TRIGGER_SKILLS);
+`;
+}
+
+async function main() {
+  assertGoldenCoversAll(prompts);
+
+  // Clear any prior generated dirs so re-runs don't leave orphans. Only
+  // touches dirs matching the `investigate-trigger-` prefix.
+  const generatedPrefix = 'investigate-trigger-';
+  let cleared = 0;
+  for (const g of golden) {
+    const dir = join(
+      EVALS_DIR,
+      `${generatedPrefix}${g.category}-${String(g.promptIndex).padStart(2, '0')}`
+    );
+    await rm(dir, { recursive: true, force: true });
+    cleared += 1;
+  }
+
+  let written = 0;
+  for (const g of golden) {
+    const prompt = prompts[g.promptIndex];
+    const dirName = `${generatedPrefix}${g.category}-${String(g.promptIndex).padStart(2, '0')}`;
+    const dir = join(EVALS_DIR, dirName);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'PROMPT.md'),
+      promptMarkdown(prompt.text, g.category),
+      'utf8'
+    );
+    await writeFile(join(dir, 'EVAL.ts'), evalTs(g.expectedSkills), 'utf8');
+    written += 1;
+  }
+
+  console.log(
+    `cleared ${cleared} prior dirs, wrote ${written} eval dirs under evals/`
+  );
+  // ponytail: no runtime check here — assertGoldenCoversAll above + the
+  // trigger suite's invariant test cover correctness.
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/framework/scripts/test-skill-triggers.ts
+++ b/apps/framework/scripts/test-skill-triggers.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env tsx
+/**
+ * Standalone skill-trigger tester — decoupled from the eval harness.
+ *
+ * Point it at one or more skills and a bulk prompt set; for each prompt it
+ * runs a minimal in-process agent (system prompt + `load_skill` tool only, no
+ * MCP/sandbox/localStack) and records which skills it chose to load. Useful
+ * while iterating on a SKILL.md description: no eval dirs, no results/
+ * bookkeeping, no golden data required for a new skill.
+ *
+ * Usage:
+ *   pnpm test-skill-triggers -- --skill=supabase-postgres-best-practices
+ *   pnpm test-skill-triggers -- --skill=my-new-skill --prompts=./my-prompts.json --category=schema --limit=20
+ *
+ * Flags:
+ *   --skill=<name>[,<name>...]  required. Skills advertised to the agent
+ *                                (skills/<name>/SKILL.md). Testing one skill in
+ *                                isolation means the agent only ever sees that
+ *                                one option — the realistic single-skill case.
+ *   --prompts=<path>            JSON file: string[] or {text, category?}[].
+ *                                Defaults to the built-in 97-prompt corpus
+ *                                (evals/trigger/prompts.ts).
+ *   --category=<cat>[,<cat>...] filter the built-in corpus by category.
+ *   --limit=<n>                 cap the number of prompts run.
+ *   --concurrency=<n>           default 5.
+ *   --out=<path>                write full per-prompt JSON results here.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { anthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { aiSdkAgent, buildSkillResult } from '@supabase-evals/core';
+import {
+  buildLoadSkillTool,
+  buildSystemPrompt,
+  buildToolsSkillsPrompt,
+  loadToolsSkills,
+} from '../lib/tools-skills.js';
+import { readRepeatedFlag } from '../lib/cli-args.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..', '..');
+const TIMEOUT_SEC = 120;
+
+const rawArgs = process.argv.slice(2);
+
+function readFlag(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inline = rawArgs.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const idx = rawArgs.indexOf(`--${name}`);
+  if (idx !== -1) {
+    const value = rawArgs[idx + 1];
+    if (value && !value.startsWith('--')) return value;
+  }
+  return undefined;
+}
+
+const SKILL_NAMES = readRepeatedFlag(rawArgs, 'skill');
+if (SKILL_NAMES.length === 0) {
+  console.error(
+    'Usage: test-skill-triggers -- --skill=<name>[,<name>...] [--prompts=<path>] ...'
+  );
+  process.exit(1);
+}
+const CATEGORY_FILTER = readRepeatedFlag(rawArgs, 'category');
+const LIMIT = Number(readFlag('limit') ?? Infinity);
+const CONCURRENCY = Number(readFlag('concurrency') ?? 5);
+const PROMPTS_PATH = readFlag('prompts');
+const OUT_PATH = readFlag('out');
+
+type TestPrompt = { text: string; category?: string };
+
+async function loadPrompts(): Promise<TestPrompt[]> {
+  if (PROMPTS_PATH) {
+    const raw = JSON.parse(readFileSync(PROMPTS_PATH, 'utf8'));
+    const list: unknown[] = Array.isArray(raw) ? raw : [];
+    return list.map((entry) =>
+      typeof entry === 'string' ? { text: entry } : (entry as TestPrompt)
+    );
+  }
+  const { prompts } = await import('../../../evals/trigger/prompts.js');
+  return prompts;
+}
+
+// ponytail: fast iterative testing while tuning a skill description, not
+// scored final results — Haiku is far cheaper, so default to it either way,
+// OpenRouter or direct Anthropic (OpenRouter has its own daily budget cap
+// independent of the Anthropic key, so runs need to survive it being spent).
+const model = process.env.OPENROUTER_API_KEY
+  ? createOpenAI({
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })('anthropic/claude-haiku-4.5')
+  : anthropic('claude-haiku-4-5');
+
+const agent = aiSdkAgent({
+  model,
+  providerOptions: { anthropic: { effort: 'max' } },
+});
+
+type PromptResult = {
+  text: string;
+  category?: string;
+  loaded: string[];
+  error?: string;
+};
+
+async function runOne(
+  prompt: TestPrompt,
+  skills: ReturnType<typeof loadToolsSkills>
+): Promise<PromptResult> {
+  try {
+    const skillsPrompt = buildToolsSkillsPrompt(skills);
+    const systemPrompt = buildSystemPrompt('tools', undefined, skillsPrompt);
+    const run = await agent.run({
+      systemPrompt,
+      userPrompt: prompt.text,
+      tools: buildLoadSkillTool(skills),
+      timeoutSec: TIMEOUT_SEC,
+    });
+    const { loaded } = buildSkillResult(
+      skills.map((s) => s.name),
+      run.toolCalls
+    );
+    return { text: prompt.text, category: prompt.category, loaded };
+  } catch (e) {
+    return {
+      text: prompt.text,
+      category: prompt.category,
+      loaded: [],
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker)
+  );
+  return results;
+}
+
+async function main() {
+  agent.assertReady();
+  const skills = loadToolsSkills(ROOT, SKILL_NAMES);
+  if (skills.length === 0) {
+    console.error(`No skills found for: ${SKILL_NAMES.join(', ')}`);
+    process.exit(1);
+  }
+
+  let prompts = await loadPrompts();
+  if (CATEGORY_FILTER.length > 0) {
+    prompts = prompts.filter(
+      (p) => p.category && CATEGORY_FILTER.includes(p.category)
+    );
+  }
+  if (Number.isFinite(LIMIT)) prompts = prompts.slice(0, LIMIT);
+
+  console.log(
+    `Testing ${skills.map((s) => s.name).join(', ')} against ${prompts.length} prompt(s)...\n`
+  );
+
+  let done = 0;
+  const results = await mapWithConcurrency(
+    prompts,
+    CONCURRENCY,
+    async (prompt) => {
+      const result = await runOne(prompt, skills);
+      done += 1;
+      const status = result.error
+        ? `ERROR: ${result.error.slice(0, 60)}`
+        : result.loaded.length > 0
+          ? result.loaded.join(', ')
+          : '—';
+      console.log(
+        `[${done}/${prompts.length}] ${status.padEnd(40)} ${result.text.slice(0, 70)}`
+      );
+      return result;
+    }
+  );
+
+  const ok = results.filter((r) => !r.error);
+  const errored = results.length - ok.length;
+  if (errored > 0) {
+    console.log(
+      `\n${errored} prompt(s) errored and are excluded from the rates below.`
+    );
+  }
+
+  console.log('\n── Activation rate by skill ──');
+  for (const skill of skills) {
+    const fired = ok.filter((r) => r.loaded.includes(skill.name)).length;
+    console.log(
+      `  ${skill.name}: ${fired}/${ok.length} (${ok.length ? Math.round((100 * fired) / ok.length) : 0}%)`
+    );
+  }
+
+  const categories = [...new Set(ok.map((r) => r.category).filter(Boolean))];
+  if (categories.length > 0) {
+    console.log('\n── Activation rate by category ──');
+    for (const category of categories) {
+      const inCategory = ok.filter((r) => r.category === category);
+      const fired = inCategory.filter((r) => r.loaded.length > 0).length;
+      console.log(`  ${category}: ${fired}/${inCategory.length}`);
+    }
+  }
+
+  if (OUT_PATH) {
+    writeFileSync(OUT_PATH, JSON.stringify(results, null, 2));
+    console.log(`\nWrote ${results.length} result(s) to ${OUT_PATH}`);
+  }
+}
+
+main();

--- a/apps/framework/scripts/trigger-report.ts
+++ b/apps/framework/scripts/trigger-report.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env tsx
+/**
+ * Skill-trigger correlation report.
+ *
+ * Reads trigger-suite result files (`results/<experiment>/<evalId>.json`) and
+ * cross-tabulates `SkillResult.loaded` × `passed` per skill, answering the
+ * question the raw pass-rate can't: does activating a skill actually *help*?
+ *
+ *   P(pass | loaded)      — pass rate when the skill fired
+ *   P(pass | not loaded)  — pass rate when it didn't (the no-skills runs feed
+ *                            this population: nothing loads, so every skill
+ *                            counts as "not loaded" there)
+ *   Δ = P(pass|loaded) − P(pass|not loaded)
+ *
+ * A positive Δ means the skill helps; a negative Δ means it hurts (bad advice
+ * from a misfired skill is worse than none). Trigger quality (did it fire on
+ * the right prompts?) is the suite's job; this report closes the *utility* gap
+ * — activated vs helped — that evals never cross-tabulated before.
+ *
+ * Usage (run from apps/framework):
+ *   node --import tsx/esm scripts/trigger-report.ts
+ *   node --import tsx/esm scripts/trigger-report.ts \
+ *     --results=trigger-claude-sonnet-5 \
+ *     --no-skills=trigger-no-skills-claude-sonnet-5 \
+ *     --diff=trigger-claude-sonnet-5-noisy
+ *
+ * `--diff=<dir>` adds a clean-vs-noisy comparison per skill (trigger-rate and
+ * pass-rate shift under a noisy context window), flagging |Δ| ≥ 5pp with ⚠.
+ *
+ * Pure analytics over existing result files — no LLM, no sandbox, no DB.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..', '..');
+const RESULTS_DIR = join(ROOT, 'results');
+
+// ponytail: closed skill set inlined — canonical home is
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+type Run = {
+  evalId: string;
+  category: string;
+  passed: boolean;
+  loaded: Set<string>;
+  available: Set<string>;
+};
+
+/** Pull the prompt category out of `investigate-trigger-<category>-<nn>`. */
+function categoryFromEvalId(id: string): string | null {
+  const m = id.match(/^investigate-trigger-(.+)-\d+$/);
+  return m ? m[1]! : null;
+}
+
+/** Short column label for a skill (the `supabase-` prefix is redundant here). */
+function shortSkill(s: string): string {
+  return s === 'supabase' ? 'supabase' : s.replace('supabase-', '');
+}
+
+function resolveResultsArg(value: string): string {
+  return isAbsolute(value) || value.startsWith('results/')
+    ? value
+    : join(RESULTS_DIR, value);
+}
+
+async function readResults(label: string): Promise<Run[]> {
+  const dir = resolveResultsArg(label);
+  if (!existsSync(dir)) {
+    console.warn(`(no results at ${dir}; skipping)`);
+    return [];
+  }
+  const files = (await readdir(dir)).filter((f) => f.endsWith('.json'));
+  const runs: Run[] = [];
+  for (const f of files) {
+    const raw = JSON.parse(await readFile(join(dir, f), 'utf8')) as {
+      eval?: string;
+      passed?: boolean;
+      skills?: { loaded?: string[]; available?: string[] };
+    };
+    const evalId = raw.eval;
+    if (!evalId) continue;
+    const category = categoryFromEvalId(evalId);
+    if (!category) continue; // not a trigger-suite eval
+    runs.push({
+      evalId,
+      category,
+      passed: !!raw.passed,
+      loaded: new Set(raw.skills?.loaded ?? []),
+      available: new Set(raw.skills?.available ?? []),
+    });
+  }
+  return runs;
+}
+
+type Cell = { passed: number; total: number };
+
+function rate(cell: Cell): number {
+  return cell.total === 0 ? NaN : (cell.passed / cell.total) * 100;
+}
+
+function pct(x: number): string {
+  return Number.isNaN(x) ? '  —  ' : `${x.toFixed(1)}%`;
+}
+
+/** Cross-tab loaded × passed for one skill over a set of runs. */
+function tabulate(
+  skill: string,
+  runs: Run[]
+): {
+  loaded: Cell;
+  notLoaded: Cell;
+  delta: number;
+} {
+  const loaded: Cell = { passed: 0, total: 0 };
+  const notLoaded: Cell = { passed: 0, total: 0 };
+  for (const r of runs) {
+    const isLoaded = r.loaded.has(skill);
+    // A no-skills run has the skill neither available nor loaded — it counts
+    // as "not loaded" (the baseline population).
+    const cell = isLoaded ? loaded : notLoaded;
+    cell.total += 1;
+    if (r.passed) cell.passed += 1;
+  }
+  return { loaded, notLoaded, delta: rate(loaded) - rate(notLoaded) };
+}
+
+function printCorrelationTable(runs: Run[]): void {
+  console.log('\n=== Activated vs helped (per skill) ===');
+  console.log(
+    'skill                              P(pass|loaded)  P(pass|−load)   Δ      n+    n−'
+  );
+  for (const skill of TRIGGER_SKILLS) {
+    const t = tabulate(skill, runs);
+    console.log(
+      `${skill.padEnd(34)}  ${pct(rate(t.loaded)).padStart(14)}  ${pct(rate(t.notLoaded)).padStart(14)}  ${Number.isNaN(t.delta) ? '  —  ' : (t.delta >= 0 ? '+' : '') + t.delta.toFixed(1).padStart(5)}pp  ${String(t.loaded.total).padStart(4)}  ${String(t.notLoaded.total).padStart(4)}`
+    );
+  }
+}
+
+function printCategoryBreakdown(runs: Run[]): void {
+  const byCat = new Map<string, Run[]>();
+  for (const r of runs) {
+    const list = byCat.get(r.category) ?? [];
+    list.push(r);
+    byCat.set(r.category, list);
+  }
+  console.log('\n=== Per-category (trigger rate · pass rate · n) ===');
+  console.log(
+    'category          ' +
+      TRIGGER_SKILLS.map((s) => shortSkill(s).padEnd(22)).join('  ')
+  );
+  for (const cat of [...byCat.keys()].sort()) {
+    const catRuns = byCat.get(cat)!;
+    const cells = TRIGGER_SKILLS.map((skill) => {
+      const t = tabulate(skill, catRuns);
+      const trigRate = (t.loaded.total / catRuns.length) * 100;
+      const passRate = rate(t.loaded);
+      // ponytail: NaN passRate (no loads in this category) shows as —
+      return `${pct(trigRate).padStart(6)}·${pct(passRate).padStart(6)}·${String(catRuns.length).padStart(2)}`.padEnd(
+        22
+      );
+    });
+    console.log(`${cat.padEnd(18)} ${cells.join('  ')}`);
+  }
+}
+
+function printDiff(clean: Run[], noisy: Run[]): void {
+  console.log(
+    '\n=== Clean vs noisy (trigger-rate Δ · pass-rate Δ per skill) ==='
+  );
+  console.log(
+    'skill                              trig(clean→noisy)       pass(clean→noisy)'
+  );
+  for (const skill of TRIGGER_SKILLS) {
+    const c = tabulate(skill, clean);
+    const n = tabulate(skill, noisy);
+    const trigC = (c.loaded.total / clean.length) * 100;
+    const trigN = (n.loaded.total / noisy.length) * 100;
+    const dTrig = trigN - trigC;
+    const passC = rate(c.loaded);
+    const passN = rate(n.loaded);
+    const dPass = passN - passC;
+    const warnTrig = Math.abs(dTrig) >= 5 ? ' ⚠' : '';
+    const warnPass = Number.isNaN(dPass)
+      ? ''
+      : Math.abs(dPass) >= 5
+        ? ' ⚠'
+        : '';
+    console.log(
+      `${skill.padEnd(34)}  ${pct(trigC).padStart(7)}→${pct(trigN).padStart(7)}  ${fmtDelta(dTrig).padStart(7)}pp${warnTrig}   ${pct(passC).padStart(7)}→${pct(passN).padStart(7)}  ${Number.isNaN(dPass) ? '   —    ' : fmtDelta(dPass).padStart(7) + 'pp'}${warnPass}`
+    );
+  }
+}
+
+function fmtDelta(x: number): string {
+  return (x >= 0 ? '+' : '') + x.toFixed(1);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const get = (name: string): string | undefined => {
+    const inline = args.find((a) => a.startsWith(`--${name}=`));
+    if (inline) return inline.slice(`--${name}=`.length);
+    const i = args.indexOf(`--${name}`);
+    if (i >= 0 && args[i + 1] && !args[i + 1].startsWith('--'))
+      return args[i + 1];
+    return undefined;
+  };
+
+  const resultsLabel = get('results') ?? 'trigger-claude-sonnet-5';
+  const noSkillsLabel = get('no-skills') ?? 'trigger-no-skills-claude-sonnet-5';
+  const diffLabel = get('diff');
+
+  const withSkills = await readResults(resultsLabel);
+  const noSkills = await readResults(noSkillsLabel);
+  const all = [...withSkills, ...noSkills];
+
+  if (all.length === 0) {
+    console.error(
+      `no trigger results found (looked at ${resolveResultsArg(resultsLabel)} and ${resolveResultsArg(noSkillsLabel)}). ` +
+        `Run the trigger suite first: pnpm eval -- --experiment=${resultsLabel} --suite=trigger`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `read ${withSkills.length} with-skills + ${noSkills.length} no-skills runs = ${all.length} total`
+  );
+
+  printCorrelationTable(all);
+  printCategoryBreakdown(all);
+
+  if (diffLabel) {
+    const noisy = await readResults(diffLabel);
+    if (noisy.length === 0) {
+      console.error(`(--diff) no results at ${resolveResultsArg(diffLabel)}`);
+      process.exit(1);
+    }
+    printDiff(withSkills, noisy);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/evals/investigate-trigger-data-ops-29/EVAL.ts
+++ b/evals/investigate-trigger-data-ops-29/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-data-ops-29/PROMPT.md
+++ b/evals/investigate-trigger-data-ops-29/PROMPT.md
@@ -1,0 +1,17 @@
+---
+motivation: derived from resolve-dataapi-001-empty-results, AI-822, https://supabase.com/docs/guides/troubleshooting/why-is-my-select-returning-an-empty-data-array-and-i-have-data-in-the-table-xvOPgx
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. 
+Users also need to be able to save new bookmarks from the app.
+
+I can see the rows when I query the table directly, but the dashboard shows an empty list for every user.
+
+Find out why the Data API returns nothing and fix it.

--- a/evals/investigate-trigger-data-ops-30/EVAL.ts
+++ b/evals/investigate-trigger-data-ops-30/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-data-ops-30/PROMPT.md
+++ b/evals/investigate-trigger-data-ops-30/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from resolve-dataapi-002-secure-default-grants, AI-914, AI-667
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.
+
+I can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.

--- a/evals/investigate-trigger-data-ops-31/EVAL.ts
+++ b/evals/investigate-trigger-data-ops-31/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-data-ops-31/PROMPT.md
+++ b/evals/investigate-trigger-data-ops-31/PROMPT.md
@@ -1,0 +1,16 @@
+---
+motivation: derived from resolve-dataapi-002-update-zero-rows-affected, https://supabase.com/docs/guides/troubleshooting/rls-simplified-BJTcS8, supabase/agent-skills#112
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+Our app lets signed-in users manage a personal `tasks` list. Users can create tasks and check them off (`is_done`).
+
+Creating a task works fine, and I can see the row in the table. But when a user checks off a task, the app's update call succeeds with no error, yet `is_done` never actually changes, and the API doesn't return the updated row either.
+
+Find out why the update has no effect and fix it.

--- a/evals/investigate-trigger-general-00/EVAL.ts
+++ b/evals/investigate-trigger-general-00/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-general-00/PROMPT.md
+++ b/evals/investigate-trigger-general-00/PROMPT.md
@@ -1,0 +1,21 @@
+---
+motivation: derived from build-cli-001-bootstrap-app, AI-809, https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+We're kicking off a todos app and I want the Supabase side ready for the team
+to build on. Set it up the way we'd run it in development, with schema changes
+tracked as migrations so they can be reviewed and replayed.
+
+For the first slice we just need a `todos` table. Todos aren't public: anyone
+signed in can read all of them, but nothing should be writable through the API
+for now. Add a couple of sample todos so there's something to look at.
+
+Before you hand it back, make sure the running API actually behaves that way —
+signed-in users get the todos, signed-out requests get nothing.

--- a/evals/investigate-trigger-general-02/EVAL.ts
+++ b/evals/investigate-trigger-general-02/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-general-02/PROMPT.md
+++ b/evals/investigate-trigger-general-02/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from build-cli-003-pg-cron-queue-workflow, AI-812, https://supabase.com/docs/guides/queues/consuming-messages-with-edge-functions
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+I want to set up a recurring background workflow on my local Supabase stack.
+
+Can you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.

--- a/evals/investigate-trigger-general-04/EVAL.ts
+++ b/evals/investigate-trigger-general-04/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-general-04/PROMPT.md
+++ b/evals/investigate-trigger-general-04/PROMPT.md
@@ -1,0 +1,38 @@
+---
+motivation: derived from build-frontend-001-todos-app; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Build the missing Supabase integration for this Vite + React todos app.
+
+The Supabase project already has a `todos` table with RLS policies:
+
+```sql
+todos(id uuid, user_id uuid default auth.uid(), body text, done boolean, created_at timestamptz)
+```
+
+The project files are under `local/`. `local/src/App.tsx` already contains the UI
+markup and stable `data-testid`s used by the tests. Keep that UI shape intact
+and hook it up to Supabase.
+
+Requirements:
+
+1. Create a Supabase client using `@supabase/supabase-js`. You may create a
+   helper like `local/src/supabase.ts` or keep the client in `App.tsx`.
+2. Read `import.meta.env.VITE_SUPABASE_URL` and
+   `import.meta.env.VITE_SUPABASE_ANON_KEY`.
+3. The sign-in form signs in with email/password.
+4. After sign-in, load and render only the current user's todos.
+5. The add-todo form inserts a todo for the current user. The table defaults `user_id`
+   from `auth.uid()`, so insert only the todo body.
+6. Checking a todo updates its `done` state in Supabase.
+7. Throw an error if any Supabase call fails.
+
+You may refactor the implementation, but keep the existing user-facing controls
+and `data-testid` attributes so the tests can drive the app.

--- a/evals/investigate-trigger-general-05/EVAL.ts
+++ b/evals/investigate-trigger-general-05/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-05/PROMPT.md
+++ b/evals/investigate-trigger-general-05/PROMPT.md
@@ -1,0 +1,43 @@
+---
+motivation: derived from build-functions-001-order-total; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Create a Supabase Edge Function named `order-total`.
+
+The function should accept only `POST` requests with a JSON body:
+
+```json
+{
+  "items": [
+    { "sku": "basic-plan", "unit_price_cents": 1200, "quantity": 2 }
+  ],
+  "customer_tier": "standard",
+  "coupon": "WELCOME10"
+}
+```
+
+Implement this behavior:
+
+1. Return `405` for non-`POST` requests.
+2. Return `400` with a JSON error if the body is invalid JSON, if `items` is
+   missing or empty, or if any item has a non-positive `unit_price_cents` or
+   `quantity`.
+3. Calculate `subtotal_cents` as the sum of `unit_price_cents * quantity`.
+4. Apply the best single discount:
+   - Coupon `WELCOME10`: 10% off subtotal, capped at 2000 cents.
+   - `customer_tier: "enterprise"`: 15% off subtotal.
+   - Discounts do not stack; use whichever discount is larger.
+5. Calculate `tax_cents` as 7.25% of the post-discount amount, rounded to the
+   nearest cent.
+6. Return `200` JSON with `subtotal_cents`, `discount_cents`, `tax_cents`, and
+   `total_cents`.
+
+Deploy the function with slug `order-total`. The deployed source should be a
+single `index.ts` file.

--- a/evals/investigate-trigger-general-06/EVAL.ts
+++ b/evals/investigate-trigger-general-06/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-06/PROMPT.md
+++ b/evals/investigate-trigger-general-06/PROMPT.md
@@ -1,0 +1,29 @@
+---
+motivation: derived from build-functions-002-edge-auth-db; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Create a Supabase Edge Function named `todo-create`.
+
+The function must:
+
+1. Accept only `POST` requests.
+2. Require the caller's `Authorization` header and forward it to Supabase.
+3. Use `@supabase/supabase-js` with:
+  - `Deno.env.get("SUPABASE_URL")`
+  - `Deno.env.get("SUPABASE_ANON_KEY")`
+4. Read JSON body `{ "body": "todo text" }`.
+5. Insert one row into the existing `todos` table. The table defaults `user_id`
+  from `auth.uid()`, so insert only the `body` value.
+6. Return `201` JSON containing the inserted row.
+7. Return a non-2xx JSON error for missing auth, invalid JSON, missing body, or
+  insert/select failures.
+
+Deploy the function with slug `todo-create`. The deployed source should be a
+single `index.ts` file.

--- a/evals/investigate-trigger-general-07/EVAL.ts
+++ b/evals/investigate-trigger-general-07/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-07/PROMPT.md
+++ b/evals/investigate-trigger-general-07/PROMPT.md
@@ -1,0 +1,48 @@
+---
+motivation: derived from build-functions-003-todos-crud-api; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Create a Supabase Edge Function named `todos-api`.
+
+The function must use `@supabase/supabase-js` with:
+
+- `Deno.env.get("SUPABASE_URL")`
+- `Deno.env.get("SUPABASE_ANON_KEY")`
+- The caller's `Authorization` header forwarded through `global.headers`
+
+Implement these routes:
+
+1. `GET /todos-api`
+  - Requires auth.
+  - Returns the caller's todos ordered by `created_at` ascending.
+  - Supports optional `?done=true|false`.
+  - Supports optional `?limit=` from 1 to 100, defaulting to 50.
+2. `POST /todos-api`
+  - Requires auth.
+  - Reads JSON body `{ "body": "todo text", "done": false }`.
+  - `body` is required and must be a non-empty string.
+  - `done` is optional and defaults to `false`.
+  - Returns `201` JSON containing the inserted row.
+3. `PATCH /todos-api/<uuid>`
+  - Requires auth.
+  - Accepts a JSON object with only `body` and/or `done`.
+  - Returns the updated row.
+  - Return `404` if the row does not belong to the caller or does not exist.
+4. `DELETE /todos-api/<uuid>`
+  - Requires auth.
+  - Deletes the caller's row and returns JSON `{ "deleted": true }`.
+  - Return `404` if the row does not belong to the caller or does not exist.
+
+Return JSON errors for missing auth (`401`), unsupported methods (`405`),
+invalid JSON (`400`), invalid UUID path params (`400`), invalid query params
+(`400`), and database failures.
+
+Deploy the function with slug `todos-api`. The deployed source should be a
+single `index.ts` file.

--- a/evals/investigate-trigger-general-11/EVAL.ts
+++ b/evals/investigate-trigger-general-11/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-11/PROMPT.md
+++ b/evals/investigate-trigger-general-11/PROMPT.md
@@ -1,0 +1,17 @@
+---
+motivation: derived from build-realtime-001-live-chat-updates; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+I'm building a simple chat app on Supabase.
+
+Users can send messages, and I want everyone in the same room to see new
+messages appear automatically without refreshing the page.
+
+Can you inspect the project and set up whatever Supabase needs for live updates?

--- a/evals/investigate-trigger-general-18/EVAL.ts
+++ b/evals/investigate-trigger-general-18/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-18/PROMPT.md
+++ b/evals/investigate-trigger-general-18/PROMPT.md
@@ -1,0 +1,21 @@
+---
+motivation: derived from deploy-functions-001-edge-function-secrets, AI-815
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Our weather widget currently calls WeatherAPI straight from the browser, which
+leaks our API key. I want to move that behind a Supabase Edge Function called
+`weather` that holds the key server-side and proxies the request.
+
+The function should read the key from an environment variable named
+`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project
+root.
+
+Deploy the function to our project so it's live, and make sure the deployed
+function can actually read the key at runtime.

--- a/evals/investigate-trigger-general-19/EVAL.ts
+++ b/evals/investigate-trigger-general-19/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-19/PROMPT.md
+++ b/evals/investigate-trigger-general-19/PROMPT.md
@@ -1,0 +1,17 @@
+---
+motivation: derived from deploy-self-hosting-001-docker-compose, AI-816, https://supabase.com/docs/guides/self-hosting/docker
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+I'm moving off the hosted Supabase and running the whole thing myself on a VPS I
+just spun up. Can you get a Docker setup ready for me to copy onto the box?
+
+I don't need it running here, I'll do the actual bring-up once I'm on the
+server. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`
+folder at the repo root so I can scp the whole thing across in one go.

--- a/evals/investigate-trigger-general-24/EVAL.ts
+++ b/evals/investigate-trigger-general-24/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-general-24/PROMPT.md
+++ b/evals/investigate-trigger-general-24/PROMPT.md
@@ -1,0 +1,21 @@
+---
+motivation: derived from investigate-realtime-001-subscribed-no-events, AI-819, REAL-577
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Our dispatch dashboard shows incoming orders as they happen. The courier
+location feed on the same page updates live without problems, but new orders
+only show up after a page refresh.
+
+The dashboard uses supabase-js to subscribe to INSERT events on the `orders`
+table through postgres_changes, the same way it subscribes to courier
+locations. The channel's status callback logs SUBSCRIBED and there are no
+errors in the browser console.
+
+Figure out why no order events ever arrive and fix it.

--- a/evals/investigate-trigger-monitoring-17/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-17/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-17/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-17/PROMPT.md
@@ -1,0 +1,13 @@
+---
+motivation: derived from deploy-database-001-prometheus-metrics, AI-817
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Can you wire my Supabase project metrics into our existing observability stack and document
+in the observability README what we need to do to make the config live?

--- a/evals/investigate-trigger-monitoring-22/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-22/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-22/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-22/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from investigate-functions-001-546-resource-limit, https://supabase.com/docs/guides/troubleshooting/edge-function-546-error-response, supabase/agent-skills#112
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Our `video-thumbnails` edge function has been failing intermittently since this morning. It generates a thumbnail from a user-uploaded video, and about half the calls are erroring out.
+
+Can you investigate the project logs and tell me what's going on and what we should do about it?

--- a/evals/investigate-trigger-monitoring-23/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-23/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-23/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-23/PROMPT.md
@@ -1,0 +1,20 @@
+---
+motivation: derived from investigate-logs-001-top-error-function; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Identify the edge function with the most errors in the last 15 minutes.
+
+Report:
+
+- The function id
+- The exact error count
+- The total event count for that function in the same window
+
+Use the available project observability data to answer.

--- a/evals/investigate-trigger-monitoring-25/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-25/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-25/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-25/PROMPT.md
@@ -1,0 +1,21 @@
+---
+motivation: derived from investigate-reliability-001-error-rate-spike; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Audit the recent edge-function logs for any reliability problem worth flagging.
+
+If you find one, report:
+
+- The affected function id
+- The observed error rate
+- Why the rate is concerning
+- A concrete next step to investigate or mitigate it
+
+Be specific. Vague answers like "review the logs" do not count.

--- a/evals/investigate-trigger-monitoring-26/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-26/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-26/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-26/PROMPT.md
@@ -1,0 +1,17 @@
+---
+motivation: derived from investigate-reliability-002-subtle-error-spike; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Audit recent edge-function logs for any reliability issue worth a human's
+attention.
+
+Report the affected function and explain why it is concerning. Be concrete
+about the window or grouping you used. Vague answers like "some errors are
+present" do not count.

--- a/evals/investigate-trigger-monitoring-27/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-27/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-27/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-27/PROMPT.md
@@ -1,0 +1,15 @@
+---
+motivation: derived from investigate-reliability-003-edge-function-5xx-correlation, AI-818, SU-341553, SU-341817
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.
+
+Can you investigate the project logs and tell me what is going on and what we
+should do next?

--- a/evals/investigate-trigger-monitoring-34/EVAL.ts
+++ b/evals/investigate-trigger-monitoring-34/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-monitoring-34/PROMPT.md
+++ b/evals/investigate-trigger-monitoring-34/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from resolve-reliability-001-unhealthy-project-recovery; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - observability
+---
+
+My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.
+
+Would restart or pause/restore be better?

--- a/evals/investigate-trigger-performance-33/EVAL.ts
+++ b/evals/investigate-trigger-performance-33/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-performance-33/PROMPT.md
+++ b/evals/investigate-trigger-performance-33/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from resolve-performance-001-slow-query-cpu-spike, AI-824, FDBKIN-1563, FDBKIN-17002, FDBKIN-1688, https://supabase.com/docs/guides/troubleshooting/high-cpu-usage
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?
+
+End your turn with a short summary of what you changed and why.

--- a/evals/investigate-trigger-schema-01/EVAL.ts
+++ b/evals/investigate-trigger-schema-01/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-schema-01/PROMPT.md
+++ b/evals/investigate-trigger-schema-01/PROMPT.md
@@ -1,0 +1,12 @@
+---
+motivation: derived from build-cli-002-declarative-schema, AI-814, https://supabase.com/docs/guides/local-development/declarative-database-schemas
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+Add a description text column to the `products` table in my local Supabase stack

--- a/evals/investigate-trigger-schema-03/EVAL.ts
+++ b/evals/investigate-trigger-schema-03/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-schema-03/PROMPT.md
+++ b/evals/investigate-trigger-schema-03/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from build-database-001-migrate-postgres-to-supabase, AI-825, https://supabase.com/docs/guides/platform/migrating-to-supabase/postgres
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.
+
+Can you set up a local Supabase project and restore the dump into it?

--- a/evals/investigate-trigger-schema-16/EVAL.ts
+++ b/evals/investigate-trigger-schema-16/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-schema-16/PROMPT.md
+++ b/evals/investigate-trigger-schema-16/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from build-vectors-001-rag-with-permissions, AI-811, FDBKIN-14517
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?
+
+Some documents are confidential, so users should only have access to documents they own.

--- a/evals/investigate-trigger-schema-21/EVAL.ts
+++ b/evals/investigate-trigger-schema-21/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-schema-21/PROMPT.md
+++ b/evals/investigate-trigger-schema-21/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from investigate-db-001-table-row-counts; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+List every user-defined table in the `public` schema and its exact row count.
+
+Report the results as table name plus count.

--- a/evals/investigate-trigger-schema-32/EVAL.ts
+++ b/evals/investigate-trigger-schema-32/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-schema-32/PROMPT.md
+++ b/evals/investigate-trigger-schema-32/PROMPT.md
@@ -1,0 +1,12 @@
+---
+motivation: derived from resolve-database-001-migration-history-mismatch, AI-823
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - sql
+---
+
+I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?

--- a/evals/investigate-trigger-security-08/EVAL.ts
+++ b/evals/investigate-trigger-security-08/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-08/PROMPT.md
+++ b/evals/investigate-trigger-security-08/PROMPT.md
@@ -1,0 +1,17 @@
+---
+motivation: derived from build-functions-004-service-role-bypass; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+I built an Edge Function called `private-notes` for showing a user's saved
+private notes.
+
+Can you check whether there's any way one user could see another user's notes?
+
+Please fix and deploy it if needed.

--- a/evals/investigate-trigger-security-09/EVAL.ts
+++ b/evals/investigate-trigger-security-09/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-security-09/PROMPT.md
+++ b/evals/investigate-trigger-security-09/PROMPT.md
@@ -1,0 +1,29 @@
+---
+motivation: derived from build-functions-005-dual-auth-user-secret, FDBKIN-19273
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Build and serve a Supabase Edge Function named `user-stats` for this project,
+reachable over HTTP at `/functions/v1/user-stats`.
+
+Our product stores per-user metrics in the existing `user_stats` table.
+
+Two very different callers need to hit this one endpoint:
+
+1. **Our mobile app**, acting for a signed-in user. It sends that user's
+   Supabase access token. The endpoint should return the user's own stats.
+
+2. **Our internal billing service**, a trusted backend with no signed-in user.
+   It authenticates with the project's secret (service-role) key in the `apikey`
+   header, and names the target user with a `user_id` in the JSON request body.
+   It needs that user's stats.
+
+Return the matching rows as JSON. The endpoint must be secure: only ever serve
+stats to a caller that is genuinely entitled to them, and turn away callers that
+are not.

--- a/evals/investigate-trigger-security-10/EVAL.ts
+++ b/evals/investigate-trigger-security-10/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-security-10/PROMPT.md
+++ b/evals/investigate-trigger-security-10/PROMPT.md
@@ -1,0 +1,40 @@
+---
+motivation: derived from build-functions-006-dual-auth-with-server, FDBKIN-19273
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Build and serve a Supabase Edge Function named `user-stats` for this project,
+reachable over HTTP at `/functions/v1/user-stats`.
+
+Implement it with the **`@supabase/server`** package, which is built for exactly
+this kind of multi-auth Edge Function. Import it directly in your function:
+
+```ts
+import { withSupabase } from "npm:@supabase/server";
+```
+
+Our product stores per-user metrics in a `user_stats` table that already exists
+(see `supabase/migrations/`), protected by row-level security so a user can read
+only their own rows.
+
+Two very different callers need to hit this one endpoint:
+
+1. **Our mobile app**, acting for a signed-in user. It sends that user's
+   Supabase access token. The endpoint should return the user's own stats.
+
+2. **Our internal billing service**, a trusted backend with no signed-in user.
+   It authenticates with the project's secret (service-role) key in the `apikey`
+   header, and names the target user with a `user_id` in the JSON request body.
+   It needs that user's stats.
+
+Return the matching rows as JSON. The endpoint must be secure: only ever serve
+stats to a caller that is genuinely entitled to them, and turn away callers that
+are not.
+
+Get the local stack running so the function is reachable at the path above.

--- a/evals/investigate-trigger-security-12/EVAL.ts
+++ b/evals/investigate-trigger-security-12/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-12/PROMPT.md
+++ b/evals/investigate-trigger-security-12/PROMPT.md
@@ -1,0 +1,31 @@
+---
+motivation: derived from build-rls-002-own-todos-client; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+You are working on a Supabase project for a todos app.
+
+The `todos` table already exists:
+
+```sql
+id uuid, user_id uuid, body text, done boolean, created_at timestamptz
+```
+
+`user_id` defaults to `auth.uid()`, so app code can insert a todo by sending only
+`body` / `done`.
+
+Add the RLS policies needed so that authenticated users can:
+
+1. `SELECT` only their own todos.
+2. `INSERT` only their own todos.
+3. `UPDATE` only their own todos.
+4. `DELETE` only their own todos.
+
+Apply the required database changes. End your turn when you believe the
+policies are in place.

--- a/evals/investigate-trigger-security-13/EVAL.ts
+++ b/evals/investigate-trigger-security-13/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-13/PROMPT.md
+++ b/evals/investigate-trigger-security-13/PROMPT.md
@@ -1,0 +1,37 @@
+---
+motivation: derived from build-rls-003-org-roles-permissions; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+You are working on a Supabase project for a multi-tenant document app.
+
+The schema has three tables already created and seeded:
+
+```sql
+-- memberships
+user_id uuid, org_id uuid, role text
+
+-- documents
+id uuid, org_id uuid, owner_id uuid, title text, body text, deleted_at timestamptz
+
+-- document_audit
+id uuid, document_id uuid, actor_id uuid, action text, ts timestamptz
+```
+
+Add the RLS policies and database logic needed for authenticated users:
+
+1. Viewers can read active documents in orgs where they are members.
+2. Editors can read active documents in their orgs, insert documents they own in their orgs, and update or delete only documents they own.
+3. Admins can read, update, and delete any active document in orgs where they are admins.
+4. Soft-deleted documents (`deleted_at IS NOT NULL`) should not be visible through normal reads.
+5. Deletes should be soft deletes by setting `deleted_at`; do not hard-delete rows.
+6. Every insert, update, and soft-delete should write a row to `document_audit` with the acting user.
+
+Apply the required database changes. End your turn when you believe the
+policies and audit behavior are in place.

--- a/evals/investigate-trigger-security-14/EVAL.ts
+++ b/evals/investigate-trigger-security-14/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-security-14/PROMPT.md
+++ b/evals/investigate-trigger-security-14/PROMPT.md
@@ -1,0 +1,21 @@
+---
+motivation: derived from build-storage-001-private-bucket-access, AI-810, STORAGE-478, AI-676
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Our app lets signed-in users keep personal files like receipts and bank
+statements. These files are private — a user must only ever be able to upload
+and download their own. The app uploads each file under a path that starts
+with the owner's user id, e.g. `<user_id>/receipt-march.pdf`.
+
+Set up a `user-files` bucket on our project and lock it down that way.
+
+Users also sometimes share one of their files with someone else through a
+temporary link that expires. Include the supabase-js code the app should use
+for that.

--- a/evals/investigate-trigger-security-15/EVAL.ts
+++ b/evals/investigate-trigger-security-15/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-15/PROMPT.md
+++ b/evals/investigate-trigger-security-15/PROMPT.md
@@ -1,0 +1,12 @@
+---
+motivation: derived from build-tests-001-rls-tenant-isolation, AI-813, FDBKIN-9635, FDBKIN-8983
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.

--- a/evals/investigate-trigger-security-20/EVAL.ts
+++ b/evals/investigate-trigger-security-20/EVAL.ts
@@ -1,0 +1,11 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(['supabase'], TRIGGER_SKILLS);

--- a/evals/investigate-trigger-security-20/PROMPT.md
+++ b/evals/investigate-trigger-security-20/PROMPT.md
@@ -1,0 +1,24 @@
+---
+motivation: derived from investigate-auth-001-deleted-user-access, AI-820, AI-422, https://supabase.com/docs/guides/troubleshooting/should-i-set-a-shorter-max-age-parameter-on-the-cookies-8sbF4V
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Last week support removed a user through our app's delete-account flow — the
+app calls the `delete_account` function over RPC as the signed-in user. This
+morning that same person was back: still signed in, reading and saving their
+data like nothing happened.
+
+Figure out why the account still works, fix the flow so a deleted account
+loses access, and tell me whether there is any window where they could still
+get in after the fix.
+
+One more thing while you're at it: we're migrating off the legacy
+anon/service_role API keys to the new publishable and secret keys, and the
+team isn't sure which one belongs in the frontend and what each means for
+RLS. Give us a quick rundown.

--- a/evals/investigate-trigger-security-28/EVAL.ts
+++ b/evals/investigate-trigger-security-28/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-28/PROMPT.md
+++ b/evals/investigate-trigger-security-28/PROMPT.md
@@ -1,0 +1,23 @@
+---
+motivation: derived from investigate-security-001-public-table; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+You have access to the project's database schema and recent logs.
+
+Identify any tables exposed to the public/anon role without proper Row Level
+Security in place. For each issue found, report:
+
+- The table name
+- The role(s) that can access it
+- Why this is a problem
+- A specific fix (SQL preferred)
+
+Be concrete. Vague answers like "consider reviewing your RLS settings" do not
+count.

--- a/evals/investigate-trigger-security-35/EVAL.ts
+++ b/evals/investigate-trigger-security-35/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-35/PROMPT.md
+++ b/evals/investigate-trigger-security-35/PROMPT.md
@@ -1,0 +1,17 @@
+---
+motivation: derived from resolve-security-001-rls-cross-user-leak; provenance carried by the canonical eval (see evals/trigger/MAPPING.md)
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Audit the RLS policies on this Supabase project.
+
+If any policy lets one authenticated user access another user's data, fix it in
+the database. Do not weaken existing legitimate access.
+
+End your turn when you believe the policies are correct.

--- a/evals/investigate-trigger-security-36/EVAL.ts
+++ b/evals/investigate-trigger-security-36/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-36/PROMPT.md
+++ b/evals/investigate-trigger-security-36/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from resolve-security-002-rls-cross-tenant-leak, AI-821
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+A customer reported that notes showed up in the wrong workspace.
+
+Can you investigate what is going on and fix it?

--- a/evals/investigate-trigger-security-37/EVAL.ts
+++ b/evals/investigate-trigger-security-37/EVAL.ts
@@ -1,0 +1,14 @@
+import { createSkillTriggerScorer } from '@supabase-evals/core';
+
+// ponytail: closed skill set inlined so this eval dir is self-contained and
+// does not import the trigger data files at runtime. Canonical list lives in
+// evals/trigger/golden.ts (TRIGGER_SKILLS).
+const TRIGGER_SKILLS = [
+  'supabase',
+  'supabase-postgres-best-practices',
+] as const;
+
+export default createSkillTriggerScorer(
+  ['supabase', 'supabase-postgres-best-practices'],
+  TRIGGER_SKILLS
+);

--- a/evals/investigate-trigger-security-37/PROMPT.md
+++ b/evals/investigate-trigger-security-37/PROMPT.md
@@ -1,0 +1,14 @@
+---
+motivation: derived from resolve-storage-001-upsert-missing-update-policy, https://supabase.com/docs/guides/troubleshooting/why-cant-i-uploadlistetc-my-public-bucket-Z6CmGt, supabase/agent-skills#112
+stage: investigate
+suite: trigger
+interface: mcp
+product:
+  - database
+topic:
+  - rls
+---
+
+Our app has a public `avatars` bucket so profile photos have a public URL. Each user's avatar is stored at `<user_id>/avatar.png`, and the app uploads it with `upsert: true` so a new photo replaces the old one at that same path.
+
+The very first upload for a user always works, but replacing an existing avatar fails. Find out why and fix it.

--- a/evals/trigger/MAPPING.md
+++ b/evals/trigger/MAPPING.md
@@ -1,0 +1,41 @@
+# Trigger suite → canonical eval mapping
+
+idx | canonical eval | category | expected | prompt (first 60 chars)
+00 | build-cli-001-bootstrap-app                      | general     | S+P | We're kicking off a todos app and I want the Supabase side r
+01 | build-cli-002-declarative-schema                 | schema      | S+P | Add a description text column to the `products` table in my 
+02 | build-cli-003-pg-cron-queue-workflow             | general     | S+P | I want to set up a recurring background workflow on my local
+03 | build-database-001-migrate-postgres-to-supabase  | schema      | S+P | I have an existing Postgres database I want to migrate to Su
+04 | build-frontend-001-todos-app                     | general     | S+P | Build the missing Supabase integration for this Vite + React
+05 | build-functions-001-order-total                  | general     | S   | Create a Supabase Edge Function named `order-total`.  The fu
+06 | build-functions-002-edge-auth-db                 | general     | S   | Create a Supabase Edge Function named `todo-create`.  The fu
+07 | build-functions-003-todos-crud-api               | general     | S   | Create a Supabase Edge Function named `todos-api`.  The func
+08 | build-functions-004-service-role-bypass          | security    | S+P | I built an Edge Function called `private-notes` for showing 
+09 | build-functions-005-dual-auth-user-secret        | security    | S   | Build and serve a Supabase Edge Function named `user-stats` 
+10 | build-functions-006-dual-auth-with-server        | security    | S   | Build and serve a Supabase Edge Function named `user-stats` 
+11 | build-realtime-001-live-chat-updates             | general     | S   | I'm building a simple chat app on Supabase.  Users can send 
+12 | build-rls-002-own-todos-client                   | security    | S+P | You are working on a Supabase project for a todos app.  The 
+13 | build-rls-003-org-roles-permissions              | security    | S+P | You are working on a Supabase project for a multi-tenant doc
+14 | build-storage-001-private-bucket-access          | security    | S   | Our app lets signed-in users keep personal files like receip
+15 | build-tests-001-rls-tenant-isolation             | security    | S+P | Can you audit the tenant isolation on our tables? Write some
+16 | build-vectors-001-rag-with-permissions           | schema      | S+P | We're adding semantic search to our internal knowledge base 
+17 | deploy-database-001-prometheus-metrics           | monitoring  | S   | Can you wire my Supabase project metrics into our existing o
+18 | deploy-functions-001-edge-function-secrets       | general     | S   | Our weather widget currently calls WeatherAPI straight from 
+19 | deploy-self-hosting-001-docker-compose           | general     | S   | I'm moving off the hosted Supabase and running the whole thi
+20 | investigate-auth-001-deleted-user-access         | security    | S   | Last week support removed a user through our app's delete-ac
+21 | investigate-db-001-table-row-counts              | schema      | S+P | List every user-defined table in the `public` schema and its
+22 | investigate-functions-001-546-resource-limit     | monitoring  | S   | Our `video-thumbnails` edge function has been failing interm
+23 | investigate-logs-001-top-error-function          | monitoring  | S   | Identify the edge function with the most errors in the last 
+24 | investigate-realtime-001-subscribed-no-events    | general     | S   | Our dispatch dashboard shows incoming orders as they happen.
+25 | investigate-reliability-001-error-rate-spike     | monitoring  | S   | Audit the recent edge-function logs for any reliability prob
+26 | investigate-reliability-002-subtle-error-spike   | monitoring  | S   | Audit recent edge-function logs for any reliability issue wo
+27 | investigate-reliability-003-edge-function-5xx-correlation | monitoring  | S   | Users have been reporting that image uploads are intermitten
+28 | investigate-security-001-public-table            | security    | S+P | You have access to the project's database schema and recent 
+29 | resolve-dataapi-001-empty-results                | data-ops    | S+P | Our app lets signed-in users save bookmarks and view them on
+30 | resolve-dataapi-002-secure-default-grants        | data-ops    | S+P | Our app lets signed-in users keep a private journal. Entries
+31 | resolve-dataapi-002-update-zero-rows-affected    | data-ops    | S+P | Our app lets signed-in users manage a personal `tasks` list.
+32 | resolve-database-001-migration-history-mismatch  | schema      | S+P | I'm trying to ship a migration to our hosted project and it'
+33 | resolve-performance-001-slow-query-cpu-spike     | performance | S+P | My database CPU keeps spiking and the app gets slow when loa
+34 | resolve-reliability-001-unhealthy-project-recovery | monitoring  | S   | My Supabase dashboard says my project is unhealthy, and the 
+35 | resolve-security-001-rls-cross-user-leak         | security    | S+P | Audit the RLS policies on this Supabase project.  If any pol
+36 | resolve-security-002-rls-cross-tenant-leak       | security    | S+P | A customer reported that notes showed up in the wrong worksp
+37 | resolve-storage-001-upsert-missing-update-policy | security    | S+P | Our app has a public `avatars` bucket so profile photos have

--- a/evals/trigger/README.md
+++ b/evals/trigger/README.md
@@ -1,0 +1,84 @@
+# Trigger suite
+
+Measures **skill triggering** — whether an agent loads the right skills from their
+descriptions alone — **not** end-state correctness. A passing run here says the agent
+recognized which skills a prompt needs; it says nothing about whether it solved the task.
+
+Each of the 38 evals reuses a prompt body from a canonical Supabase eval (see
+[`MAPPING.md`](./MAPPING.md)) as a realistic user message, then checks only which skills
+loaded. No sandbox, no database, no LLM judge — the scorer is pure analytics over the
+run's tool calls.
+
+## What it measures
+
+The closed set of skills under test is two:
+
+- `supabase` (S)
+- `supabase-postgres-best-practices` (P)
+
+Ground truth lives in [`golden.ts`](./golden.ts), one entry per prompt:
+
+- **S** is expected on every prompt — all 38 name Supabase or an unmistakable
+  Supabase-only concern (Edge Functions, Realtime, storage buckets, self-hosting).
+- **P** is expected only on Postgres-mechanics prompts — schema, RLS, migration,
+  query/index, performance. Edge-function/Realtime/storage/auth/self-hosting/
+  observability-integration prompts are Supabase-meta, not Postgres mechanics, so a
+  correct agent skips P.
+
+Per [`MAPPING.md`](./MAPPING.md): 20 prompts expect `S+P`, 18 expect `S` only. Categories
+span security (12), general (10), monitoring (7), schema (5), data-ops (3), performance (1).
+
+## Scorer
+
+Each eval's `EVAL.ts` is a one-liner over [`createSkillTriggerScorer`](../../packages/core/src/skill-trigger-scorer.ts)
+from `@supabase-evals/core`. It compares loaded skills against the expected set and emits
+one `CheckResult` per skill in the closed set:
+
+| expected | loaded | result |
+|----------|--------|--------|
+| yes | yes | `loaded <skill>` — pass |
+| yes | no | `loaded <skill>` — **fail** (missed) |
+| no | yes | `<skill> not expected` — **fail** (false positive) |
+| no | no | `correctly skipped <skill>` — pass |
+
+`passed = no missed && no false positive`. Deterministic — no LLM, no sandbox, no DB.
+The evals are `stage: investigate`, `suite: trigger`, `interface: mcp`, tools-mode with
+no `localStack`, so the scoring context's DB surface is unused.
+
+## Files
+
+- [`prompts.ts`](./prompts.ts) — the 38-prompt corpus (prompt text + category), indexed to
+  match `golden.ts`. Provenance stays with the canonical evals; no `motivation` is
+  duplicated here.
+- [`golden.ts`](./golden.ts) — hand-authored ground truth (expected skills per prompt).
+- [`contexts.ts`](./contexts.ts) — per-prompt context fixtures.
+- [`MAPPING.md`](./MAPPING.md) — idx → canonical eval, category, expected signal, prompt preview.
+- `../investigate-trigger-<category>-<idx>/` — the 38 eval dirs (`PROMPT.md` + `EVAL.ts`),
+  one per golden entry.
+
+## Running
+
+The suite is wired to the `trigger` experiment suite (custom, not `benchmark`):
+
+- [`experiments/trigger-claude-sonnet-5.ts`](../../experiments/trigger-claude-sonnet-5.ts) —
+  Claude with both skills available.
+- [`experiments/trigger-no-skills-claude-sonnet-5.ts`](../../experiments/trigger-no-skills-claude-sonnet-5.ts) —
+  no skills available; with nothing to load, every expected-skill check is a "missed". This
+  baseline contrasts P(pass | loaded) vs P(pass | not loaded) per skill.
+- [`experiments/trigger-openai-gpt-5.6.ts`](../../experiments/trigger-openai-gpt-5.6.ts) —
+  the OpenAI model with both skills.
+
+Run via the standard eval flow against the `trigger` suite, or use the standalone dev tool
+while iterating on a `SKILL.md` description (no eval dirs or golden data required):
+
+```bash
+pnpm eval -- --experiment=trigger-claude-sonnet-5              # full suite
+pnpm test-skill-triggers -- --skill=supabase-postgres-best-practices --category=schema
+```
+
+## Relationship to the canonical evals
+
+This suite is a parallel measurement layer over the canonical eval prompts. The canonical
+`evals/<id>/PROMPT.md` carries the scenario provenance (`motivation:`) and end-state
+scorers; the trigger evals reuse only the prompt text to probe skill selection. See
+[`MAPPING.md`](./MAPPING.md) for the per-eval derivation.

--- a/evals/trigger/contexts.ts
+++ b/evals/trigger/contexts.ts
@@ -1,0 +1,452 @@
+/**
+ * Simulated prior-conversation context blocks.
+ *
+ * Each context represents a realistic Claude Code session in progress —
+ * file reads, bash output, error messages, partial implementations —
+ * the kind of noise that fills a context window before a user asks a
+ * Supabase question mid-task.
+ *
+ * Injected as preceding messages in the API call so the model must
+ * identify relevant references with a half-full, noisy context.
+ */
+
+export type ContextMessage = { role: 'user' | 'assistant'; content: string };
+export type Context = {
+  name: string;
+  description: string;
+  messages: ContextMessage[];
+};
+
+export const contexts: Context[] = [
+  // ── 1. TypeScript refactor in progress ──────────────────────────────────────
+  {
+    name: 'ts-refactor',
+    description: 'Mid-refactor of a React/TypeScript codebase',
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Refactor UserProfile to use the new useUser hook and remove the direct service calls.',
+      },
+      {
+        role: 'assistant',
+        content: `I'll refactor it. Reading the current file first.
+
+\`\`\`typescript
+// src/components/UserProfile.tsx (current)
+import React, { useState, useEffect } from 'react';
+import { UserService } from '../services/user';
+import type { User } from '../types';
+
+interface Props { userId: string; onUpdate?: (u: User) => void; }
+
+export const UserProfile: React.FC<Props> = ({ userId, onUpdate }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    UserService.getById(userId)
+      .then(setUser)
+      .catch(() => setError('Failed to load'))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  if (loading) return <Spinner />;
+  if (error) return <ErrorBanner message={error} />;
+  return <div className="profile">{user?.name}</div>;
+};
+\`\`\`
+
+Refactored to use \`useUser\`:
+
+\`\`\`typescript
+// src/components/UserProfile.tsx (refactored)
+import React from 'react';
+import { useUser } from '../hooks/useUser';
+
+interface Props { userId: string; onUpdate?: (u: User) => void; }
+
+export const UserProfile: React.FC<Props> = ({ userId }) => {
+  const { user, loading, error } = useUser(userId);
+  if (loading) return <Spinner />;
+  if (error) return <ErrorBanner message={error.message} />;
+  return <div className="profile">{user?.name}</div>;
+};
+\`\`\``,
+      },
+      {
+        role: 'user',
+        content:
+          "Getting TS errors: Property 'avatar_url' does not exist on type 'User'. Also 'created_at' is missing.",
+      },
+      {
+        role: 'assistant',
+        content: `The \`User\` type is out of sync with the DB schema. Update \`src/types/index.ts\`:
+
+\`\`\`typescript
+export type User = {
+  id: string;
+  email: string;
+  name: string;
+  avatar_url: string | null;   // was missing
+  created_at: string;           // was missing
+  updated_at: string;
+};
+\`\`\`
+
+And the mock in tests:
+\`\`\`typescript
+const mockUser: User = {
+  id: 'user-123',
+  email: 'test@example.com',
+  name: 'Test User',
+  avatar_url: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+\`\`\``,
+      },
+      {
+        role: 'user',
+        content:
+          'Tests pass now. Can you also update the API route to validate the request body properly?',
+      },
+      {
+        role: 'assistant',
+        content: `Here's the updated route with Zod validation:
+
+\`\`\`typescript
+// src/app/api/users/[id]/route.ts
+import { z } from 'zod';
+import { NextRequest, NextResponse } from 'next/server';
+
+const UpdateUserSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  avatar_url: z.string().url().nullable().optional(),
+});
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const body = await req.json();
+  const parsed = UpdateUserSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  // update user in db...
+}
+\`\`\`
+
+The validation rejects unknown fields and enforces types at the API boundary.`,
+      },
+    ],
+  },
+
+  // ── 2. Debugging a broken CI pipeline ────────────────────────────────────────
+  {
+    name: 'ci-debug',
+    description: 'Debugging failing CI — test timeouts and env var issues',
+    messages: [
+      {
+        role: 'user',
+        content: `CI is failing on the integration tests. Here's the output:
+
+\`\`\`
+FAIL src/__tests__/integration/auth.test.ts
+  ● AuthService › login › should return JWT on valid credentials
+
+    Timeout - Async callback was not invoked within the 5000 ms timeout specified by jest.setTimeout.
+
+      at node_modules/jest-jasmine2/build/jasmine/Env.js:275:51
+
+  ● AuthService › login › should reject invalid password
+
+    expect(received).rejects.toThrow()
+
+    Received promise resolved instead of rejecting
+
+FAIL src/__tests__/integration/users.test.ts (12.4 s)
+  ● 3 tests failed
+\`\`\``,
+      },
+      {
+        role: 'assistant',
+        content: `Two separate issues:
+
+1. **Timeout** — the test is calling a real endpoint or waiting on a real DB. Check that \`TEST_DATABASE_URL\` points to a test DB and the connection isn't timing out:
+
+\`\`\`bash
+$ echo $TEST_DATABASE_URL
+# should be: postgresql://localhost:5432/myapp_test
+\`\`\`
+
+2. **Invalid password not rejected** — looks like \`bcrypt.compare\` might be getting the wrong hash. Check:
+
+\`\`\`typescript
+// AuthService.login (likely culprit)
+const valid = await bcrypt.compare(password, user.password_hash);
+//                                            ^^^ ensure this is the hash, not plaintext
+\`\`\`
+
+Add a \`jest.setTimeout(15000)\` at the top of the integration test file while you investigate the DB connection speed.`,
+      },
+      {
+        role: 'user',
+        content:
+          'TEST_DATABASE_URL was pointing to prod. Fixed. Now 47 tests pass but 3 still fail — all related to token expiry.',
+      },
+      {
+        role: 'assistant',
+        content: `Token expiry tests fail when system clock drift differs between where the token is signed and verified. Freeze time in tests:
+
+\`\`\`typescript
+import { jest } from '@jest/globals';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2024-06-01T00:00:00Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+it('rejects expired token', async () => {
+  const token = sign({ userId: '123' }, SECRET, { expiresIn: '1h' });
+  jest.advanceTimersByTime(2 * 60 * 60 * 1000); // +2 hours
+  await expect(verify(token)).rejects.toThrow('jwt expired');
+});
+\`\`\`
+
+This makes expiry deterministic regardless of when the test runs.`,
+      },
+      {
+        role: 'user',
+        content:
+          "All 50 tests passing now. Let's move on — I need to optimize some database stuff.",
+      },
+      { role: 'assistant', content: 'Sure, what are you working on?' },
+    ],
+  },
+
+  // ── 3. Large file read + partial implementation ───────────────────────────────
+  {
+    name: 'file-read-noise',
+    description:
+      'Agent just read several large files and is mid-implementation',
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Read the main entry point and the config so you understand the project structure.',
+      },
+      {
+        role: 'assistant',
+        content: `Read \`src/index.ts\` (187 lines):
+
+\`\`\`typescript
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { rateLimit } from 'express-rate-limit';
+import { errorHandler } from './middleware/errorHandler';
+import { requestLogger } from './middleware/logger';
+import { authRouter } from './routes/auth';
+import { usersRouter } from './routes/users';
+import { postsRouter } from './routes/posts';
+import { commentsRouter } from './routes/comments';
+import { db } from './db';
+import { config } from './config';
+
+const app = express();
+
+app.use(helmet());
+app.use(cors({ origin: config.allowedOrigins, credentials: true }));
+app.use(express.json({ limit: '10mb' }));
+app.use(requestLogger);
+app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100 }));
+
+app.use('/api/auth', authRouter);
+app.use('/api/users', usersRouter);
+app.use('/api/posts', postsRouter);
+app.use('/api/comments', commentsRouter);
+app.use(errorHandler);
+
+const start = async () => {
+  await db.connect();
+  app.listen(config.port, () => {
+    console.log(\`Server running on port \${config.port}\`);
+  });
+};
+
+start().catch(console.error);
+\`\`\`
+
+Read \`src/config.ts\` (64 lines):
+
+\`\`\`typescript
+import { z } from 'zod';
+
+const ConfigSchema = z.object({
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  PORT: z.coerce.number().default(3000),
+  DATABASE_URL: z.string(),
+  JWT_SECRET: z.string().min(32),
+  JWT_EXPIRES_IN: z.string().default('7d'),
+  ALLOWED_ORIGINS: z.string().default('http://localhost:3000'),
+  REDIS_URL: z.string().optional(),
+  LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+});
+
+const env = ConfigSchema.parse(process.env);
+
+export const config = {
+  env: env.NODE_ENV,
+  port: env.PORT,
+  db: { url: env.DATABASE_URL },
+  jwt: { secret: env.JWT_SECRET, expiresIn: env.JWT_EXPIRES_IN },
+  allowedOrigins: env.ALLOWED_ORIGINS.split(','),
+  redis: env.REDIS_URL,
+  logLevel: env.LOG_LEVEL,
+};
+\`\`\``,
+      },
+      {
+        role: 'user',
+        content:
+          "Now read the posts router — I think there's an N+1 query in there.",
+      },
+      {
+        role: 'assistant',
+        content: `Read \`src/routes/posts.ts\` (143 lines). Found it — line 67:
+
+\`\`\`typescript
+// ❌ N+1: fetches author for every post individually
+router.get('/', async (req, res) => {
+  const posts = await db.query('SELECT * FROM posts ORDER BY created_at DESC LIMIT 20');
+  const withAuthors = await Promise.all(
+    posts.rows.map(async (post) => {
+      const author = await db.query('SELECT id, name, avatar_url FROM users WHERE id = $1', [post.user_id]);
+      return { ...post, author: author.rows[0] };
+    })
+  );
+  res.json(withAuthors);
+});
+\`\`\`
+
+For 20 posts that's 21 queries. Fix with a JOIN:
+
+\`\`\`typescript
+// ✅ Single query
+router.get('/', async (req, res) => {
+  const result = await db.query(\`
+    SELECT p.*, u.id as author_id, u.name as author_name, u.avatar_url as author_avatar
+    FROM posts p
+    JOIN users u ON u.id = p.user_id
+    ORDER BY p.created_at DESC
+    LIMIT 20
+  \`);
+  res.json(result.rows.map(row => ({
+    ...row,
+    author: { id: row.author_id, name: row.author_name, avatar_url: row.author_avatar }
+  })));
+});
+\`\`\``,
+      },
+      {
+        role: 'user',
+        content:
+          'Good catch. Now I need your help with something in the database layer.',
+      },
+      { role: 'assistant', content: 'What do you need?' },
+    ],
+  },
+
+  // ── 4. Mixed noise — Slack export, bash output, errors ───────────────────────
+  {
+    name: 'mixed-noise',
+    description:
+      'Scattered context: bash output, stack traces, unrelated discussion',
+    messages: [
+      {
+        role: 'user',
+        content: `Here's the output from the deploy:
+
+\`\`\`
+$ pnpm build
+▶ Compiling TypeScript...
+  src/utils/cache.ts(34,12): error TS2322: Type 'undefined' is not assignable to type 'string'
+  src/utils/cache.ts(89,5): error TS2339: Property 'ttl' does not exist on type 'CacheOptions'
+
+▶ Build failed (2 errors)
+\`\`\``,
+      },
+      {
+        role: 'assistant',
+        content: `Two type errors in \`cache.ts\`. Fix:
+
+\`\`\`typescript
+// Line 34: add undefined to the return type or provide a fallback
+function getCacheKey(prefix: string, id: string | undefined): string {
+  return \`\${prefix}:\${id ?? 'global'}\`; // was: id (could be undefined)
+}
+
+// Line 89: add ttl to CacheOptions type
+interface CacheOptions {
+  ttl?: number;   // add this
+  namespace?: string;
+}
+\`\`\``,
+      },
+      {
+        role: 'user',
+        content: `Build passes. But now there's a runtime error in prod:
+
+\`\`\`
+UnhandledPromiseRejection: Error: connect ECONNREFUSED 127.0.0.1:6379
+    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1141:16)
+\`\`\``,
+      },
+      {
+        role: 'assistant',
+        content: `Redis is refusing connections — likely not running in the prod environment. Two options:
+
+1. **Start Redis** or point \`REDIS_URL\` to your managed instance (Upstash, Redis Cloud, etc.)
+2. **Make Redis optional** — fall back to in-memory if \`REDIS_URL\` is absent:
+
+\`\`\`typescript
+const redis = process.env.REDIS_URL
+  ? new Redis(process.env.REDIS_URL)
+  : null;
+
+async function getCached<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  if (!redis) return fn(); // graceful fallback
+  const cached = await redis.get(key);
+  if (cached) return JSON.parse(cached);
+  const result = await fn();
+  await redis.setex(key, 300, JSON.stringify(result));
+  return result;
+}
+\`\`\``,
+      },
+      {
+        role: 'user',
+        content:
+          'Perfect. Okay different topic — can you help me with the database schema?',
+      },
+      { role: 'assistant', content: 'Of course, what are you working on?' },
+    ],
+  },
+];
+
+/** Pick a random context, or a specific one by name */
+export function pickContext(name?: string): Context {
+  if (name) {
+    const found = contexts.find((c) => c.name === name);
+    if (!found)
+      throw new Error(
+        `Unknown context: "${name}". Available: ${contexts.map((c) => c.name).join(', ')}`
+      );
+    return found;
+  }
+  return contexts[Math.floor(Math.random() * contexts.length)];
+}

--- a/evals/trigger/golden.ts
+++ b/evals/trigger/golden.ts
@@ -1,0 +1,322 @@
+/**
+ * Hand-authored ground truth for the trigger suite, derived from the 38
+ * canonical Supabase eval prompts (evals/<id>/PROMPT.md). For each prompt,
+ * records which of the two closed-set skills should load on the prompt text
+ * alone.
+ *
+ * Rule (unchanged from the prior corpus):
+ *   supabase (S) ∈ expected  iff the prompt carries a Supabase signal. All 38
+ *     canonical prompts name Supabase (or an unmistakable Supabase-only
+ *     concern: Edge Functions, Realtime, storage buckets, self-hosting), so
+ *     every entry expects S.
+ *   supabase-postgres-best-practices (P) ∈ expected  iff the prompt is about
+ *     Postgres mechanics the reference rules cover — schema/RLS/migration/
+ *     query/index/performance. Edge-function/Realtime/storage/auth/
+ *     self-hosting/observability-integration prompts are Supabase-meta, not
+ *     Postgres mechanics, so a correct agent skips P on them.
+ */
+import type { Category } from './prompts.js';
+
+export const SKILL_SUPABASE = 'supabase';
+export const SKILL_POSTGRES = 'supabase-postgres-best-practices';
+
+/** The closed set of skills the trigger suite exercises. */
+export const TRIGGER_SKILLS = [SKILL_SUPABASE, SKILL_POSTGRES] as const;
+
+export type GoldenEntry = {
+  promptIndex: number;
+  category: Category;
+  expectedSkills: readonly string[];
+  sourceEval: string;
+  notes?: string;
+};
+
+const S = SKILL_SUPABASE;
+const P = SKILL_POSTGRES;
+
+export const golden: GoldenEntry[] = [
+  // 0: build-cli-001-bootstrap-app
+  {
+    promptIndex: 0,
+    category: 'general',
+    expectedSkills: [S, P],
+    sourceEval: 'build-cli-001-bootstrap-app',
+  },
+  // 1: build-cli-002-declarative-schema
+  {
+    promptIndex: 1,
+    category: 'schema',
+    expectedSkills: [S, P],
+    sourceEval: 'build-cli-002-declarative-schema',
+  },
+  // 2: build-cli-003-pg-cron-queue-workflow
+  {
+    promptIndex: 2,
+    category: 'general',
+    expectedSkills: [S, P],
+    sourceEval: 'build-cli-003-pg-cron-queue-workflow',
+  },
+  // 3: build-database-001-migrate-postgres-to-supabase
+  {
+    promptIndex: 3,
+    category: 'schema',
+    expectedSkills: [S, P],
+    sourceEval: 'build-database-001-migrate-postgres-to-supabase',
+  },
+  // 4: build-frontend-001-todos-app
+  {
+    promptIndex: 4,
+    category: 'general',
+    expectedSkills: [S, P],
+    sourceEval: 'build-frontend-001-todos-app',
+  },
+  // 5: build-functions-001-order-total
+  {
+    promptIndex: 5,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'build-functions-001-order-total',
+  },
+  // 6: build-functions-002-edge-auth-db
+  {
+    promptIndex: 6,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'build-functions-002-edge-auth-db',
+  },
+  // 7: build-functions-003-todos-crud-api
+  {
+    promptIndex: 7,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'build-functions-003-todos-crud-api',
+  },
+  // 8: build-functions-004-service-role-bypass
+  {
+    promptIndex: 8,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'build-functions-004-service-role-bypass',
+  },
+  // 9: build-functions-005-dual-auth-user-secret
+  {
+    promptIndex: 9,
+    category: 'security',
+    expectedSkills: [S],
+    sourceEval: 'build-functions-005-dual-auth-user-secret',
+  },
+  // 10: build-functions-006-dual-auth-with-server
+  {
+    promptIndex: 10,
+    category: 'security',
+    expectedSkills: [S],
+    sourceEval: 'build-functions-006-dual-auth-with-server',
+  },
+  // 11: build-realtime-001-live-chat-updates
+  {
+    promptIndex: 11,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'build-realtime-001-live-chat-updates',
+  },
+  // 12: build-rls-002-own-todos-client
+  {
+    promptIndex: 12,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'build-rls-002-own-todos-client',
+  },
+  // 13: build-rls-003-org-roles-permissions
+  {
+    promptIndex: 13,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'build-rls-003-org-roles-permissions',
+  },
+  // 14: build-storage-001-private-bucket-access
+  {
+    promptIndex: 14,
+    category: 'security',
+    expectedSkills: [S],
+    sourceEval: 'build-storage-001-private-bucket-access',
+  },
+  // 15: build-tests-001-rls-tenant-isolation
+  {
+    promptIndex: 15,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'build-tests-001-rls-tenant-isolation',
+  },
+  // 16: build-vectors-001-rag-with-permissions
+  {
+    promptIndex: 16,
+    category: 'schema',
+    expectedSkills: [S, P],
+    sourceEval: 'build-vectors-001-rag-with-permissions',
+  },
+  // 17: deploy-database-001-prometheus-metrics
+  {
+    promptIndex: 17,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'deploy-database-001-prometheus-metrics',
+  },
+  // 18: deploy-functions-001-edge-function-secrets
+  {
+    promptIndex: 18,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'deploy-functions-001-edge-function-secrets',
+  },
+  // 19: deploy-self-hosting-001-docker-compose
+  {
+    promptIndex: 19,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'deploy-self-hosting-001-docker-compose',
+  },
+  // 20: investigate-auth-001-deleted-user-access
+  {
+    promptIndex: 20,
+    category: 'security',
+    expectedSkills: [S],
+    sourceEval: 'investigate-auth-001-deleted-user-access',
+  },
+  // 21: investigate-db-001-table-row-counts
+  {
+    promptIndex: 21,
+    category: 'schema',
+    expectedSkills: [S, P],
+    sourceEval: 'investigate-db-001-table-row-counts',
+  },
+  // 22: investigate-functions-001-546-resource-limit
+  {
+    promptIndex: 22,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'investigate-functions-001-546-resource-limit',
+  },
+  // 23: investigate-logs-001-top-error-function
+  {
+    promptIndex: 23,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'investigate-logs-001-top-error-function',
+  },
+  // 24: investigate-realtime-001-subscribed-no-events
+  {
+    promptIndex: 24,
+    category: 'general',
+    expectedSkills: [S],
+    sourceEval: 'investigate-realtime-001-subscribed-no-events',
+  },
+  // 25: investigate-reliability-001-error-rate-spike
+  {
+    promptIndex: 25,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'investigate-reliability-001-error-rate-spike',
+  },
+  // 26: investigate-reliability-002-subtle-error-spike
+  {
+    promptIndex: 26,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'investigate-reliability-002-subtle-error-spike',
+  },
+  // 27: investigate-reliability-003-edge-function-5xx-correlation
+  {
+    promptIndex: 27,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'investigate-reliability-003-edge-function-5xx-correlation',
+  },
+  // 28: investigate-security-001-public-table
+  {
+    promptIndex: 28,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'investigate-security-001-public-table',
+  },
+  // 29: resolve-dataapi-001-empty-results
+  {
+    promptIndex: 29,
+    category: 'data-ops',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-dataapi-001-empty-results',
+  },
+  // 30: resolve-dataapi-002-secure-default-grants
+  {
+    promptIndex: 30,
+    category: 'data-ops',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-dataapi-002-secure-default-grants',
+  },
+  // 31: resolve-dataapi-002-update-zero-rows-affected
+  {
+    promptIndex: 31,
+    category: 'data-ops',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-dataapi-002-update-zero-rows-affected',
+  },
+  // 32: resolve-database-001-migration-history-mismatch
+  {
+    promptIndex: 32,
+    category: 'schema',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-database-001-migration-history-mismatch',
+  },
+  // 33: resolve-performance-001-slow-query-cpu-spike
+  {
+    promptIndex: 33,
+    category: 'performance',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-performance-001-slow-query-cpu-spike',
+  },
+  // 34: resolve-reliability-001-unhealthy-project-recovery
+  {
+    promptIndex: 34,
+    category: 'monitoring',
+    expectedSkills: [S],
+    sourceEval: 'resolve-reliability-001-unhealthy-project-recovery',
+  },
+  // 35: resolve-security-001-rls-cross-user-leak
+  {
+    promptIndex: 35,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-security-001-rls-cross-user-leak',
+  },
+  // 36: resolve-security-002-rls-cross-tenant-leak
+  {
+    promptIndex: 36,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-security-002-rls-cross-tenant-leak',
+  },
+  // 37: resolve-storage-001-upsert-missing-update-policy
+  {
+    promptIndex: 37,
+    category: 'security',
+    expectedSkills: [S, P],
+    sourceEval: 'resolve-storage-001-upsert-missing-update-policy',
+  },
+];
+
+/** Invariant: one golden entry per prompt, in index order. */
+export function assertGoldenCoversAll(
+  prompts: { text: string; category: Category }[]
+): void {
+  if (golden.length !== prompts.length) {
+    throw new Error(
+      `golden has ${golden.length} entries; prompts has ${prompts.length}`
+    );
+  }
+  for (let i = 0; i < golden.length; i++) {
+    if (golden[i].promptIndex !== i) {
+      throw new Error(
+        `golden[${i}].promptIndex=${golden[i].promptIndex}, expected ${i}`
+      );
+    }
+  }
+}

--- a/evals/trigger/prompts.ts
+++ b/evals/trigger/prompts.ts
@@ -1,0 +1,207 @@
+export type Category =
+  | 'schema'
+  | 'security'
+  | 'performance'
+  | 'data-ops'
+  | 'monitoring'
+  | 'general';
+
+export type Prompt = { text: string; category: Category };
+
+// Skill-trigger prompt corpus. Each entry is the prompt body from a canonical
+// Supabase eval (see evals/<id>/PROMPT.md), reused here as a realistic user
+// message to test whether the agent loads the right skill. Index == golden
+// promptIndex. No motivation frontmatter is duplicated here; the canonical
+// eval carries the provenance.
+export const prompts: Prompt[] = [
+  // 0: build-cli-001-bootstrap-app
+  {
+    text: "We're kicking off a todos app and I want the Supabase side ready for the team\nto build on. Set it up the way we'd run it in development, with schema changes\ntracked as migrations so they can be reviewed and replayed.\n\nFor the first slice we just need a `todos` table. Todos aren't public: anyone\nsigned in can read all of them, but nothing should be writable through the API\nfor now. Add a couple of sample todos so there's something to look at.\n\nBefore you hand it back, make sure the running API actually behaves that way —\nsigned-in users get the todos, signed-out requests get nothing.",
+    category: 'general',
+  },
+  // 1: build-cli-002-declarative-schema
+  {
+    text: 'Add a description text column to the `products` table in my local Supabase stack',
+    category: 'schema',
+  },
+  // 2: build-cli-003-pg-cron-queue-workflow
+  {
+    text: 'I want to set up a recurring background workflow on my local Supabase stack.\n\nCan you set up a cron job called `enqueue-tasks` to run every minute and push a task into a queue called `tasks`? Then add a `process-tasks` edge function that reads messages off the `tasks` queue and removes them, so a scheduled worker can keep the backlog drained.',
+    category: 'general',
+  },
+  // 3: build-database-001-migrate-postgres-to-supabase
+  {
+    text: "I have an existing Postgres database I want to migrate to Supabase. There's a binary dump at `source.dump` in the current directory.\n\nCan you set up a local Supabase project and restore the dump into it?",
+    category: 'schema',
+  },
+  // 4: build-frontend-001-todos-app
+  {
+    text: "Build the missing Supabase integration for this Vite + React todos app.\n\nThe Supabase project already has a `todos` table with RLS policies:\n\n```sql\ntodos(id uuid, user_id uuid default auth.uid(), body text, done boolean, created_at timestamptz)\n```\n\nThe project files are under `local/`. `local/src/App.tsx` already contains the UI\nmarkup and stable `data-testid`s used by the tests. Keep that UI shape intact\nand hook it up to Supabase.\n\nRequirements:\n\n1. Create a Supabase client using `@supabase/supabase-js`. You may create a\n   helper like `local/src/supabase.ts` or keep the client in `App.tsx`.\n2. Read `import.meta.env.VITE_SUPABASE_URL` and\n   `import.meta.env.VITE_SUPABASE_ANON_KEY`.\n3. The sign-in form signs in with email/password.\n4. After sign-in, load and render only the current user's todos.\n5. The add-todo form inserts a todo for the current user. The table defaults `user_id`\n   from `auth.uid()`, so insert only the todo body.\n6. Checking a todo updates its `done` state in Supabase.\n7. Throw an error if any Supabase call fails.\n\nYou may refactor the implementation, but keep the existing user-facing controls\nand `data-testid` attributes so the tests can drive the app.",
+    category: 'general',
+  },
+  // 5: build-functions-001-order-total
+  {
+    text: 'Create a Supabase Edge Function named `order-total`.\n\nThe function should accept only `POST` requests with a JSON body:\n\n```json\n{\n  "items": [\n    { "sku": "basic-plan", "unit_price_cents": 1200, "quantity": 2 }\n  ],\n  "customer_tier": "standard",\n  "coupon": "WELCOME10"\n}\n```\n\nImplement this behavior:\n\n1. Return `405` for non-`POST` requests.\n2. Return `400` with a JSON error if the body is invalid JSON, if `items` is\n   missing or empty, or if any item has a non-positive `unit_price_cents` or\n   `quantity`.\n3. Calculate `subtotal_cents` as the sum of `unit_price_cents * quantity`.\n4. Apply the best single discount:\n   - Coupon `WELCOME10`: 10% off subtotal, capped at 2000 cents.\n   - `customer_tier: "enterprise"`: 15% off subtotal.\n   - Discounts do not stack; use whichever discount is larger.\n5. Calculate `tax_cents` as 7.25% of the post-discount amount, rounded to the\n   nearest cent.\n6. Return `200` JSON with `subtotal_cents`, `discount_cents`, `tax_cents`, and\n   `total_cents`.\n\nDeploy the function with slug `order-total`. The deployed source should be a\nsingle `index.ts` file.',
+    category: 'general',
+  },
+  // 6: build-functions-002-edge-auth-db
+  {
+    text: 'Create a Supabase Edge Function named `todo-create`.\n\nThe function must:\n\n1. Accept only `POST` requests.\n2. Require the caller\'s `Authorization` header and forward it to Supabase.\n3. Use `@supabase/supabase-js` with:\n  - `Deno.env.get("SUPABASE_URL")`\n  - `Deno.env.get("SUPABASE_ANON_KEY")`\n4. Read JSON body `{ "body": "todo text" }`.\n5. Insert one row into the existing `todos` table. The table defaults `user_id`\n  from `auth.uid()`, so insert only the `body` value.\n6. Return `201` JSON containing the inserted row.\n7. Return a non-2xx JSON error for missing auth, invalid JSON, missing body, or\n  insert/select failures.\n\nDeploy the function with slug `todo-create`. The deployed source should be a\nsingle `index.ts` file.',
+    category: 'general',
+  },
+  // 7: build-functions-003-todos-crud-api
+  {
+    text: 'Create a Supabase Edge Function named `todos-api`.\n\nThe function must use `@supabase/supabase-js` with:\n\n- `Deno.env.get("SUPABASE_URL")`\n- `Deno.env.get("SUPABASE_ANON_KEY")`\n- The caller\'s `Authorization` header forwarded through `global.headers`\n\nImplement these routes:\n\n1. `GET /todos-api`\n  - Requires auth.\n  - Returns the caller\'s todos ordered by `created_at` ascending.\n  - Supports optional `?done=true|false`.\n  - Supports optional `?limit=` from 1 to 100, defaulting to 50.\n2. `POST /todos-api`\n  - Requires auth.\n  - Reads JSON body `{ "body": "todo text", "done": false }`.\n  - `body` is required and must be a non-empty string.\n  - `done` is optional and defaults to `false`.\n  - Returns `201` JSON containing the inserted row.\n3. `PATCH /todos-api/<uuid>`\n  - Requires auth.\n  - Accepts a JSON object with only `body` and/or `done`.\n  - Returns the updated row.\n  - Return `404` if the row does not belong to the caller or does not exist.\n4. `DELETE /todos-api/<uuid>`\n  - Requires auth.\n  - Deletes the caller\'s row and returns JSON `{ "deleted": true }`.\n  - Return `404` if the row does not belong to the caller or does not exist.\n\nReturn JSON errors for missing auth (`401`), unsupported methods (`405`),\ninvalid JSON (`400`), invalid UUID path params (`400`), invalid query params\n(`400`), and database failures.\n\nDeploy the function with slug `todos-api`. The deployed source should be a\nsingle `index.ts` file.',
+    category: 'general',
+  },
+  // 8: build-functions-004-service-role-bypass
+  {
+    text: "I built an Edge Function called `private-notes` for showing a user's saved\nprivate notes.\n\nCan you check whether there's any way one user could see another user's notes?\n\nPlease fix and deploy it if needed.",
+    category: 'security',
+  },
+  // 9: build-functions-005-dual-auth-user-secret
+  {
+    text: "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nOur product stores per-user metrics in the existing `user_stats` table.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.",
+    category: 'security',
+  },
+  // 10: build-functions-006-dual-auth-with-server
+  {
+    text: "Build and serve a Supabase Edge Function named `user-stats` for this project,\nreachable over HTTP at `/functions/v1/user-stats`.\n\nImplement it with the **`@supabase/server`** package, which is built for exactly\nthis kind of multi-auth Edge Function. Import it directly in your function:\n\n```ts\nimport { withSupabase } from \"npm:@supabase/server\";\n```\n\nOur product stores per-user metrics in a `user_stats` table that already exists\n(see `supabase/migrations/`), protected by row-level security so a user can read\nonly their own rows.\n\nTwo very different callers need to hit this one endpoint:\n\n1. **Our mobile app**, acting for a signed-in user. It sends that user's\n   Supabase access token. The endpoint should return the user's own stats.\n\n2. **Our internal billing service**, a trusted backend with no signed-in user.\n   It authenticates with the project's secret (service-role) key in the `apikey`\n   header, and names the target user with a `user_id` in the JSON request body.\n   It needs that user's stats.\n\nReturn the matching rows as JSON. The endpoint must be secure: only ever serve\nstats to a caller that is genuinely entitled to them, and turn away callers that\nare not.\n\nGet the local stack running so the function is reachable at the path above.",
+    category: 'security',
+  },
+  // 11: build-realtime-001-live-chat-updates
+  {
+    text: "I'm building a simple chat app on Supabase.\n\nUsers can send messages, and I want everyone in the same room to see new\nmessages appear automatically without refreshing the page.\n\nCan you inspect the project and set up whatever Supabase needs for live updates?",
+    category: 'general',
+  },
+  // 12: build-rls-002-own-todos-client
+  {
+    text: 'You are working on a Supabase project for a todos app.\n\nThe `todos` table already exists:\n\n```sql\nid uuid, user_id uuid, body text, done boolean, created_at timestamptz\n```\n\n`user_id` defaults to `auth.uid()`, so app code can insert a todo by sending only\n`body` / `done`.\n\nAdd the RLS policies needed so that authenticated users can:\n\n1. `SELECT` only their own todos.\n2. `INSERT` only their own todos.\n3. `UPDATE` only their own todos.\n4. `DELETE` only their own todos.\n\nApply the required database changes. End your turn when you believe the\npolicies are in place.',
+    category: 'security',
+  },
+  // 13: build-rls-003-org-roles-permissions
+  {
+    text: 'You are working on a Supabase project for a multi-tenant document app.\n\nThe schema has three tables already created and seeded:\n\n```sql\n-- memberships\nuser_id uuid, org_id uuid, role text\n\n-- documents\nid uuid, org_id uuid, owner_id uuid, title text, body text, deleted_at timestamptz\n\n-- document_audit\nid uuid, document_id uuid, actor_id uuid, action text, ts timestamptz\n```\n\nAdd the RLS policies and database logic needed for authenticated users:\n\n1. Viewers can read active documents in orgs where they are members.\n2. Editors can read active documents in their orgs, insert documents they own in their orgs, and update or delete only documents they own.\n3. Admins can read, update, and delete any active document in orgs where they are admins.\n4. Soft-deleted documents (`deleted_at IS NOT NULL`) should not be visible through normal reads.\n5. Deletes should be soft deletes by setting `deleted_at`; do not hard-delete rows.\n6. Every insert, update, and soft-delete should write a row to `document_audit` with the acting user.\n\nApply the required database changes. End your turn when you believe the\npolicies and audit behavior are in place.',
+    category: 'security',
+  },
+  // 14: build-storage-001-private-bucket-access
+  {
+    text: "Our app lets signed-in users keep personal files like receipts and bank\nstatements. These files are private — a user must only ever be able to upload\nand download their own. The app uploads each file under a path that starts\nwith the owner's user id, e.g. `<user_id>/receipt-march.pdf`.\n\nSet up a `user-files` bucket on our project and lock it down that way.\n\nUsers also sometimes share one of their files with someone else through a\ntemporary link that expires. Include the supabase-js code the app should use\nfor that.",
+    category: 'security',
+  },
+  // 15: build-tests-001-rls-tenant-isolation
+  {
+    text: 'Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.',
+    category: 'security',
+  },
+  // 16: build-vectors-001-rag-with-permissions
+  {
+    text: "We're adding semantic search to our internal knowledge base app. I already wrote the edge functions, but search doesn't work yet. Can you set up whatever the database needs to make search work end to end?\n\nSome documents are confidential, so users should only have access to documents they own.",
+    category: 'schema',
+  },
+  // 17: deploy-database-001-prometheus-metrics
+  {
+    text: 'Can you wire my Supabase project metrics into our existing observability stack and document\nin the observability README what we need to do to make the config live?',
+    category: 'monitoring',
+  },
+  // 18: deploy-functions-001-edge-function-secrets
+  {
+    text: "Our weather widget currently calls WeatherAPI straight from the browser, which\nleaks our API key. I want to move that behind a Supabase Edge Function called\n`weather` that holds the key server-side and proxies the request.\n\nThe function should read the key from an environment variable named\n`WEATHER_API_KEY`. Our key already lives in a local `.env` file at the project\nroot.\n\nDeploy the function to our project so it's live, and make sure the deployed\nfunction can actually read the key at runtime.",
+    category: 'general',
+  },
+  // 19: deploy-self-hosting-001-docker-compose
+  {
+    text: "I'm moving off the hosted Supabase and running the whole thing myself on a VPS I\njust spun up. Can you get a Docker setup ready for me to copy onto the box?\n\nI don't need it running here, I'll do the actual bring-up once I'm on the\nserver. I just want everything in place and the secrets set up. Put it in a `supabase-docker/`\nfolder at the repo root so I can scp the whole thing across in one go.",
+    category: 'general',
+  },
+  // 20: investigate-auth-001-deleted-user-access
+  {
+    text: "Last week support removed a user through our app's delete-account flow — the\napp calls the `delete_account` function over RPC as the signed-in user. This\nmorning that same person was back: still signed in, reading and saving their\ndata like nothing happened.\n\nFigure out why the account still works, fix the flow so a deleted account\nloses access, and tell me whether there is any window where they could still\nget in after the fix.\n\nOne more thing while you're at it: we're migrating off the legacy\nanon/service_role API keys to the new publishable and secret keys, and the\nteam isn't sure which one belongs in the frontend and what each means for\nRLS. Give us a quick rundown.",
+    category: 'security',
+  },
+  // 21: investigate-db-001-table-row-counts
+  {
+    text: 'List every user-defined table in the `public` schema and its exact row count.\n\nReport the results as table name plus count.',
+    category: 'schema',
+  },
+  // 22: investigate-functions-001-546-resource-limit
+  {
+    text: "Our `video-thumbnails` edge function has been failing intermittently since this morning. It generates a thumbnail from a user-uploaded video, and about half the calls are erroring out.\n\nCan you investigate the project logs and tell me what's going on and what we should do about it?",
+    category: 'monitoring',
+  },
+  // 23: investigate-logs-001-top-error-function
+  {
+    text: 'Identify the edge function with the most errors in the last 15 minutes.\n\nReport:\n\n- The function id\n- The exact error count\n- The total event count for that function in the same window\n\nUse the available project observability data to answer.',
+    category: 'monitoring',
+  },
+  // 24: investigate-realtime-001-subscribed-no-events
+  {
+    text: "Our dispatch dashboard shows incoming orders as they happen. The courier\nlocation feed on the same page updates live without problems, but new orders\nonly show up after a page refresh.\n\nThe dashboard uses supabase-js to subscribe to INSERT events on the `orders`\ntable through postgres_changes, the same way it subscribes to courier\nlocations. The channel's status callback logs SUBSCRIBED and there are no\nerrors in the browser console.\n\nFigure out why no order events ever arrive and fix it.",
+    category: 'general',
+  },
+  // 25: investigate-reliability-001-error-rate-spike
+  {
+    text: 'Audit the recent edge-function logs for any reliability problem worth flagging.\n\nIf you find one, report:\n\n- The affected function id\n- The observed error rate\n- Why the rate is concerning\n- A concrete next step to investigate or mitigate it\n\nBe specific. Vague answers like "review the logs" do not count.',
+    category: 'monitoring',
+  },
+  // 26: investigate-reliability-002-subtle-error-spike
+  {
+    text: 'Audit recent edge-function logs for any reliability issue worth a human\'s\nattention.\n\nReport the affected function and explain why it is concerning. Be concrete\nabout the window or grouping you used. Vague answers like "some errors are\npresent" do not count.',
+    category: 'monitoring',
+  },
+  // 27: investigate-reliability-003-edge-function-5xx-correlation
+  {
+    text: 'Users have been reporting that image uploads are intermittently failing with server errors throughout the morning of `2026-04-28`.\n\nCan you investigate the project logs and tell me what is going on and what we\nshould do next?',
+    category: 'monitoring',
+  },
+  // 28: investigate-security-001-public-table
+  {
+    text: 'You have access to the project\'s database schema and recent logs.\n\nIdentify any tables exposed to the public/anon role without proper Row Level\nSecurity in place. For each issue found, report:\n\n- The table name\n- The role(s) that can access it\n- Why this is a problem\n- A specific fix (SQL preferred)\n\nBe concrete. Vague answers like "consider reviewing your RLS settings" do not\ncount.',
+    category: 'security',
+  },
+  // 29: resolve-dataapi-001-empty-results
+  {
+    text: 'Our app lets signed-in users save bookmarks and view them on their dashboard. Bookmarks are stored in the `bookmarks` table and are private — a user must only ever see their own. \nUsers also need to be able to save new bookmarks from the app.\n\nI can see the rows when I query the table directly, but the dashboard shows an empty list for every user.\n\nFind out why the Data API returns nothing and fix it.',
+    category: 'data-ops',
+  },
+  // 30: resolve-dataapi-002-secure-default-grants
+  {
+    text: "Our app lets signed-in users keep a private journal. Entries are stored in the `journal_entries` table. A user should only ever see their own, and they need to be able to create new entries from the app.\n\nI can see the rows when I query the table directly, but the journal page shows an empty list for every signed-in user. New entries don't show up after saving either. Please figure out why and fix it.",
+    category: 'data-ops',
+  },
+  // 31: resolve-dataapi-002-update-zero-rows-affected
+  {
+    text: "Our app lets signed-in users manage a personal `tasks` list. Users can create tasks and check them off (`is_done`).\n\nCreating a task works fine, and I can see the row in the table. But when a user checks off a task, the app's update call succeeds with no error, yet `is_done` never actually changes, and the API doesn't return the updated row either.\n\nFind out why the update has no effect and fix it.",
+    category: 'data-ops',
+  },
+  // 32: resolve-database-001-migration-history-mismatch
+  {
+    text: "I'm trying to ship a migration to our hosted project and it's not working. Can you figure out what's wrong and get it deployed?",
+    category: 'schema',
+  },
+  // 33: resolve-performance-001-slow-query-cpu-spike
+  {
+    text: 'My database CPU keeps spiking and the app gets slow when loading recent events for a user. Can you figure out what query is causing it and make the database change needed to fix it?\n\nEnd your turn with a short summary of what you changed and why.',
+    category: 'performance',
+  },
+  // 34: resolve-reliability-001-unhealthy-project-recovery
+  {
+    text: 'My Supabase dashboard says my project is unhealthy, and the dashboard is unusable.\n\nWould restart or pause/restore be better?',
+    category: 'monitoring',
+  },
+  // 35: resolve-security-001-rls-cross-user-leak
+  {
+    text: "Audit the RLS policies on this Supabase project.\n\nIf any policy lets one authenticated user access another user's data, fix it in\nthe database. Do not weaken existing legitimate access.\n\nEnd your turn when you believe the policies are correct.",
+    category: 'security',
+  },
+  // 36: resolve-security-002-rls-cross-tenant-leak
+  {
+    text: 'A customer reported that notes showed up in the wrong workspace.\n\nCan you investigate what is going on and fix it?',
+    category: 'security',
+  },
+  // 37: resolve-storage-001-upsert-missing-update-policy
+  {
+    text: "Our app has a public `avatars` bucket so profile photos have a public URL. Each user's avatar is stored at `<user_id>/avatar.png`, and the app uploads it with `upsert: true` so a new photo replaces the old one at that same path.\n\nThe very first upload for a user always works, but replacing an existing avatar fails. Find out why and fix it.",
+    category: 'security',
+  },
+];

--- a/experiments/openai-gpt-5.6.ts
+++ b/experiments/openai-gpt-5.6.ts
@@ -1,4 +1,4 @@
-import { openai } from '@ai-sdk/openai';
+import { createOpenAI } from '@ai-sdk/openai';
 import {
   aiSdkAgent,
   defineExperiment,
@@ -7,12 +7,18 @@ import {
 } from '@supabase-evals/core';
 import { localStackRuntime } from '@supabase-evals/sandbox';
 
+// Routed through OpenRouter (BYOK'd with the OpenAI key) for the gpt-5.6-terra
+// discount — OpenRouter namespaces model ids by provider, hence "openai/...".
+const model = createOpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+})('openai/gpt-5.6-terra');
+
 export default defineExperiment({
   agent: aiSdkAgent({
-    model: openai('gpt-5.6'),
+    model,
     providerOptions: {
       openai: {
-        reasoningEffort: 'medium',
         textVerbosity: 'low',
       },
     },

--- a/experiments/trigger-claude-sonnet-5.ts
+++ b/experiments/trigger-claude-sonnet-5.ts
@@ -1,0 +1,37 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import {
+  aiSdkAgent,
+  defineExperiment,
+  platformLiteRuntime,
+  supabaseMcpServer,
+} from '@supabase-evals/core';
+
+// ponytail: route through OpenRouter's OpenAI-compatible endpoint when
+// OPENROUTER_API_KEY is set (billing fallback for local runs), else call
+// Anthropic directly. Same model either way — only the transport differs.
+const model = process.env.OPENROUTER_API_KEY
+  ? createOpenAI({
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })('anthropic/claude-sonnet-5')
+  : anthropic('claude-sonnet-5');
+
+// Skill-trigger suite: measures whether the agent loads the right skills from
+// their descriptions alone (clean run) and under a noisy context window
+// (`--noisy-context`). Tools mode, in-process ai-sdk agent (no sandbox) — the
+// scorer is deterministic (`createSkillTriggerScorer` in each EVAL.ts) and only
+// reads which skills loaded, so no localStack/runtime DB surface is exercised.
+export default defineExperiment({
+  suite: ['trigger'],
+  agent: aiSdkAgent({
+    model,
+    providerOptions: {
+      anthropic: { effort: 'max' },
+    },
+  }),
+  runtime: platformLiteRuntime({
+    mcpServers: [supabaseMcpServer()],
+  }),
+  skills: ['supabase', 'supabase-postgres-best-practices'],
+});

--- a/experiments/trigger-no-skills-claude-sonnet-5.ts
+++ b/experiments/trigger-no-skills-claude-sonnet-5.ts
@@ -1,0 +1,26 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import {
+  aiSdkAgent,
+  defineExperiment,
+  platformLiteRuntime,
+  supabaseMcpServer,
+} from '@supabase-evals/core';
+
+// Same as trigger-claude-sonnet-5 but with no skills available, so the
+// trigger-report correlation can contrast P(pass|loaded) vs P(pass|not
+// loaded) per skill. Runs against the same 97 trigger evals; with no skills the
+// agent cannot load any, so every expected-skill check is a "missed" — that
+// baseline is exactly the signal the report needs.
+export default defineExperiment({
+  suite: ['trigger'],
+  agent: aiSdkAgent({
+    model: anthropic('claude-sonnet-5'),
+    providerOptions: {
+      anthropic: { effort: 'max' },
+    },
+  }),
+  runtime: platformLiteRuntime({
+    mcpServers: [supabaseMcpServer()],
+  }),
+  skills: [],
+});

--- a/experiments/trigger-openai-gpt-5.6.ts
+++ b/experiments/trigger-openai-gpt-5.6.ts
@@ -1,0 +1,37 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import {
+  aiSdkAgent,
+  defineExperiment,
+  platformLiteRuntime,
+  supabaseMcpServer,
+} from '@supabase-evals/core';
+
+// Routed through OpenRouter (OpenAI-compatible endpoint) — same transport as
+// experiments/openai-gpt-5.6.ts. OpenRouter namespaces model ids by provider,
+// hence "openai/...". Chosen for the trigger suite after OpenRouter's account
+// data policy blocked the anthropic/claude-sonnet-5 route.
+const model = createOpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+})('openai/gpt-5.6-terra');
+
+// Skill-trigger suite on the OpenAI model: measures whether the agent loads the
+// right skills from their descriptions alone (clean run). Tools mode, in-process
+// ai-sdk agent (no sandbox) — the scorer is deterministic
+// (`createSkillTriggerScorer` in each EVAL.ts) and only reads which skills
+// loaded, so no localStack/runtime DB surface is exercised.
+export default defineExperiment({
+  suite: ['trigger'],
+  agent: aiSdkAgent({
+    model,
+    providerOptions: {
+      openai: {
+        textVerbosity: 'low',
+      },
+    },
+  }),
+  runtime: platformLiteRuntime({
+    mcpServers: [supabaseMcpServer()],
+  }),
+  skills: ['supabase', 'supabase-postgres-best-practices'],
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eval:force": "pnpm --filter @supabase-evals/framework eval:force",
     "test:framework": "pnpm --filter @supabase-evals/framework test:framework",
     "export-results": "pnpm --filter @supabase-evals/framework export-results",
+    "test-skill-triggers": "pnpm --filter @supabase-evals/framework test-skill-triggers",
     "typecheck": "pnpm --filter @supabase-evals/framework typecheck && pnpm --filter @supabase-evals/web typecheck",
     "web": "pnpm --filter @supabase-evals/web dev",
     "web:build": "pnpm --filter @supabase-evals/web build",

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -40,7 +40,12 @@ export const evalTopicSchema = z.enum([
 export const EVAL_TOPICS = evalTopicSchema.options;
 export type EvalTopic = z.infer<typeof evalTopicSchema>;
 
-export const evalSuiteSchema = z.enum(['benchmark', 'regression', 'other']);
+export const evalSuiteSchema = z.enum([
+  'benchmark',
+  'regression',
+  'other',
+  'trigger',
+]);
 export const EVAL_SUITES = evalSuiteSchema.options;
 export type EvalSuite = z.infer<typeof evalSuiteSchema>;
 
@@ -48,6 +53,7 @@ export const experimentSuiteSchema = z.enum([
   'benchmark',
   'no-skills',
   'regression',
+  'trigger',
 ]);
 export const EXPERIMENT_SUITES = experimentSuiteSchema.options;
 export type ExperimentSuite = z.infer<typeof experimentSuiteSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,13 +12,14 @@ import type { ToolName } from './transcript/types.js';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { createMCPClient } from '@ai-sdk/mcp';
 import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
-import { openai } from '@ai-sdk/openai';
+import { createOpenAI, openai } from '@ai-sdk/openai';
 import {
   Output,
   generateText,
   stepCountIs,
   type JSONValue,
   type LanguageModel,
+  type ModelMessage,
   type ToolSet,
 } from 'ai';
 import ts from 'typescript';
@@ -36,11 +37,9 @@ import {
 import type {
   AgentHarnessId,
   CheckResult,
-  EvalSuite,
   ExperimentDisplayMetadata,
   ExperimentSuite,
   ModelProvider,
-  ReasoningEffortLevel,
 } from './eval-metadata.js';
 import { reasoningEffortSchema } from './eval-metadata.js';
 import type { AgentMetadata, AgentSandbox } from './agents/types.js';
@@ -117,6 +116,12 @@ export { createParser, supportedParsers } from './agents/registry.js';
 export { adaptTranscript } from './parsers/adapt.js';
 export type { AdaptedTranscript } from './parsers/adapt.js';
 export type { AgentTranscriptParser } from './parsers/types.js';
+// Deterministic scorer factory for skill-trigger-quality evals (the trigger
+// suite): compares loaded skills vs a hand-authored expected set.
+export {
+  createSkillTriggerScorer,
+  loadedSkillsFromToolCalls,
+} from './skill-trigger-scorer.js';
 export type {
   ToolName,
   TranscriptEvent,
@@ -364,6 +369,14 @@ export type AgentRunArgs = {
   tools?: ToolSet;
   mcpServers?: Record<string, McpServerConfig>;
   /**
+   * Prior conversation injected before `userPrompt` to simulate a half-full,
+   * noisy context window (the trigger suite's `--noisy-context` mode). Only
+   * `aiSdkAgent` honors this: it sends `system` + `messages: [...priorMessages,
+   * {user}]` instead of `system` + `prompt`. CLI agents are one-shot and ignore
+   * it (the harness prepends a text block to their prompt instead).
+   */
+  priorMessages?: ModelMessage[];
+  /**
    * Execution environment for CLI agents (Claude Code, Codex, …). In-process
    * agents like `aiSdkAgent` ignore it; CLI agents need it to run their binary,
    * edit the workspace, and read back their transcript. Provided by the
@@ -560,7 +573,12 @@ const judgeOutputSchema = z.object({
   notes: z.string(),
 });
 
-const DEFAULT_JUDGE_MODEL = openai('gpt-5.5');
+const DEFAULT_JUDGE_MODEL = process.env.OPENROUTER_API_KEY
+  ? createOpenAI({
+      baseURL: 'https://openrouter.ai/api/v1',
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })('openai/gpt-5.5')
+  : openai('gpt-5.5');
 const DEFAULT_JUDGE_PROVIDER_OPTIONS: AiSdkProviderOptions = {
   openai: {
     reasoningEffort: 'low',
@@ -590,11 +608,11 @@ export async function judge(args: JudgeInput): Promise<JudgeResult> {
 }
 
 function getModelProvider(provider: string, modelId: string): ModelProvider {
-  if (provider.startsWith('anthropic') || modelId.startsWith('claude-')) {
+  if (provider.startsWith('anthropic') || modelId.includes('claude-')) {
     return 'anthropic';
   }
 
-  if (provider.startsWith('openai') || modelId.startsWith('gpt-')) {
+  if (provider.startsWith('openai') || modelId.includes('gpt-')) {
     return 'openai';
   }
 
@@ -609,7 +627,12 @@ export function aiSdkAgent(options: {
   const configuredEffort = po?.anthropic?.effort ?? po?.openai?.reasoningEffort;
   const reasoningEffort =
     reasoningEffortSchema.safeParse(configuredEffort).data;
-  const modelId = options.model.modelId;
+  // OpenRouter-routed models carry a vendor-prefixed slug (e.g.
+  // "anthropic/claude-sonnet-5") required on the wire, but that's a transport
+  // detail — direct-provider runs of the same model report the bare id (e.g.
+  // "claude-sonnet-5"). Normalize so results/labels for one experiment don't
+  // fork depending on which transport happened to run them.
+  const modelId = options.model.modelId.replace(/^[\w-]+\//, '');
   return {
     id: 'ai-sdk',
     modelId,
@@ -628,8 +651,24 @@ export function aiSdkAgent(options: {
         ? await createAiSdkTools(args.mcpServers)
         : [];
       const toolCalls: ToolCallRecord[] = [];
+      // Seed the transcript with the system prompt, then any prior conversation
+      // (trigger suite noisy-context mode), then the user prompt. priorMessages
+      // are {user|assistant, string} from the distractor templates — non-string
+      // content is stringified defensively; a 'system' role would fold to 'user',
+      // but the templates never emit one.
+      const priorTranscript: TranscriptPart[] = (args.priorMessages ?? []).map(
+        (m) => ({
+          type: 'message' as const,
+          role: m.role === 'assistant' ? 'assistant' : ('user' as 'user'),
+          content:
+            typeof m.content === 'string'
+              ? m.content
+              : JSON.stringify(m.content),
+        })
+      );
       const transcript: TranscriptPart[] = [
         { type: 'message', role: 'system', content: args.systemPrompt },
+        ...priorTranscript,
         { type: 'message', role: 'user', content: args.userPrompt },
       ];
       const tools = mergeToolSets([
@@ -638,11 +677,16 @@ export function aiSdkAgent(options: {
       ]);
 
       try {
-        const result = await generateText({
+        // When prior context is supplied, send it as real turns before the user
+        // prompt; otherwise the plain one-shot prompt. `tools` and the
+        // discriminating prompt/messages key stay inline so generateText's
+        // overloaded generics resolve; the rest is shared boilerplate. Two
+        // calls because prompt and messages are mutually exclusive on the
+        // options union — a conditional spread would leave both optional and
+        // match no overload.
+        const common = {
           model: options.model,
           system: args.systemPrompt,
-          prompt: args.userPrompt,
-          tools,
           stopWhen: stepCountIs(MAX_STEPS),
           maxOutputTokens: MAX_OUTPUT_TOKENS,
           timeout: { totalMs: args.timeoutSec * 1000 },
@@ -650,7 +694,10 @@ export function aiSdkAgent(options: {
             options.model.provider,
             options.providerOptions
           ),
-          experimental_onToolCallFinish: (event) => {
+          experimental_onToolCallFinish: (event: {
+            toolCall: { toolName: string; input: unknown };
+            output?: unknown;
+          }) => {
             const input = isRecord(event.toolCall.input)
               ? event.toolCall.input
               : {};
@@ -673,7 +720,17 @@ export function aiSdkAgent(options: {
               ts: Date.now(),
             });
           },
-        });
+        };
+        const result = args.priorMessages
+          ? await generateText({
+              ...common,
+              tools,
+              messages: [
+                ...args.priorMessages,
+                { role: 'user' as const, content: args.userPrompt },
+              ],
+            })
+          : await generateText({ ...common, tools, prompt: args.userPrompt });
 
         // Build the transcript from every step's content so the judge sees
         // all user-facing assistant text, not just the final step's text.
@@ -1196,7 +1253,11 @@ const MAX_OUTPUT_TOKENS = 4096;
 const RUNTIME_URL = 'http://supabase-evals.local';
 
 function assertProviderReady(provider: string): void {
-  if (provider.startsWith('openai') && !process.env.OPENAI_API_KEY) {
+  if (
+    provider.startsWith('openai') &&
+    !process.env.OPENAI_API_KEY &&
+    !process.env.OPENROUTER_API_KEY
+  ) {
     throw new Error(
       'Missing OpenAI credentials. Set OPENAI_API_KEY before running OpenAI evals.'
     );

--- a/packages/core/src/skill-trigger-scorer.ts
+++ b/packages/core/src/skill-trigger-scorer.ts
@@ -1,0 +1,59 @@
+import type { CheckResult, ToolCallRecord, ToolScorer } from './index.js';
+
+/** The unique skill names actually loaded during a run (from `load_skill` tool calls). */
+export function loadedSkillsFromToolCalls(
+  toolCalls: ToolCallRecord[]
+): string[] {
+  const set = new Set<string>();
+  for (const call of toolCalls) {
+    for (const skill of call.loadedSkills ?? []) set.add(skill);
+  }
+  return [...set];
+}
+
+/**
+ * Builds a deterministic `ToolScorer` for skill-trigger-quality evals: compares
+ * the skills the agent actually loaded against a hand-authored expected set,
+ * emitting one `CheckResult` per skill in the closed set.
+ *
+ *   expected & loaded   → `loaded <skill>`            passed  (loaded-correct)
+ *   expected & !loaded  → `loaded <skill>`            FAILED  (missed)
+ *   !expected & loaded  → `<skill> not expected`      FAILED  (false-positive)
+ *   !expected & !loaded → `correctly skipped <skill>`  passed  (correctly inactive)
+ *
+ * `passed = no missed && no false-positive`. Pure analytics over `ctx.toolCalls`
+ * — no LLM, no sandbox, no DB. The trigger evals are tools-mode with no
+ * `localStack`, so the scoring context's DB surface is unused.
+ */
+export function createSkillTriggerScorer(
+  expectedSkills: readonly string[],
+  allSkills: readonly string[]
+): ToolScorer {
+  const expected = new Set(expectedSkills);
+  return async (ctx) => {
+    const loaded = new Set(loadedSkillsFromToolCalls(ctx.toolCalls));
+    const checks: CheckResult[] = [];
+    for (const skill of allSkills) {
+      const want = expected.has(skill);
+      const got = loaded.has(skill);
+      if (want && got) {
+        checks.push({ name: `loaded ${skill}`, passed: true });
+      } else if (want && !got) {
+        checks.push({
+          name: `loaded ${skill}`,
+          passed: false,
+          notes: `expected ${skill} to load; it did not`,
+        });
+      } else if (!want && got) {
+        checks.push({
+          name: `${skill} not expected`,
+          passed: false,
+          notes: `${skill} loaded but not expected for this prompt`,
+        });
+      } else {
+        checks.push({ name: `correctly skipped ${skill}`, passed: true });
+      }
+    }
+    return { passed: checks.every((check) => check.passed), checks };
+  };
+}


### PR DESCRIPTION
## What

Adds a **skill-trigger eval suite** — a measurement layer that scores whether an agent *loads the right skills* in response to a prompt, independent of whether it reaches the correct end state. Existing evals measure end-state correctness; this measures the prerequisite skill-selection step.

## Why

The benchmark tells us an agent solved a problem, not whether it loaded the right skill to do so. The trigger suite isolates skill *triggering*: given a closed skill set, did the agent call `load_skill` for the expected skill(s)? A model that reaches the right answer without the right skill, or fails to load a skill it needed, both surface here — signal the end-state benchmark misses.

## What's in it

**Core (`packages/core`)**
- `skill-trigger-scorer.ts` — `createSkillTriggerScorer(expectedSkills, allSkills)`: a deterministic `ToolScorer` over `ctx.toolCalls.loadedSkills`. Compares the set of skills an agent loaded against a hand-authored expected set; no LLM judge.
- `eval-metadata.ts` — adds `'trigger'` to `evalSuiteSchema` + `experimentSuiteSchema`.
- `index.ts` — `aiSdkAgent` gains:
  - `priorMessages?: ModelMessage[]` on `AgentRunArgs` → noisy-context mode (sends `system` + `messages: [...priorMessages, {user}]` instead of `system` + `prompt`). The trigger suite measures trigger-quality against a half-full context window.
  - OpenRouter judge routing (`createOpenAI` + `OPENROUTER_API_KEY`) so judge runs don't require a direct OpenAI key; bare `openai('gpt-5.5')` still used when the key is absent.
  - `getModelProvider` uses `.includes` (not `.startsWith`) and `modelId` is normalized (`replace(/^[\w-]+\//, '')`) so OpenRouter-prefixed slugs don't fork results/labels from direct-provider runs of the same model.

**Framework (`apps/framework`)**
- `harness/run-eval.ts` — refactored to use a shared `tools-skills.ts` loader; noisy-context (trigger suite) support.
- `scripts/build-golden.ts`, `gen-trigger-evals.ts`, `test-skill-triggers.ts`, `trigger-report.ts` — golden-set construction, eval generation, and reporting for the suite.

**Evals (`evals/`)**
- 38 trigger evals (`investigate-trigger-*`, `resolve-*`) across data-ops, general, monitoring, security, schema topics. Each `PROMPT.md` carries a `motivation:` citing evidence (support tickets AI-XXX, docs URLs, derived-from parent evals) per CONTRIBUTING.
- `evals/trigger/README.md` — the 84-line suite README (closed skill set: `supabase` (S) + `supabase-postgres-best-practices` (P); deterministic scorer; run commands).

**Experiments (`experiments/`)**
- `trigger-claude-sonnet-5.ts`, `no-skills-claude-sonnet-5.ts`, `openai-gpt-5.6.ts` (OpenRouter-routed).

## Closed skill set

Two skills only — keeps the trigger signal unambiguous:
- **S** = `supabase`
- **P** = `supabase-postgres-best-practices`

A prompt expecting S is scored on whether the agent loaded S; loading P instead is a miss.

## Scoring

Deterministic, not LLM-judge: `createSkillTriggerScorer` reports precision/recall over loaded-vs-expected skills. Noisy-context runs measure trigger-quality when the context window is half-full of distractor conversation.

## How to run

```bash
pnpm tsx apps/framework/scripts/test-skill-triggers.ts
# or via the trigger experiment:
pnpm --filter @supabase-evals/framework tsx experiments/trigger-claude-sonnet-5.ts
```

## Verification

- `pnpm typecheck` — green (framework + web).
- `pnpm format:check` — green (repo files; the only reported errors are in gitignored `.remember/tmp/` local session artifacts, not in CI scope).
- No new dependencies (suite adds zero deps; the lockfile is unchanged from `main`).

## Results

Adding the `run-evals-changed` label to refresh the trigger evals' results in CI. (Result dirs are gitignored locally; the refresh workflow commits them.)

## Scope note

This is the **suite** half of a split from the `agent-prism` branch. A sibling PR adds the **AgentPrism trace viewer** (web UI to visualize any eval run); it depends on nothing here and can land independently.