### PR TITLE
fix(evals): state the pgTAP workflow the tenant isolation scorer requires

### DIFF
--- a/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
+++ b/evals/build-tests-001-rls-tenant-isolation/PROMPT.md
@@ -11,4 +11,4 @@ services: []
 motivation: AI-813, FDBKIN-9635, FDBKIN-8983
 ---
 
-Can you audit the tenant isolation on our tables? Write some database tests covering both the happy path and the negative case, run them, and share the results.
+Can you audit the tenant isolation on our tables? We keep our database tests as pgTAP under `supabase/tests/`. Add some covering both the happy path and negative cross-tenant access, run them with `supabase test db`, and tell me whether isolation actually holds.


### PR DESCRIPTION
Closes #207

## Summary

`build-tests-001-rls-tenant-isolation` requires pgTAP tests under
`supabase/tests/` and re-runs them with `supabase test db`, but those workflow
requirements were not stated in the agent-facing prompt.

This updates `PROMPT.md` to make that workflow explicit while keeping the
benchmark diagnosis hidden.

## What changed

- mention pgTAP as the expected database test format
- state that tests live under `supabase/tests/`
- state that they should be run with `supabase test db`
- keep both happy-path and negative cross-tenant coverage
- leave `EVAL.ts`, seed data, and the planted bug unchanged

The prompt still does not reveal which table is broken or what the expected
diagnosis is.

## Validation

- `git diff --check`
- `pnpm typecheck`
- targeted `pnpm eval:dry` for `build-tests-001-rls-tenant-isolation`
- relevant sandbox, web, and Vercel runner tests
- prompt parsed with the repository's `parseEvalMarkdown()`
- verified scorer requirements are present and planted-answer terms remain absent

No screenshots were added because this is not a UI change.

Changed eval results should be refreshed through the repository's CI.
