### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @supabase/ai


### PR DESCRIPTION
Adds a CODEOWNERS file pointing the whole repo at `@supabase/ai`, so we can turn on "require review from Code Owners" in branch protection.

This is needed for [Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) PRs (e.g. supabase/evals#175): the bot can never be a code owner, so this setting guarantees a named human still reviews before merge.

**References:**
- https://supabase.slack.com/archives/C051L8U2EJF?thread_ts=1786027360.167159&cid=C051L8U2EJF
