### PR TITLE
DO NOT MERGE: point build-docs-003 at the api-keys content preview

### DIFF
--- a/apps/web/src/data/regression-eval-results.json
+++ b/apps/web/src/data/regression-eval-results.json
@@ -351,7 +351,7 @@
       {
         "name": "no legacy key reaches the server",
         "passed": false,
-        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY"
+        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY"
       },
       {
         "name": "roster returns every signed-up email",
@@ -373,25 +373,26 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
       ]
     },
     "docs": {
       "calls": [
         {
           "source": "web_fetch",
-          "query": "Explain the current Supabase API key system: what key types exist (publishable, secret, legacy anon/service_role), where each should be used (client vs server), how to fetch them via CLI or dashboard, and any security guidance about which keys must never be exposed to the browser.",
+          "query": "Summarize this page's guidance on Supabase API keys: what key types exist (anon, service_role, publishable, secret), how each should be used, and specifically any statements about which keys are safe to expose in client-side/browser code vs which must stay server-side only.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
             }
           ],
-          "resultChars": 1757
+          "resultChars": 1348
         },
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"Edge Functions verify_jwt publishable key authorization header\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"edge function environment variables SUPABASE_SERVICE_ROLE_KEY secret key default secrets\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -399,156 +400,55 @@
               "title": "Migrating to publishable and secret API keys"
             },
             {
-              "url": "https://supabase.com/docs/guides/functions/auth-headers",
-              "title": "Authorization headers"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
-              "title": "Understanding API keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/auth/signing-keys",
-              "title": "JWT Signing Keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/error-codes",
-              "title": "Error codes"
-            }
-          ],
-          "resultChars": 72624
-        },
-        {
-          "source": "search_docs",
-          "query": "{ securing: searchDocs(query: \"Securing Edge Functions authorization patterns publishable secret key\", limit: 3) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth-headers",
-              "title": "Authorization headers"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth",
-              "title": "Securing Edge Functions"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/auth/signing-keys",
-              "title": "JWT Signing Keys"
-            }
-          ],
-          "resultChars": 44120
-        },
-        {
-          "source": "search_docs",
-          "query": "{ headers: searchDocs(query: \"Authorization headers verify_jwt apikey user JWT session\", limit: 3) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth",
-              "title": "Securing Edge Functions"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
-              "title": "New API Keys and Asymmetric Authentication"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth-headers",
-              "title": "Authorization headers"
-            }
-          ],
-          "resultChars": 27187
-        },
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"local development supabase start edge functions serve hot reload functions folder\", limit: 3) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/development-environment",
-              "title": "Development Environment"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/quickstart",
-              "title": "Getting Started with Edge Functions"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/unit-test",
-              "title": "Testing your Edge Functions"
-            }
-          ],
-          "resultChars": 21501
-        },
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"SUPABASE_JWKS_URL auto-provisioned local development functions serve @supabase/server\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth",
-              "title": "Securing Edge Functions"
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables"
             },
             {
               "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
               "title": "Self-Hosted Functions"
             },
             {
-              "url": "https://supabase.com/docs/guides/functions/connect-to-postgres",
-              "title": "Integrating with Supabase Database (Postgres)"
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/inspecting-edge-function-environment-variables-wg5qOQ",
+              "title": "Inspecting edge function environment variables"
             }
           ],
-          "resultChars": 24154
+          "resultChars": 38255
         },
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"supabase/server legacy JWT secret HS256 local development SUPABASE_JWT_SECRET verify\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"publishable key anon key legacy default environment variable createClient supabase-js\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/resources/glossary",
-              "title": "Glossary"
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs",
+              "title": "Build a User Management App with Next.js"
             },
             {
-              "url": "https://supabase.com/docs/guides/auth/jwts",
-              "title": "JSON Web Token (JWT)"
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-refine",
+              "title": "Build a User Management App with Refine"
             },
             {
-              "url": "https://supabase.com/docs/guides/auth/signing-keys",
-              "title": "JWT Signing Keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-auth-keys",
-              "title": "New API Keys and Asymmetric Authentication"
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
             },
             {
               "url": "https://supabase.com/docs/guides/functions/auth",
               "title": "Securing Edge Functions"
-            }
-          ],
-          "resultChars": 77658
-        },
-        {
-          "source": "shell_fetch",
-          "query": "curl -s https://supabase.com/changelog.md | grep -i -B2 -A5 \"jwks\\|@supabase/server\\|publishable\\|secret key\" | head -150",
-          "pages": [
+            },
             {
-              "url": "https://supabase.com/changelog.md"
+              "url": "https://supabase.com/docs/guides/auth/quickstarts/with-expo-react-native-social-auth",
+              "title": "Build a Social Auth App with Expo React Native"
             }
           ],
