### PR TITLE
fix(core): normalize Claude Code Agent tool

### DIFF
--- a/packages/core/src/agents/claude-code/parser.test.ts
+++ b/packages/core/src/agents/claude-code/parser.test.ts
@@ -152,6 +152,42 @@ describe('claudeCodeParser', () => {
     ]);
   });
 
+  it('normalizes current and legacy subagent tool names', () => {
+    const transcript = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_agent',
+            name: 'Agent',
+            input: { description: 'Inspect the parser' },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_task',
+            name: 'Task',
+            input: { description: 'Inspect the runner' },
+          },
+        ],
+      },
+    });
+
+    const { events, errors } = claudeCodeParser.parseTranscript(transcript);
+    expect(errors).toEqual([]);
+
+    const toolCalls = events.filter((event) => event.type === 'tool_call');
+    expect(toolCalls.map((event) => event.tool?.name)).toEqual([
+      'agent_task',
+      'agent_task',
+    ]);
+    expect(toolCalls.map((event) => event.tool?.originalName)).toEqual([
+      'Agent',
+      'Task',
+    ]);
+  });
+
   it('still emits the result text when it was never streamed as a message', () => {
     // Plain `--print` (no stream-json) yields only the terminal result line.
     const transcript = JSON.stringify({

--- a/packages/core/src/agents/claude-code/parser.ts
+++ b/packages/core/src/agents/claude-code/parser.ts
@@ -49,6 +49,7 @@ const CLAUDE_CODE_TOOLS: AgentToolMap = {
     Grep: 'grep',
     LS: 'list_dir',
     // Agent / subagent
+    Agent: 'agent_task',
     Task: 'agent_task',
     TodoWrite: 'agent_task',
   },


### PR DESCRIPTION
## Summary

- map Claude Code's current `Agent` tool name to the canonical `agent_task` name
- retain the legacy `Task` mapping
- add a regression test covering both current and legacy subagent tool names

Closes #173.

## Root cause

The Claude Code transcript parser only recognized the previous `Task` tool name. Claude Code 2.1.191 emits subagent calls as `Agent`, so those calls fell through normalization and were recorded as `unknown`, corrupting downstream tool-usage statistics and trace views.

## Impact

Subagent calls emitted by current Claude Code versions now normalize consistently as `agent_task`, while older transcripts using `Task` remain supported.

## Validation

- `pnpm --filter @supabase-evals/core test` — 105 tests passed
- `pnpm --filter @supabase-evals/sandbox test` — 39 tests passed
- `pnpm --filter @supabase-evals/web test` — 71 tests passed
- `pnpm --filter @supabase-evals/framework typecheck` — passed
- `pnpm --filter @supabase-evals/framework test:vercel-runner` — 10 tests passed
- `pnpm format:check` — passed with two pre-existing broken-symlink warnings

The repository-wide framework smoke test passed eight scenarios before reaching the judge-backed security eval, which requires an `OPENAI_API_KEY` that is not available in the local environment.
