### PR TITLE
fix(ci): merge the scheduled results PR with --admin

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -505,6 +505,8 @@ jobs:
 
       - name: Merge scheduled results pull request
         # The app is on the ruleset's bypass list, so no review is required.
+        # --admin skips gh's own mergeStateStatus precheck, which doesn't account
+        # for bypass lists and intermittently refuses a merge the API allows.
         # Skips the merge when results are partial, so it stays open for review.
         if: >-
           github.event_name == 'schedule' &&
@@ -512,7 +514,7 @@ jobs:
           steps.audit.outputs.count == '0'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --squash --delete-branch
+        run: gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --squash --delete-branch --admin
 
       - name: Require complete results
         # Runs last so partial results still publish, but the job still fails.

--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -504,9 +504,9 @@ jobs:
           delete-branch: true
 
       - name: Merge scheduled results pull request
-        # The app is on the ruleset's bypass list, so no review is required.
-        # --admin skips gh's own mergeStateStatus precheck, which doesn't account
-        # for bypass lists and intermittently refuses a merge the API allows.
+        # --admin merges without the required review, which the bypass list
+        # entitles the app to.
+        # https://cli.github.com/manual/gh_pr_merge
         # Skips the merge when results are partial, so it stays open for review.
         if: >-
           github.event_name == 'schedule' &&


### PR DESCRIPTION
## Problem

Sometimes (~15% of the time) nightly regression refreshes fail because of our required reviewers rule, leaving stale data in Hex.

For example last night's PR is stuck unmerged: https://github.com/supabase/evals/pull/215

You can see the corresponding failing step here: https://github.com/supabase/evals/actions/runs/32223257049/job/95980723901#step:13:1

<img width="822" height="168" alt="CleanShot 2026-08-19 at 14 38 41@2x" src="https://github.com/user-attachments/assets/6bfb168a-900e-4eef-8b34-22ad9566bfa0" />

## Fix

The bot is already on our bypass list, however it needs to opt-in with `--admin` which is similar to an AI team member clicking the checkbox on PRs:

<img width="846" height="130" alt="CleanShot 2026-08-19 at 14 39 03@2x" src="https://github.com/user-attachments/assets/9adc4769-ad82-4d24-b44f-ff21f6874513" />

Oddly, `gh` will happily allow the auto merge if the merge status is UNKNOWN which is why this wasn't noticed earlier. The flakiness is a race condition if `gh` has finished determining that the merge status is [blocked](https://github.com/cli/cli/blob/95d3a1db45abd547c2dafbee4f8a68ca53fb9c80/pkg/cmd/pr/merge/merge.go#L716-L733) before we attempt to auto merge. The `--admin` flag makes the bypass consistent.

Possibly related [issue](https://github.com/cli/cli/issues/13388) reporting the merge status quirk.

## How to review

We can't easily test this manually outside of the CI refresh path. So you'll have to just review based on the evidence [logged in our failing run](https://github.com/supabase/evals/actions/runs/32223257049/job/95980723901#step:13:1), and `gh` docs: https://cli.github.com/manual/gh_pr_merge

After merge, we should monitor the nightly refreshes and confirm they merge uninhibited.

## Note for the future

If we decide to add any additional required checks on PRs, we should add those on a separate ruleset, that bot's bypass ability only applies to the required reviewers check.

To prevent this footgun, I've renamed the ruleset to `main: review required` so its scope is clearer.