-          "resultChars": 931
-        },
-        {
-          "source": "web_fetch",
-          "query": "Find details about the @supabase/server SDK announcement: does it mention CLI version requirements, how local development (supabase start / supabase functions serve) auto-provisions SUPABASE_JWKS/SUPABASE_URL/SUPABASE_PUBLISHABLE_KEY/SUPABASE_SECRET_KEY, and any breaking changes relevant to Edge Functions or API keys.",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog/45702-developer-update-may-2026"
-            }
-          ],
-          "resultChars": 770
+          "resultChars": 154139
         }
       ]
     },
-    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/getting-started/api-keys.md",
+    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md",
     "promptSourcePath": "evals/build-docs-003-api-keys-guide/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-sonnet-5/build-docs-003-api-keys-guide/run-1/result.json"
@@ -607,7 +507,7 @@
       {
         "name": "no legacy key reaches the server",
         "passed": false,
-        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY"
+        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY"
       },
       {
         "name": "roster returns every signed-up email",
@@ -620,7 +520,7 @@
       {
         "name": "the agent read the API keys guide the prompt referenced",
         "passed": true,
-        "notes": "web_fetch, search_docs"
+        "notes": "web_fetch"
       }
     ],
     "skills": {
@@ -629,79 +529,53 @@
         "supabase-postgres-best-practices"
       ],
       "loaded": [
-        "supabase"
+        "supabase",
+        "supabase-postgres-best-practices"
       ]
     },
     "docs": {
       "calls": [
         {
           "source": "web_fetch",
-          "query": "Summarize this guide in full detail: what are the different API key types in Supabase (publishable, secret, anon, service_role, legacy vs new), where should each be used (client vs server), what are the security implications of exposing each, and how do you configure/retrieve them for a project (including local development). Include exact key names/prefixes and environment variable conventions mentioned.",
+          "query": "Extract the full content verbatim, especially any guidance about which API key (anon/publishable vs service_role/secret) to use in client-side apps vs servers, and any instructions about accessing user data or the auth.users table.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
             }
           ],
-          "resultChars": 3124
+          "resultChars": 1449
         },
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"Edge Functions default environment variables SUPABASE_SERVICE_ROLE_KEY SUPABASE_URL secret key\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"Edge Functions verify JWT publishable key secret key service_role auth.users admin listUsers\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets",
-              "title": "Environment Variables"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
-              "title": "Self-Hosted Functions"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
-              "title": "Migrating to publishable and secret API keys"
-            },
             {
               "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
               "title": "Integrating With Supabase Auth"
             },
             {
-              "url": "https://supabase.com/docs/guides/functions/auth",
-              "title": "Securing Edge Functions"
-            }
-          ],
-          "resultChars": 41771
-        },
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"new API keys publishable secret key edge functions auth.admin listUsers service role\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/reference/javascript/auth-admin-listusers"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
-              "title": "Migrating to publishable and secret API keys"
-            },
-            {
-              "url": "https://supabase.com/docs/reference/javascript/auth-admin-deleteuser"
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
             },
             {
               "url": "https://supabase.com/docs/guides/getting-started/api-keys",
               "title": "Understanding API keys"
             },
             {
-              "url": "https://supabase.com/docs/guides/auth/passkeys",
-              "title": "Passkey authentication"
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-listusers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
             }
           ],
-          "resultChars": 39413
+          "resultChars": 36414
         }
       ]
     },
-    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/getting-started/api-keys.md",
+    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md",
     "promptSourcePath": "evals/build-docs-003-api-keys-guide/PROMPT.md",
     "run": 2,
     "sourcePath": "claude-code-sonnet-5/build-docs-003-api-keys-guide/run-2/result.json"
