### PR TITLE
fix: keep LLM credentials out of the eval scorer environment

### DIFF
--- a/apps/framework/harness/project-runner.ts
+++ b/apps/framework/harness/project-runner.ts
@@ -12,6 +12,13 @@ import type { CommandResult, VitestResult } from '@supabase-evals/core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
+const PROJECT_DB_URL = 'http://supabase-evals.local';
+const PROJECT_DB_ANON_KEY = 'supabase-evals-anon-key';
+const PROJECT_DB_JWT_SECRET = 'supabase-evals-dev-secret';
+const PROJECT_ENV = {
+  VITE_SUPABASE_URL: PROJECT_DB_URL,
+  VITE_SUPABASE_ANON_KEY: PROJECT_DB_ANON_KEY,
+};
 
 // Vite/vitest resolve their own package (and the workspace's deps, e.g. react)
 // by walking up from the workspace looking for a node_modules dir. Workspaces
@@ -26,7 +33,8 @@ export async function viteBuild(workspace: string): Promise<CommandResult> {
   return runNodeBin(
     join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js'),
     ['build'],
-    workspace
+    workspace,
+    PROJECT_ENV
   );
 }
 
@@ -63,7 +71,7 @@ export async function vitestRun(workspace: string): Promise<VitestResult> {
       `--outputFile=${reportPath}`,
     ],
     workspace,
-    { SUPABASE_EVALS_WORKSPACE: workspace }
+    { ...PROJECT_ENV, SUPABASE_EVALS_WORKSPACE: workspace }
   );
   const parsed = existsSync(reportPath)
     ? parseVitestReport(reportPath)
@@ -79,9 +87,9 @@ import { afterAll } from "vitest";
 import { App, getAuthSchemaSql, SUPABASE_AUTH_HELPERS_SQL } from "@supabase/lite";
 import { createPgliteConnection } from "@supabase/lite/pglite";
 
