### PR TITLE
feat(framework): add docs:local content API loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ evals/*/local/supabase/.branches/
 results/*/
 .sync-tmp/
 
+/.local-docs/

--- a/apps/framework/harness/mcp-launch.ts
+++ b/apps/framework/harness/mcp-launch.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
+import { MCP_SERVER_VERSION } from '@supabase-evals/core';
+
+/** First stable MCP release containing supabase/mcp#343. */
+export const CONTENT_API_FLAG_MIN_VERSION = '0.10.0';
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
+
+export function supportsContentApiFlag(version: string): boolean {
+  const parse = (value: string, label: string) => {
+    const match = VERSION_RE.exec(value.trim());
+    if (!match) {
+      throw new Error(
+        `${label} is not a MAJOR.MINOR.PATCH version: ${JSON.stringify(value)}`
+      );
+    }
+    return {
+      numbers: [Number(match[1]), Number(match[2]), Number(match[3])],
+      prerelease: match[4] !== undefined,
+    };
+  };
+  const current = parse(version, 'mcp server version');
+  const minimum = parse(
+    CONTENT_API_FLAG_MIN_VERSION,
+    'CONTENT_API_FLAG_MIN_VERSION'
+  );
+  if (current.prerelease) return false;
+  for (let index = 0; index < 3; index++) {
+    if (current.numbers[index] !== minimum.numbers[index]) {
+      return current.numbers[index] > minimum.numbers[index];
+    }
+  }
+  return true;
+}
+
+export function resolveMcpServerPath(raw: string): string {
+  let path = isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
+  if (!existsSync(path)) throw new Error(`--mcp path does not exist: ${path}`);
+  const packageDir = join(path, 'packages', 'mcp-server-supabase');
+  if (existsSync(packageDir)) path = packageDir;
+  if (!existsSync(join(path, 'dist', 'transports', 'stdio.js'))) {
+    throw new Error(
+      `no built server at ${path} (dist/transports/stdio.js missing) — build it first:\n  pnpm install && pnpm build`
+    );
+  }
+  try {
+    const localVersion = JSON.parse(
+      readFileSync(join(path, 'package.json'), 'utf8')
+    ).version;
+    if (localVersion && localVersion !== MCP_SERVER_VERSION) {
+      console.error(
+        `note: local mcp build is v${localVersion}; the harness fixture (platform-lite) tracks the v${MCP_SERVER_VERSION} pin — endpoint drift is possible`
+      );
+    }
+  } catch {
+    // An unversioned checkout is valid when it has the expected built entry.
+  }
+  return realpathSync(path);
+}
+
+const CONTENT_API_OPTION = /[,{]\s*(["'])(?:--)?content-api-url\1\s*:/;
+
+export function validateContentApi(
+  contentApiUrl: string,
+  mcpServerPath?: string
+) {
+  if (!mcpServerPath) {
+    if (supportsContentApiFlag(MCP_SERVER_VERSION)) return;
+    throw new Error(
+      `--content-api needs --mcp <path>: the harness launches the pinned v${MCP_SERVER_VERSION} package, which has no --content-api-url flag (added in v${CONTENT_API_FLAG_MIN_VERSION} via supabase/mcp#343), so search_docs would query production docs while the receipt claims ${contentApiUrl}`
+    );
+  }
+  const stdio = join(mcpServerPath, 'dist', 'transports', 'stdio.js');
+  if (!CONTENT_API_OPTION.test(readFileSync(stdio, 'utf8'))) {
+    throw new Error(
+      `the mcp build at ${mcpServerPath} has no --content-api-url flag (predates supabase/mcp#343) — search_docs would query production docs, not ${contentApiUrl}`
+    );
+  }
+}

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -12,7 +12,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { jsonSchema, tool, type ToolSet } from 'ai';
 import { parseEvalMarkdown } from '@supabase-evals/core/eval-markdown';
@@ -33,6 +33,7 @@ import {
 } from '../lib/cli-args.js';
 import { bootPlatformBackend } from './platform-backend.js';
 import { viteBuild, vitestRun } from './project-runner.js';
+import { resolveMcpServerPath, validateContentApi } from './mcp-launch.js';
 import {
   buildDocsResult,
   buildSkillResult,
@@ -103,6 +104,7 @@ const SMOKE = args.has('--smoke');
 const DRY = args.has('--dry');
 const STRICT = args.has('--strict');
 const MCP_PATH = readFlag(rawArgs, 'mcp');
+const CONTENT_API_URL = readFlag(rawArgs, 'content-api');
 const EXPERIMENT_FILTERS = readRepeatedFlag(rawArgs, 'experiment').map(
   normalizeExperimentName
 );
@@ -671,6 +673,7 @@ type Provenance = {
   generatedAt: string;
   host: { sha?: string; branch?: string; dirtyFiles: number };
   mcpOverride?: { path: string; sha?: string; dirtyFiles?: number };
+  contentApiUrl?: string;
   platform: string;
 };
 
@@ -684,7 +687,10 @@ function tryGit(args: string[], cwd: string): string | undefined {
   }
 }
 
-function collectProvenance(mcpPath?: string): Provenance {
+function collectProvenance(
+  mcpPath?: string,
+  contentApiUrl?: string
+): Provenance {
   const dirty = (cwd: string) =>
     (tryGit(['status', '--porcelain'], cwd) ?? '').split('\n').filter(Boolean)
       .length;
@@ -705,32 +711,8 @@ function collectProvenance(mcpPath?: string): Provenance {
       dirtyFiles: repository ? dirty(repository) : undefined,
     };
   }
+  if (contentApiUrl) provenance.contentApiUrl = contentApiUrl;
   return provenance;
-}
-
-function resolveMcpServerPath(raw: string): string {
-  let path = isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
-  if (!existsSync(path)) throw new Error(`--mcp path does not exist: ${path}`);
-  const packageDir = join(path, 'packages', 'mcp-server-supabase');
-  if (existsSync(packageDir)) path = packageDir;
-  if (!existsSync(join(path, 'dist', 'transports', 'stdio.js'))) {
-    throw new Error(
-      `no built server at ${path} (dist/transports/stdio.js missing) — build it first:\n  pnpm install && pnpm build`
-    );
-  }
-  try {
-    const localVersion = JSON.parse(
-      readFileSync(join(path, 'package.json'), 'utf8')
-    ).version;
-    if (localVersion && localVersion !== MCP_SERVER_VERSION) {
-      console.error(
-        `note: local mcp build is v${localVersion}; the harness fixture (platform-lite) tracks the v${MCP_SERVER_VERSION} pin — endpoint drift is possible`
-      );
-    }
-  } catch {
-    // An unversioned checkout is valid when it has the expected built entry.
-  }
-  return realpathSync(path);
 }
 
 function validateJudgeKeys(evals: readonly EvalManifest[]) {
@@ -811,6 +793,10 @@ async function main() {
 
   const mcpPath = MCP_PATH ? resolveMcpServerPath(MCP_PATH) : undefined;
   if (mcpPath) process.env.SUPABASE_MCP_SERVER_PATH = mcpPath;
+  if (CONTENT_API_URL) {
+    validateContentApi(CONTENT_API_URL, mcpPath);
+    process.env.SUPABASE_CONTENT_API_URL = CONTENT_API_URL;
+  }
 
   const allExperiments = await loadExperiments();
   if (EXPERIMENT_FILTERS.length > 0) {
@@ -946,7 +932,7 @@ async function main() {
 
   validateJudgeKeys([...new Set(allWork.map(({ ev }) => ev))]);
   if (!DEBUG) console.error = () => undefined;
-  const provenance = collectProvenance(mcpPath);
+  const provenance = collectProvenance(mcpPath, CONTENT_API_URL);
 
   let localStackTurn = Promise.resolve();
   const errored: Error[] = [];

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -80,6 +80,7 @@ const CLI_ARGS = {
   ],
   valueFlags: [
     'mcp',
+    'content-api',
     'experiment',
     'eval',
     'suite',
@@ -90,7 +91,7 @@ const CLI_ARGS = {
   ],
   positionals: ['list'],
   usage:
-    'Usage: pnpm eval -- [list] [--skip-existing] [--smoke] [--dry] [--strict] [--run-all-attempts] [--debug] [--mcp PATH] [--experiment NAME] [--eval ID] [--suite SUITE] [--experiment-suite SUITE] [--runs N] [--timeout-sec N] [--concurrency N]',
+    'Usage: pnpm eval -- [list] [--skip-existing] [--smoke] [--dry] [--strict] [--run-all-attempts] [--debug] [--mcp PATH] [--content-api URL] [--experiment NAME] [--eval ID] [--suite SUITE] [--experiment-suite SUITE] [--runs N] [--timeout-sec N] [--concurrency N]',
 } as const;
 try {
   validateCliArgs(rawArgs, CLI_ARGS);

--- a/apps/framework/lib/cli-args.test.ts
+++ b/apps/framework/lib/cli-args.test.ts
@@ -85,7 +85,13 @@ describe('run-eval argument validation', () => {
   });
 
   it('accepts a valid list invocation', () => {
-    const result = run('list', '--experiment-suite', 'benchmark');
+    const result = run(
+      'list',
+      '--experiment-suite',
+      'benchmark',
+      '--content-api',
+      'http://127.0.0.1:9999'
+    );
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('codex-gpt-5.6');
   });

--- a/apps/framework/package.json
+++ b/apps/framework/package.json
@@ -8,6 +8,7 @@
     "eval": "node --env-file-if-exists=../../.env --import tsx/esm harness/run-eval.ts",
     "eval:dry": "node --env-file-if-exists=../../.env --import tsx/esm harness/run-eval.ts --dry",
     "eval:smoke": "node --env-file-if-exists=../../.env --import tsx/esm harness/run-eval.ts --smoke",
+    "docs:local": "node --env-file-if-exists=../../.env --import tsx/esm scripts/local-docs.ts",
     "eval:vercel": "node --env-file=../../.env --import tsx/esm scripts/run-vercel-evals.ts",
     "typecheck": "tsc --noEmit",
     "test:framework": "node --env-file-if-exists=../../.env --import tsx/esm scripts/smoke-framework.ts",

--- a/apps/framework/scripts/docs/content-api-server.ts
+++ b/apps/framework/scripts/docs/content-api-server.ts
@@ -1,0 +1,71 @@
+// fallow-ignore-file unused-file -- loaded at runtime (spawned/injected by local-docs.ts), never statically imported
+/**
+ * Standalone docs content GraphQL API for `search_docs`.
+ *
+ * Serves the docs app's own route handler (apps/docs/app/api/graphql/route.ts
+ * in a supabase/supabase checkout) over plain node:http — no Next server.
+ * Launched by `pnpm docs:local api` with the docs checkout's tsx so the
+ * route's TS + tsconfig conditions resolve; DOCS_ROUTE_PATH points at the
+ * checkout, PORT picks the listen port.
+ */
+import { createServer } from 'node:http';
+import { pathToFileURL } from 'node:url';
+
+const routePath = process.env.DOCS_ROUTE_PATH;
+if (!routePath) {
+  console.error(
+    'DOCS_ROUTE_PATH not set — run this through `pnpm docs:local api`'
+  );
+  process.exit(1);
+}
+// The docs checkout location is user-supplied at runtime; a static import
+// cannot name it.
+const route = await import(pathToFileURL(routePath).href);
+const handlers: Record<string, (req: Request) => Promise<Response>> = {
+  GET: route.GET,
+  OPTIONS: route.OPTIONS,
+  POST: route.POST,
+};
+const port = Number(process.env.PORT ?? 3001);
+
+createServer(async (incoming, outgoing) => {
+  const url = new URL(
+    incoming.url ?? '/',
+    `http://${incoming.headers.host ?? `127.0.0.1:${port}`}`
+  );
+  const handler = handlers[incoming.method ?? ''];
+  if (url.pathname !== '/docs/api/graphql' || !handler) {
+    outgoing.writeHead(404).end();
+    return;
+  }
+
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(incoming.headers)) {
+    if (Array.isArray(value))
+      for (const item of value) headers.append(name, item);
+    else if (value !== undefined) headers.set(name, value);
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of incoming) chunks.push(Buffer.from(chunk));
+  const body =
+    incoming.method === 'GET' || incoming.method === 'HEAD'
+      ? undefined
+      : Buffer.concat(chunks).toString('utf8');
+  const response = await handler(
+    new Request(url, { method: incoming.method, headers, body })
+  );
+
+  outgoing.writeHead(
+    response.status,
+    Object.fromEntries(response.headers.entries())
+  );
+  outgoing.end(Buffer.from(await response.arrayBuffer()));
+  // Bind every interface, advertise loopback — same rule as platform-lite in
+  // tools mode (see run-eval.ts: sandboxed CLI agents run their MCP servers
+  // INSIDE the container and reach host-side services via
+  // host.docker.internal, which arrives on the host's bridge interface, not
+  // loopback; a 127.0.0.1-only listener refuses those connections).
+}).listen(port, '0.0.0.0', () => {
+  console.log(`Docs content API: http://127.0.0.1:${port}/docs/api/graphql`);
+});

--- a/apps/framework/scripts/docs/sentry-stub-loader.mjs
+++ b/apps/framework/scripts/docs/sentry-stub-loader.mjs
@@ -1,0 +1,11 @@
+// fallow-ignore-file unused-file -- registered at runtime by sentry-stub-register.mjs via module.register()
+// Loader-thread resolve hook: '@sentry/nextjs' -> the no-op stub.
+const stubUrl = new URL('./sentry-stub.mjs', import.meta.url).href;
+
+// fallow-ignore-next-line unused-export -- Node loader-hook contract: the module system calls `resolve`
+export async function resolve(specifier, context, next) {
+  if (specifier === '@sentry/nextjs') {
+    return { url: stubUrl, shortCircuit: true };
+  }
+  return next(specifier, context);
+}

--- a/apps/framework/scripts/docs/sentry-stub-register.mjs
+++ b/apps/framework/scripts/docs/sentry-stub-register.mjs
@@ -1,0 +1,9 @@
+// fallow-ignore-file unused-file -- loaded at runtime (spawned/injected by local-docs.ts), never statically imported
+// Registers a resolve hook that short-circuits '@sentry/nextjs' to the local
+// no-op stub. Injected via NODE_OPTIONS from `pnpm local docs api`; chains with tsx's
+// own hooks (ours only intercepts the one specifier). Uses module.register()
+// (Node 20.6+) rather than registerHooks() (22.15+) — mise pins node "22",
+// which an older 22.x install satisfies.
+import { register } from 'node:module';
+
+register('./sentry-stub-loader.mjs', import.meta.url);

--- a/apps/framework/scripts/docs/sentry-stub.mjs
+++ b/apps/framework/scripts/docs/sentry-stub.mjs
@@ -1,0 +1,9 @@
+// fallow-ignore-file unused-file -- loaded at runtime (spawned/injected by local-docs.ts), never statically imported
+// No-op @sentry/nextjs stand-in for the standalone docs content API.
+// The route handler calls Sentry.captureException/flush; under plain tsx
+// (outside Next's Sentry instrumentation) the real package's ESM build
+// resolves without those functions and every request crashes. A local dev
+// adapter has no business sending telemetry anyway. Wired up by
+// sentry-stub-register.mjs (see local-docs.ts).
+export const captureException = () => '';
+export const flush = async () => true;

--- a/apps/framework/scripts/local-docs.ts
+++ b/apps/framework/scripts/local-docs.ts
@@ -1,0 +1,333 @@
+/**
+ * local-docs.ts — minimal local docs loop for `search_docs` evals.
+ *
+ *   pnpm docs:local up   --docs <path-to-supabase-monorepo-checkout>
+ *   pnpm docs:local seed             # full embed via the docs app's own pipeline (~$0.12 OpenAI; asks first)
+ *   pnpm docs:local api  [--port N]  # serve the content GraphQL API (foreground; keep it running)
+ *   pnpm docs:local down
+ *
+ * Then point evals at it:
+ *   pnpm eval -- --content-api http://127.0.0.1:3001/docs/api/graphql
+ *
+ * Design:
+ * - The docs checkout is YOURS (`--docs`), cloned wherever you like — no
+ *   submodule, no patches. Edit pages there, re-seed, re-run.
+ * - The supabase stack runs from a generated workdir (.local-docs/) with its
+ *   own project id and a port block off both the evals local-stack range
+ *   (54321+) and the docs monorepo default, so it collides with neither.
+ *   Files are COPIED, not symlinked (Windows-safe); `up` regenerates them.
+ * - Minimal on purpose: full seed only. The upstream pipeline's incremental
+ *   mode has known bugs we found while building the previous iteration
+ *   (guide checksums never set -> guides always re-embed; a skipped source's
+ *   still-valid rows get purged). Incremental lands here once those fixes
+ *   land upstream in supabase/supabase.
+ * - Some sources need production creds (e.g. DOCS_GITHUB_APP_* for
+ *   lint-warnings); without them the upstream pipeline fails its run. Pass
+ *   them through the environment if you have them.
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..', '..');
+const OVERLAY = join(ROOT, '.local-docs');
+const PROJECT_ID = 'evals-local-docs';
+const DB_CONTAINER = `supabase_db_${PROJECT_ID}`;
+// stack ports: whatever block the checkout's config declares -> 443xx (off
+// the evals local-stack range 54321-9, and below the macOS ephemeral range
+// 49152+, where transient outbound sockets flakily steal listen ports)
+const PORT_PREFIX_TO = '443';
+const STACK_EXCLUDES =
+  'realtime,storage-api,imgproxy,mailpit,postgres-meta,studio,edge-runtime,logflare,vector,supavisor';
+
+const onWindows = process.platform === 'win32';
+
+type DocsOptions = { docs?: string; port?: string; yes?: boolean };
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+
+/**
+ * Run a command, streaming output; fails loudly on nonzero exit.
+ *
+ * `quiet` buffers instead of streaming, because the supabase CLI reports the
+ * stack's ANON_KEY, PUBLISHABLE_KEY, SERVICE_ROLE_KEY, SECRET_KEY, and
+ * JWT_SECRET on every start, plus an update-notifier nag. That buries our own
+ * one-line status, and the keys are not something to leave on a screen
+ * recording.
+ *
+ * On failure it replays stderr only. Measured against `supabase start`: the key
+ * report goes to stdout (3 key lines there, 0 on stderr), while stderr carries
+ * the diagnostics you actually want (workdir, config warnings, per-service
+ * status). Dropping stdout is a stream boundary rather than a pattern match, so
+ * there is no redaction regex to keep in step with the CLI's output shapes.
+ */
+function run(
+  cmd: string,
+  args: string[],
+  opts: {
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+    shim?: boolean;
+    quiet?: boolean;
+  } = {}
+) {
+  const res = spawnSync(cmd, args, {
+    stdio: opts.quiet ? 'pipe' : 'inherit',
+    encoding: opts.quiet ? 'utf8' : undefined,
+    cwd: opts.cwd ?? ROOT,
+    env: opts.env ? { ...process.env, ...opts.env } : process.env,
+    // .cmd shims (corepack, .bin/tsx) need a shell on Windows
+    shell: opts.shim ? onWindows : false,
+  });
+  if (res.status !== 0) {
+    if (opts.quiet && res.stderr) process.stderr.write(res.stderr);
+    fail(`${cmd} ${args.join(' ')} failed (exit ${res.status})`);
+  }
+}
+
+/**
+ * Capture stdout. stderr is swallowed rather than inherited: the supabase CLI
+ * writes its workdir line, deprecation warnings, stopped-service list, and
+ * update-notifier nag there on every invocation, and this runs inside helpers
+ * whose own output is one line. On failure execFileSync throws with the output
+ * attached, so nothing is lost when it matters.
+ */
+function capture(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, {
+    cwd: ROOT,
+    maxBuffer: 1 << 24,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+}
+
+function docsPath(docs: string | undefined): string {
+  const marker = join(OVERLAY, 'docs-path.txt');
+  let p =
+    docs ??
+    (existsSync(marker) ? readFileSync(marker, 'utf8').trim() : undefined);
+  if (!p)
+    fail(
+      'no docs checkout configured — pass --docs <path-to-supabase-monorepo> (git clone https://github.com/supabase/supabase)'
+    );
+  p = isAbsolute(p) ? p : resolve(process.cwd(), p);
+  if (!existsSync(join(p, 'apps', 'docs')))
+    fail(`not a supabase monorepo checkout (apps/docs missing): ${p}`);
+  return p;
+}
+
+/** Parse `supabase status -o env` output (KEY="value" lines). */
+function stackEnv(): Record<string, string> {
+  const out = capture('supabase', [
+    'status',
+    '--workdir',
+    OVERLAY,
+    '-o',
+    'env',
+  ]);
+  const env: Record<string, string> = {};
+  for (const m of out.matchAll(/^([A-Z_]+)="(.*)"$/gm)) env[m[1]] = m[2];
+  if (!env.API_URL)
+    fail('could not read the local stack env — is it up? (pnpm docs:local up)');
+  return env;
+}
+
+function cmdUp(opts: DocsOptions) {
+  const docs = docsPath(opts.docs);
+  const src = join(docs, 'supabase');
+  existsSync(join(src, 'config.toml')) ||
+    fail(`no supabase/config.toml in the docs checkout: ${docs}`);
+
+  // regenerate the overlay workdir: rewritten config + copied stack files
+  rmSync(OVERLAY, { recursive: true, force: true });
+  mkdirSync(join(OVERLAY, 'supabase'), { recursive: true });
+  const config = readFileSync(join(src, 'config.toml'), 'utf8')
+    .replace(/^project_id = ".*"$/m, `project_id = "${PROJECT_ID}"`)
+    .replace(
+      /^port = \d{3}(\d{2})$/gm,
+      (_, tail) => `port = ${PORT_PREFIX_TO}${tail}`
+    );
+  writeFileSync(join(OVERLAY, 'supabase', 'config.toml'), config);
+  for (const f of ['migrations', 'seed.sql', 'functions', 'buckets']) {
+    const from = join(src, f);
+    if (existsSync(from))
+      cpSync(from, join(OVERLAY, 'supabase', f), {
+        recursive: true,
+        dereference: true,
+      });
+  }
+  writeFileSync(join(OVERLAY, 'docs-path.txt'), `${docs}\n`);
+
+  console.log(`starting the docs stack (project ${PROJECT_ID})...`);
+  run('supabase', ['start', '--workdir', OVERLAY, '-x', STACK_EXCLUDES], {
+    quiet: true,
+  });
+  // Upstream page migrations grant service_role no CRUD on the content
+  // tables; the embedder authenticates as service_role and needs it.
+  run(
+    'docker',
+    [
+      'exec',
+      DB_CONTAINER,
+      'psql',
+      '-U',
+      'postgres',
+      '-d',
+      'postgres',
+      '-q',
+      '-c',
+      'GRANT ALL ON public.page, public.page_section TO service_role; GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role; GRANT SELECT ON public.page, public.page_section TO anon, authenticated;',
+    ],
+    { quiet: true }
+  );
+  console.log(
+    `docs stack up on ${stackEnv().API_URL}; next: pnpm docs:local seed`
+  );
+}
+
+async function cmdSeed(opts: DocsOptions) {
+  const docs = docsPath(opts.docs);
+  if (!process.env.OPENAI_API_KEY)
+    fail('OPENAI_API_KEY not set — add it to .env at the repo root');
+  const docsApp = join(docs, 'apps', 'docs');
+  if (!existsSync(join(docsApp, 'node_modules'))) {
+    fail(
+      `docs app dependencies not installed — run:\n  corepack pnpm --dir ${docs} install --filter ./apps/docs...`
+    );
+  }
+  const env = stackEnv();
+  if (!opts.yes && !process.env.LOCAL_DOCS_YES) {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    const answer = await rl.question(
+      "Full docs embed: ~1.2M tokens ≈ $0.12 OpenAI. Type 'seed' to proceed: "
+    );
+    rl.close();
+    if (answer !== 'seed') fail('cancelled.');
+  }
+  run('corepack', ['pnpm', 'run', 'embeddings:refresh'], {
+    cwd: docsApp,
+    shim: true,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: env.API_URL,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: env.PUBLISHABLE_KEY ?? env.ANON_KEY,
+      SUPABASE_SECRET_KEY: env.SECRET_KEY ?? env.SERVICE_ROLE_KEY,
+      // generate-embeddings.ts hard-requires these two before doing any work.
+      // It builds its own client from NEXT_PUBLIC_SUPABASE_URL +
+      // SUPABASE_SECRET_KEY, but sources/partner-integrations.ts reads the MISC
+      // pair to pull partner data from the hosted "misc" project. Pointed at the
+      // local stack they clear the gate; the partner source then finds no such
+      // tables, which is the right trade for a local docs index.
+      NEXT_PUBLIC_MISC_URL: env.API_URL,
+      NEXT_PUBLIC_MISC_ANON_KEY: env.PUBLISHABLE_KEY ?? env.ANON_KEY,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      NODE_ENV: 'development',
+    },
+  });
+  console.log(
+    'seeded. next: pnpm docs:local api   (keep it running in a separate terminal)'
+  );
+}
+
+function cmdApi(opts: DocsOptions) {
+  const docs = docsPath(opts.docs);
+  const docsApp = join(docs, 'apps', 'docs');
+  const port = opts.port ?? '3001';
+  const env = stackEnv();
+  const tsx = join(
+    docsApp,
+    'node_modules',
+    '.bin',
+    onWindows ? 'tsx.cmd' : 'tsx'
+  );
+  if (!existsSync(tsx))
+    fail(
+      `tsx not installed in the docs app — run:\n  corepack pnpm --dir ${docs} install --filter ./apps/docs...`
+    );
+  const stub = join(__dirname, 'docs', 'sentry-stub-register.mjs');
+  console.log(
+    `serving on http://127.0.0.1:${port}/docs/api/graphql — point evals at it with --content-api`
+  );
+  // Runs with the DOCS app's tsx + tsconfig so the route's TS and its
+  // `react-server` condition resolve; the Sentry stub no-ops the route's
+  // telemetry (the real package crashes outside Next's instrumentation).
+  run(
+    tsx,
+    [
+      '--conditions=react-server',
+      '--tsconfig',
+      'tsconfig.json',
+      join(__dirname, 'docs', 'content-api-server.ts'),
+    ],
+    {
+      cwd: docsApp,
+      shim: true,
+      env: {
+        NODE_ENV: 'development',
+        PORT: port,
+        DOCS_ROUTE_PATH: join(docsApp, 'app', 'api', 'graphql', 'route.ts'),
+        NEXT_PUBLIC_SUPABASE_URL: env.API_URL,
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: env.PUBLISHABLE_KEY ?? env.ANON_KEY,
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        NODE_OPTIONS: `--import ${stub}${process.env.NODE_OPTIONS ? ` ${process.env.NODE_OPTIONS}` : ''}`,
+      },
+    }
+  );
+}
+
+export async function main(argv: string[]) {
+  const usage =
+    'usage: pnpm docs:local <up|seed|api|down> [--docs <path>] [--port N] [--yes]';
+  const parsed = (() => {
+    try {
+      return parseArgs({
+        args: argv,
+        options: {
+          docs: { type: 'string' },
+          port: { type: 'string' },
+          yes: { type: 'boolean' },
+        },
+        allowPositionals: true,
+      });
+    } catch (err) {
+      fail(`${err instanceof Error ? err.message : String(err)}\n${usage}`);
+    }
+  })();
+  const { values } = parsed;
+  switch (parsed.positionals[0]) {
+    case 'up':
+      cmdUp(values);
+      break;
+    case 'seed':
+      await cmdSeed(values);
+      break;
+    case 'api':
+      cmdApi(values);
+      break;
+    case 'down':
+      run('supabase', ['stop', '--workdir', OVERLAY], { quiet: true });
+      console.log(
+        `docs stack stopped (project ${PROJECT_ID}); the seeded index stays in its docker volume`
+      );
+      break;
+    default:
+      fail(usage);
+  }
+}
+
+await main(process.argv.slice(2));

--- a/apps/framework/scripts/smoke-local.ts
+++ b/apps/framework/scripts/smoke-local.ts
@@ -11,6 +11,10 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import {
+  CONTENT_API_FLAG_MIN_VERSION,
+  supportsContentApiFlag,
+} from '../harness/mcp-launch.js';
 
 const ROOT = join(import.meta.dirname, '..', '..', '..');
 const SANDBOX = mkdtempSync(join(tmpdir(), 'smoke-eval-strict-'));
@@ -91,6 +95,30 @@ function check(name: string, assertion: () => void, diagnostic?: string) {
 }
 
 try {
+  check('versions below the content API flag release are not capable', () => {
+    for (const version of ['0.8.1', '0.9.0', '0.9.9', '0.1.0']) {
+      assert.equal(supportsContentApiFlag(version), false, version);
+    }
+  });
+  check('the content API flag release and newer are capable', () => {
+    for (const version of [CONTENT_API_FLAG_MIN_VERSION, '0.10.1', '1.0.0']) {
+      assert.equal(supportsContentApiFlag(version), true, version);
+    }
+  });
+  check('content API prereleases are not capable', () => {
+    for (const version of ['0.10.0-dev.1', '0.11.0-beta', '1.0.0-rc.1']) {
+      assert.equal(supportsContentApiFlag(version), false, version);
+    }
+  });
+  check('malformed content API versions throw', () => {
+    for (const version of ['0.10.foo', '0.10', '', 'latest', 'v0.10.0']) {
+      assert.throws(
+        () => supportsContentApiFlag(version),
+        /not a MAJOR\.MINOR\.PATCH version/
+      );
+    }
+  });
+
   {
     const result = runEval([
       '--strict',
@@ -222,6 +250,69 @@ try {
 
   mkdirSync(join(mcpPackage, 'dist', 'transports'), { recursive: true });
   writeFileSync(join(mcpPackage, 'dist', 'transports', 'stdio.js'), '');
+  {
+    const result = runEval([
+      '--strict',
+      '--experiment',
+      EXPERIMENT,
+      '--eval',
+      EVAL,
+      '--content-api',
+      'http://127.0.0.1:3001',
+      '--mcp',
+      mcpCheckout,
+    ]);
+    check('MCP build without the content API flag is refused', () => {
+      assert.equal(result.status, 1, result.output);
+      assert.match(result.output, /no --content-api-url flag/);
+    });
+  }
+
+  writeFileSync(
+    join(mcpPackage, 'dist', 'transports', 'stdio.js'),
+    'process.env.SUPABASE_CONTENT_API_URL\n'
+  );
+  {
+    const result = runEval([
+      '--strict',
+      '--experiment',
+      EXPERIMENT,
+      '--eval',
+      EVAL,
+      '--content-api',
+      'http://127.0.0.1:3001',
+      '--mcp',
+      mcpCheckout,
+    ]);
+    check('MCP env fallback without the content API flag is refused', () => {
+      assert.equal(result.status, 1, result.output);
+      assert.match(result.output, /no --content-api-url flag/);
+    });
+  }
+
+  writeFileSync(
+    join(mcpPackage, 'dist', 'transports', 'stdio.js'),
+    `// parser does not support 'content-api-url': legacy build
+console.error("unsupported '--content-api-url' option");
+`
+  );
+  {
+    const result = runEval([
+      '--strict',
+      '--experiment',
+      EXPERIMENT,
+      '--eval',
+      EVAL,
+      '--content-api',
+      'http://127.0.0.1:3001',
+      '--mcp',
+      mcpCheckout,
+    ]);
+    check('MCP comments and diagnostics do not prove flag support', () => {
+      assert.equal(result.status, 1, result.output);
+      assert.match(result.output, /no --content-api-url flag/);
+    });
+  }
 
   const receiptRun = runEval([
     '--strict',
@@ -272,6 +363,39 @@ try {
       assert.doesNotThrow(() => JSON.parse(readFileSync(resultPath, 'utf8')));
     });
   }
+  writeFileSync(
+    join(mcpPackage, 'dist', 'transports', 'stdio.js'),
+    `const options = {
+  'content-api-url': { type: 'string' },
+};
+`
+  );
+  const contentApiRun = runEval([
+    '--strict',
+    '--experiment',
+    EXPERIMENT,
+    '--eval',
+    EVAL,
+    '--content-api',
+    'http://127.0.0.1:3001',
+    '--mcp',
+    mcpCheckout,
+  ]);
+  check('MCP build with the content API flag reaches the eval path', () => {
+    assert.equal(contentApiRun.status, 0, contentApiRun.output);
+    assert.match(
+      contentApiRun.output,
+      new RegExp(`PASS ${EXPERIMENT} x ${EVAL}`)
+    );
+  });
+  check(
+    'content API override is recorded in the receipt',
+    () => {
+      const receipt = JSON.parse(readFileSync(resultPath, 'utf8'));
+      assert.equal(receipt.provenance.contentApiUrl, 'http://127.0.0.1:3001');
+    },
+    contentApiRun.output
+  );
 
   {
     const result = runEval([

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "eval": "pnpm --filter @supabase-evals/framework eval",
     "eval:dry": "pnpm --filter @supabase-evals/framework eval:dry",
     "eval:smoke": "pnpm --filter @supabase-evals/framework eval:smoke",
+    "docs:local": "pnpm --filter @supabase-evals/framework docs:local",
     "eval:force": "pnpm --filter @supabase-evals/framework eval:force",
     "test:framework": "pnpm --filter @supabase-evals/framework test:framework",
     "export-results": "pnpm --filter @supabase-evals/framework export-results",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -971,6 +971,18 @@ export function supabaseMcpServer(
       // docs-only server runs standalone with no `--api-url`.
       if (apiUrl) serverArgs.push('--api-url', apiUrl);
 
+      // Docs override: point `search_docs` at a local content API instead of
+      // the public docs GraphQL. Baked into args rather than left to the parent
+      // environment because CLI agents spawn this command INSIDE the sandbox
+      // container, which inherits nothing from the harness process — and
+      // `rewriteLoopback` then maps 127.0.0.1 -> host.docker.internal so the
+      // host-side API is actually reachable from in there. Flag support landed
+      // in supabase/mcp#343 and shipped in v0.10.0, so it works on the npx path
+      // too once MCP_SERVER_VERSION reaches that; below it, `pnpm local` refuses
+      // --content-api unless --mcp supplies a build that has the flag.
+      const contentApiUrl = process.env.SUPABASE_CONTENT_API_URL;
+      if (contentApiUrl) serverArgs.push('--content-api-url', contentApiUrl);
+
       const local = resolveLocalMcpServer();
       if (local) {
         // `node`, not process.execPath: CLI agents run this command INSIDE the

--- a/packages/core/src/mcp-server.test.ts
+++ b/packages/core/src/mcp-server.test.ts
@@ -18,16 +18,19 @@ import {
 } from 'node:fs';
 import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
+import { rewriteLoopback } from './agents/shared.js';
 import {
   MCP_SERVER_VERSION,
   supabaseMcpServer,
   supabaseMcpServerMounts,
 } from './index.js';
 
-// Stub (not mutate) env so a pre-existing SUPABASE_MCP_SERVER_PATH is restored
-// per test.
+// Stub (not mutate) env so pre-existing SUPABASE_* values are restored per test.
+// SUPABASE_CONTENT_API_URL is cleared too: it now adds server args, so an
+// ambient value would leak into every assertion below.
 function clearEnv() {
   vi.stubEnv('SUPABASE_MCP_SERVER_PATH', undefined);
+  vi.stubEnv('SUPABASE_CONTENT_API_URL', undefined);
 }
 
 // A real on-disk build layout: the override path is existence-checked, so the
@@ -119,6 +122,35 @@ describe('supabaseMcpServer().createConfig', () => {
     } finally {
       rmSync(linkDir, { recursive: true, force: true });
     }
+  });
+
+  it('passes SUPABASE_CONTENT_API_URL as --content-api-url so it survives into the sandbox', async () => {
+    clearEnv();
+    vi.stubEnv(
+      'SUPABASE_CONTENT_API_URL',
+      'http://127.0.0.1:3001/docs/api/graphql'
+    );
+    const { config } = await supabaseMcpServer().createConfig({});
+    // In args, not env: a CLI agent spawns this inside the container, which
+    // inherits nothing from the harness process.
+    const flag = config.args.indexOf('--content-api-url');
+    expect(flag).toBeGreaterThan(-1);
+    expect(config.args[flag + 1]).toBe(
+      'http://127.0.0.1:3001/docs/api/graphql'
+    );
+
+    // ...and being in args is what lets the container reach the host-side API.
+    const rewritten = rewriteLoopback({ supabase: config });
+    expect(rewritten.supabase.args).toContain(
+      'http://host.docker.internal:3001/docs/api/graphql'
+    );
+  });
+
+  it('omits the flag when no local docs API is configured', async () => {
+    clearEnv();
+    vi.stubEnv('SUPABASE_CONTENT_API_URL', undefined);
+    const { config } = await supabaseMcpServer().createConfig({});
+    expect(config.args).not.toContain('--content-api-url');
   });
 });
 


### PR DESCRIPTION
Stack 3/4 for [#128](https://github.com/supabase/evals/issues/128). Base: [#194](https://github.com/supabase/evals/pull/194).

Adds the local docs loop without adding another eval entrypoint:

```bash
pnpm docs:local up --docs <path-to-supabase-monorepo>
pnpm docs:local seed
pnpm docs:local api [--port N]
pnpm docs:local down
pnpm eval -- <eval> --strict --content-api <url> --mcp <checkout>
```

`--content-api` now lives on `pnpm eval` and records the URL in the result provenance. `apps/framework/harness/mcp-launch.ts` owns MCP path resolution, published-version policy, and capability probing. The standalone `docs:local` script owns the local index lifecycle.

Verification: smoke 23/23, core 116/116, sandbox 39/39, typecheck + format passed.