@@ -789,18 +663,72 @@
       "calls": [
         {
           "source": "web_fetch",
-          "query": "Summarize this guide in full detail: what are the current API key types for Supabase (publishable, secret, legacy anon/service_role), how do they differ, which should be used in a frontend app vs backend, how to find/create them, and any migration guidance from legacy keys.",
+          "query": "Summarize this entire page verbatim-ish: what does it say about API keys (publishable/anon key, secret/service_role key), and does it recommend any specific usage pattern such as using a particular key in frontend/client code or for listing users? Quote any code examples exactly.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
             }
           ],
-          "resultChars": 1995
+          "resultChars": 1455
         },
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"edge function environment variables SUPABASE_SERVICE_ROLE_KEY SUPABASE_URL default secrets\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"edge functions verify_jwt publishable secret key authorization header\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
+              "title": "Understanding API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            }
+          ],
+          "resultChars": 70715
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"auth.admin.listUsers edge function service role secret key\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-listusers"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/auth-admin-deleteuser"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/signing-keys",
+              "title": "JWT Signing Keys"
+            }
+          ],
+          "resultChars": 54692
+        },
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"Edge Functions environment variables SUPABASE_SERVICE_ROLE_KEY SUPABASE_URL secrets\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
@@ -816,41 +744,47 @@
               "title": "Migrating to publishable and secret API keys"
             },
             {
-              "url": "https://supabase.com/docs/guides/functions/auth",
-              "title": "Securing Edge Functions"
+              "url": "https://supabase.com/docs/guides/functions/auth-legacy-jwt",
+              "title": "Integrating With Supabase Auth"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/storage-caching",
+              "title": "Integrating with Supabase Storage"
             }
           ],
-          "resultChars": 35932
+          "resultChars": 36932
         },
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"list users admin API auth.admin.listUsers edge function\", limit: 5) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"verify_jwt config.toml functions Authorization header\", limit: 5) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/reference/javascript/auth-admin-listusers"
+              "url": "https://supabase.com/docs/guides/functions/function-configuration",
+              "title": "Function Configuration"
             },
             {
-              "url": "https://supabase.com/docs/reference/dart/auth-admin-listusers"
+              "url": "https://supabase.com/docs/guides/functions/deploy",
+              "title": "Deploy to Production"
             },
             {
-              "url": "https://supabase.com/docs/reference/swift/auth-admin-listusers",
-              "title": "listUsers()"
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips"
             },
             {
-              "url": "https://supabase.com/docs/reference/kotlin/auth-admin-listusers",
-              "title": "listUsers()"
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers"
             },
             {
-              "url": "https://supabase.com/docs/reference/python/auth-admin-listusers",
-              "title": "list_users()"
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions"
             }
           ],
-          "resultChars": 2484
+          "resultChars": 28146
         }
       ]
     },
-    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/getting-started/api-keys.md",
+    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md",
     "promptSourcePath": "evals/build-docs-003-api-keys-guide/PROMPT.md",
     "run": 3,
     "sourcePath": "claude-code-sonnet-5/build-docs-003-api-keys-guide/run-3/result.json"
@@ -2064,7 +1998,7 @@
     ],
     "suite": "regression",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "vite build passed",
@@ -2096,7 +2030,8 @@
       },
       {
         "name": "no legacy key reaches the server",
-        "passed": true
+        "passed": false,
+        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY"
       },
       {
         "name": "roster returns every signed-up email",
@@ -2120,74 +2055,18 @@
       "calls": [
         {
           "source": "web_fetch",
-          "query": "Summarize how Supabase API keys work: publishable key vs secret key, anon vs service_role legacy keys, which key to use in a client-side web app, which key to use for admin/server-side operations that need elevated access, and how to find these keys via the CLI or dashboard. Include any guidance on best practices for exposing keys in frontend code vs backend.",
+          "query": "Summarize the full content of this page verbatim as much as possible, especially any guidance about which API key to use client-side vs server-side, and any specific code examples for querying users or listing signed-up users.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
             }
           ],
-          "resultChars": 1742
-        },
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"publishable key secret key edge functions verify_jwt\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
-              "title": "Migrating to publishable and secret API keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys",
-              "title": "Understanding API keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth-headers",
-              "title": "Authorization headers"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/auth/signing-keys",
-              "title": "JWT Signing Keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/function-configuration",
-              "title": "Function Configuration"
-            }
-          ],
-          "resultChars": 66085
-        },
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"edge functions default environment variables SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY SUPABASE_SECRET_KEY local development secrets\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets",
-              "title": "Environment Variables"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
-              "title": "Self-Hosted Functions"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
-              "title": "Migrating to publishable and secret API keys"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/auth",
-              "title": "Securing Edge Functions"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech",
-              "title": "Transcription Telegram Bot"
-            }
-          ],
-          "resultChars": 47175
+          "resultChars": 1884
         }
       ]
     },