-const PROJECT_DB_URL = "http://supabase-evals.local";
-const PROJECT_DB_ANON_KEY = "supabase-evals-anon-key";
-const PROJECT_DB_JWT_SECRET = "supabase-evals-dev-secret";
+const PROJECT_DB_URL = ${JSON.stringify(PROJECT_DB_URL)};
+const PROJECT_DB_ANON_KEY = ${JSON.stringify(PROJECT_DB_ANON_KEY)};
+const PROJECT_DB_JWT_SECRET = ${JSON.stringify(PROJECT_DB_JWT_SECRET)};
 const AUTH_SQL = \`
 CREATE ROLE anon NOLOGIN;
 CREATE ROLE authenticated NOLOGIN;

--- a/apps/framework/harness/project-runner.ts
+++ b/apps/framework/harness/project-runner.ts
@@ -2,6 +2,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  rmSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -23,9 +24,12 @@ const PROJECT_ENV = {
 // Vite/vitest resolve their own package (and the workspace's deps, e.g. react)
 // by walking up from the workspace looking for a node_modules dir. Workspaces
 // live under results/, outside ROOT, so link ROOT's node_modules in directly.
+// The link replaces anything already there, since an agent that ran npm install
+// in the sandbox exports its own node_modules.
 function linkNodeModules(workspace: string) {
   const link = join(workspace, 'node_modules');
-  if (!existsSync(link)) symlinkSync(join(ROOT, 'node_modules'), link, 'dir');
+  rmSync(link, { recursive: true, force: true });
+  symlinkSync(join(ROOT, 'node_modules'), link, 'dir');
 }
 
 export async function viteBuild(workspace: string): Promise<CommandResult> {

--- a/apps/framework/harness/project-runner.ts
+++ b/apps/framework/harness/project-runner.ts
@@ -157,7 +157,7 @@ async function runNodeBin(
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [bin, ...args], {
       cwd,
-      env: { ...process.env, ...env },
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -475,14 +475,6 @@ async function smokeFrontendBuildTooling() {
   cpSync(join(ROOT, FRONTEND_EVAL, 'tests'), join(workspace, 'tests'), {
     recursive: true,
   });
-  writeFileSync(
-    join(workspace, '.env.local'),
-    [
-      'VITE_SUPABASE_URL=http://supabase-evals.local',
-      'VITE_SUPABASE_ANON_KEY=supabase-evals-anon-key',
-      '',
-    ].join('\n')
-  );
   writeFileSync(join(workspace, 'src', 'App.tsx'), GOOD_FRONTEND_APP);
   writeFileSync(
     join(workspace, 'vite.config.ts'),

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -484,11 +484,56 @@ async function smokeFrontendBuildTooling() {
     ].join('\n')
   );
   writeFileSync(join(workspace, 'src', 'App.tsx'), GOOD_FRONTEND_APP);
+  writeFileSync(
+    join(workspace, 'vite.config.ts'),
+    [
+      "import { defineConfig } from 'vite';",
+      "import react from '@vitejs/plugin-react';",
+      '',
+      'if (',
+      '  process.env.ANTHROPIC_API_KEY ||',
+      '  process.env.OPENAI_API_KEY ||',
+      '  process.env.AI_GATEWAY_API_KEY',
+      ") throw new Error('inherited LLM credential');",
+      '',
+      'export default defineConfig({ plugins: [react()] });',
+      '',
+    ].join('\n')
+  );
+  writeFileSync(
+    join(workspace, 'tests', 'environment.test.ts'),
+    [
+      "import { expect, test } from 'vitest';",
+      '',
+      "test('does not inherit LLM credentials', () => {",
+      '  expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();',
+      '  expect(process.env.OPENAI_API_KEY).toBeUndefined();',
+      '  expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();',
+      '});',
+      '',
+    ].join('\n')
+  );
 
-  const build = await viteBuild(workspace);
-  assert.equal(build.ok, true, build.stderr || build.stdout);
-  const vitest = await vitestRun(workspace);
-  assert.equal(vitest.ok, true, vitest.stderr || vitest.stdout);
+  const originalEnv = {
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
+  };
+  process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
+  process.env.OPENAI_API_KEY = 'test-openai-key';
+  process.env.AI_GATEWAY_API_KEY = 'test-ai-gateway-key';
+
+  try {
+    const build = await viteBuild(workspace);
+    assert.equal(build.ok, true, build.stderr || build.stdout);
+    const vitest = await vitestRun(workspace);
+    assert.equal(vitest.ok, true, vitest.stderr || vitest.stdout);
+  } finally {
+    for (const [name, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
 
   console.log('PASS frontend vite/react/supalite build + test tooling');
 }

--- a/apps/framework/scripts/smoke-framework.ts
+++ b/apps/framework/scripts/smoke-framework.ts
@@ -501,6 +501,8 @@ async function smokeFrontendBuildTooling() {
       '  expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();',
       '  expect(process.env.OPENAI_API_KEY).toBeUndefined();',
       '  expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();',
+      '  // PATH is always set in a real env, so this catches a blocklist regression the checks above would miss.',
+      '  expect(process.env.PATH).toBeUndefined();',
       '});',
       '',
     ].join('\n')


### PR DESCRIPTION
Reduces secret exposure risk and fixes the (unused) eval where it was a risk.

- `vite build` and `vitest`scorer subprocesses no longer inherit CI's `process.env`, so agent can't accidentally print sensitive keys into result `notes`
- New regression test to verifies subprocesses can't see keys
- Scored projects now get `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` from the harness, to fix `build-frontend-001-todos-app` failing with `supabaseUrl is required`
- Linking `node_modules` into the workspace now replaces whatever is there (previously, if agent ran `npm install` it'd populate `node_modules` and then block the symlink step and break `vite` deps)

Sanity checked `build-frontend-001-todos-app` runs + passes w/ the changes, plus a couple unrelated evals (`build-rls-002-own-todos-client` and `investigate-db-001-table-row-counts`) to check for regressions.

Closes AI-1004