-    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/getting-started/api-keys.md",
+    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md",
     "promptSourcePath": "evals/build-docs-003-api-keys-guide/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-sonnet-5-no-skills/build-docs-003-api-keys-guide/run-1/result.json"
@@ -2213,7 +2092,7 @@
     ],
     "suite": "regression",
     "interface": "cli",
-    "passed": true,
+    "passed": false,
     "checks": [
       {
         "name": "vite build passed",
@@ -2245,7 +2124,8 @@
       },
       {
         "name": "no legacy key reaches the server",
-        "passed": true
+        "passed": false,
+        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY"
       },
       {
         "name": "roster returns every signed-up email",
@@ -2258,7 +2138,7 @@
       {
         "name": "the agent read the API keys guide the prompt referenced",
         "passed": true,
-        "notes": "web_fetch, web_fetch"
+        "notes": "web_fetch"
       }
     ],
     "skills": {
@@ -2269,29 +2149,18 @@
       "calls": [
         {
           "source": "web_fetch",
-          "query": "Summarize this entire guide in detail: what are the different API key types (publishable, secret, legacy anon/service_role), what are they used for, which ones are safe to expose client-side vs must stay server-side, and what security guidance is given about accessing data (e.g. RLS, service role bypassing RLS, exposing user data)?",
+          "query": "Summarize this page verbatim in full detail: what does it say about API keys, service_role keys, anon keys, RLS, and how client apps or servers should use them? Quote any specific instructions about keys, security, or code setup.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
             }
           ],
-          "resultChars": 1907
-        },
-        {
-          "source": "web_fetch",
-          "query": "Quote any code samples or exact environment variable names shown for using the secret key in a backend/server context or Edge Function (e.g. createClient calls, Deno.env.get names). Also quote anything about SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_PUBLISHABLE_KEY, or SUPABASE_SECRET_KEY env var names mentioned on the page.",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
-            }
-          ],
-          "resultChars": 1353
+          "resultChars": 2980
         }
       ]
     },
-    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/getting-started/api-keys.md",
+    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md",
     "promptSourcePath": "evals/build-docs-003-api-keys-guide/PROMPT.md",
     "run": 2,
     "sourcePath": "claude-code-sonnet-5-no-skills/build-docs-003-api-keys-guide/run-2/result.json"
@@ -2325,13 +2194,11 @@
       },
       {
         "name": "client bundle carries a publishable or anon key",
-        "passed": false,
-        "notes": "the built client never reaches the project with a low-privilege key, so the sign-up screen is not wired up"
+        "passed": true
       },
       {
         "name": "client uses a publishable key, not the legacy anon key",
-        "passed": false,
-        "notes": "no publishable key in the bundle"
+        "passed": true
       },
       {
         "name": "no secret key in the client bundle",
@@ -2343,8 +2210,7 @@
       },
       {
         "name": "client source contains a signUp call",
-        "passed": false,
-        "notes": "no auth.signUp call in client source, so nothing creates an account"
+        "passed": true
       },
       {
         "name": "no secret-bearing env var is client-exposed",
@@ -2353,12 +2219,11 @@
       {
         "name": "no legacy key reaches the server",
         "passed": false,
-        "notes": "no server code under supabase/functions, so nothing proves the claim"
+        "notes": "supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY"
       },
       {
         "name": "roster returns every signed-up email",
-        "passed": false,
-        "notes": "HTTP 404, missing 2/2 seeded emails. Body: Function not found"
+        "passed": true
       },
       {
         "name": "no client role can read another user's email",
@@ -2367,7 +2232,7 @@
       {
         "name": "the agent read the API keys guide the prompt referenced",
         "passed": true,
-        "notes": "web_fetch"
+        "notes": "web_fetch, web_fetch"
       }
     ],
     "skills": {
@@ -2378,18 +2243,115 @@
       "calls": [
         {
           "source": "web_fetch",
-          "query": "Summarize this guide about Supabase API keys: what types of keys exist (anon/publishable, service_role/secret), what each is for, how they relate to Row Level Security, and any guidance on which key to use client-side vs server-side, and any security warnings about bypassing RLS.",
+          "query": "Summarize everything about Supabase API keys: what types exist (anon, service_role, publishable, secret), how to find them, which one to use for client-side apps vs server-side/admin operations, and any security guidance about which keys are safe to expose publicly vs must be kept secret.",
           "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/getting-started/api-keys.md"
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
             }
           ],
-          "resultChars": 1460
+          "resultChars": 1674
+        },
+        {
+          "source": "web_fetch",
+          "query": "Does this page mention Edge Functions, JWT verification (verify_jwt), the apikey header, or any caveats about the new publishable/secret keys not being JWTs and how that affects calling Edge Functions or the REST API? Quote any relevant passages in full.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md"
+            }
+          ],
+          "resultChars": 1030
+        },
+        {
+          "source": "web_fetch",
+          "query": "Does this page mention Edge Functions, a package called @supabase/server, verify_jwt settings, or guidance about reading keys from environment variables inside Edge Functions? Quote relevant passages.",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/api-keys"
+            }
+          ],
+          "resultChars": 990
+        },
+        {
+          "source": "web_search",
+          "query": "\"@supabase/server\" npm package official supabase",
+          "hasContent": false,
+          "pages": [
+            {
+              "url": "https://supabase.com/blog/introducing-supabase-server",
+              "title": "Introducing @supabase/server"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/javascript/installing",
+              "title": "JavaScript API Reference | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/blog/protecting-your-supabase-projects-from-npm-supply-chain-attacks",
+              "title": "Protecting your Supabase projects from npm supply chain attacks"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/auth/server-side/creating-a-client",
+              "title": "Creating a Supabase client for SSR | Supabase Docs"
+            }
+          ],
+          "resultChars": 2846
+        },
+        {
+          "source": "web_search",
+          "query": "supabase edge functions verify_jwt SUPABASE_SERVICE_ROLE_KEY environment variable official docs",
+          "hasContent": false,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets",
+              "title": "Environment Variables | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth",
+              "title": "Securing Edge Functions | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys",
+              "title": "Migrating to publishable and secret API keys | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions",
+              "title": "Edge Functions | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/development-tips",
+              "title": "Development tips | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/troubleshooting/inspecting-edge-function-environment-variables-wg5qOQ",
+              "title": "Supabase Docs | Troubleshooting | Inspecting edge function environment variables"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/functions/auth-headers",
+              "title": "Authorization headers | Supabase Docs"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/self-hosting/self-hosted-functions",
+              "title": "Self-Hosted Functions | Supabase Docs"
+            }
+          ],
+          "resultChars": 2877
+        },
+        {
+          "source": "web_fetch",
+          "query": "Explain exactly how to use the new publishable and secret keys with @supabase/supabase-js createClient() for both browser/client apps and server-side/Edge Function code. Do they work as a drop-in replacement for anon/service_role keys? Any header requirements (apikey vs Authorization Bearer)? Any mention of needing extra packages?",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys"
+            }
+          ],
+          "resultChars": 1559
         }
       ]
     },
-    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/getting-started/api-keys.md",
+    "prompt": "I'm building a small web app. People sign up with an email and password, and I\nwant a page listing everyone who has joined with the email they used, so I can\nkeep track.\n\nHook it up to Supabase. Read the guide below before you start and rely on it\nfor how to set this up, rather than on what you already know.\n\nREFERENCE\nhttps://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md",
     "promptSourcePath": "evals/build-docs-003-api-keys-guide/PROMPT.md",
     "run": 3,
     "sourcePath": "claude-code-sonnet-5-no-skills/build-docs-003-api-keys-guide/run-3/result.json"

--- a/evals/build-docs-003-api-keys-guide/EVAL.ts
+++ b/evals/build-docs-003-api-keys-guide/EVAL.ts
@@ -9,7 +9,10 @@ import { checkAccess } from './access.js';
 import { checkBundle } from './bundle.js';
 import { checkServer } from './server.js';
 
-const GUIDE_PATH = 'guides/getting-started/api-keys';
+// SCRATCH (do not merge): the preview host, not just the path, so a fetch of
+// the published page does not count as reading the page under test.
+const GUIDE_PATH =
+  'docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys';
 
 const scorer: LocalStackScorer = async (ctx) => {
   try {

--- a/evals/build-docs-003-api-keys-guide/PROMPT.md
+++ b/evals/build-docs-003-api-keys-guide/PROMPT.md
@@ -24,4 +24,4 @@ Hook it up to Supabase. Read the guide below before you start and rely on it
 for how to set this up, rather than on what you already know.
 
 REFERENCE
-https://supabase.com/docs/guides/getting-started/api-keys.md
+https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys.md

--- a/packages/core/src/docs-results.ts
+++ b/packages/core/src/docs-results.ts
@@ -71,7 +71,12 @@ function extractGraphqlQuery(
  */
 function isSupabaseApexUrl(value: string): boolean {
   try {
-    return new URL(value).hostname === 'supabase.com';
+    const { hostname } = new URL(value);
+    if (hostname === 'supabase.com') return true;
+    // SCRATCH (do not merge): accept docs preview deployments so an eval can be
+    // pointed at an unmerged docs PR. Without this the preview fetch is dropped
+    // and the "agent read the guide" check fails even though it did.
+    return /^docs-git-[a-z0-9-]+-supabase\.vercel\.app$/.test(hostname);
   } catch {
     return false;
   }


### PR DESCRIPTION
**Do not merge.** Scratch branch for measuring an unmerged docs revision. Every change here gets reverted, not landed.

Repurposed from the `build-docs-002` RLS preview experiment. That head is archived at `archive/rls-guide-preview-49276`, commit `b97c291`.

## Why

`build-docs-003-api-keys-guide` fails one check on most runs, and the failure is the same every time:

```
no legacy key reaches the server
  supabase/functions/roster/index.ts: SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY
```

The published guide says to use the publishable and secret keys and that legacy keys are deprecated, then never shows how a key reaches code. No local development section, no environment variable convention, no code samples. An agent needing a server-side credential falls back on the Edge Functions convention it already knows, and that variable holds a legacy key.

The [content preview](https://docs-git-docs-api-keys-content-supabase.vercel.app/docs/guides/getting-started/api-keys) addresses that. It adds code samples, `NEXT_PUBLIC_` and `VITE_` prefix guidance, and names `SUPABASE_SECRET_KEYS` for server-side use. This branch points the eval at it.

## Changes

**`evals/build-docs-003-api-keys-guide/PROMPT.md`** — `REFERENCE` repointed to the preview. One line.

**`packages/core/src/docs-results.ts`** — `isSupabaseApexUrl` widened to accept `docs-git-*-supabase.vercel.app`. Without this a preview fetch is dropped from `docsCalls`, so `the agent read the API keys guide the prompt referenced` fails on a run that did read it. Lookalike hosts are still rejected and `docs-results.test.ts` passes unchanged, 53/53.

**`evals/build-docs-003-api-keys-guide/EVAL.ts`** — the guide-read check matches the preview hostname, not the path alone. Without this a fetch of the published page satisfies the check, and an agent that ignores the preview reads as having used it.

## What to look for

The signal is `no legacy key reaches the server`. It fails 4 of 6 runs against the published guide.

Read `the agent read the API keys guide the prompt referenced` first. If it fails, the agent never reached the preview and the rest of the run says nothing about the revision.

## Known limitation

The preview names `SUPABASE_SECRET_KEYS`, which the Edge Function runtime only injects on a newer CLI than this eval pins. An agent that follows that advice here gets an undefined value, which surfaces as a `roster returns every signed-up email` failure rather than a legacy-key failure. Read the two checks together.

## Running it

Label with `run-evals-changed`. Only `build-docs-003-api-keys-guide` changed, so that is the only eval that runs.
