### PR TITLE
chore(evals): run the RLS guide eval with skills as well as without

### DIFF
--- a/evals/build-docs-002-rls-guide/PROMPT.md
+++ b/evals/build-docs-002-rls-guide/PROMPT.md
@@ -14,7 +14,6 @@ services:
   - kong
   - postgrest
   - realtime
-skills: []
 motivation: the Row Level Security guide is the reference agents are pointed at for RLS, and getting RLS wrong leaks user data. This eval determines whether the guide is effective at getting an agent to best-practice policies when a user asks for help building an app and never mentions security. The prompt deliberately omits that vocabulary, so read README.md before editing it.
 ---
 

--- a/evals/build-docs-002-rls-guide/README.md
+++ b/evals/build-docs-002-rls-guide/README.md
@@ -28,14 +28,6 @@ The probes use three users. The list owner, an outsider, and a member who neithe
 
 Nothing in the migration says who may read or write what.
 
-## The eval runs with and without skills
-
-The no-skills run is the measurement of the guide. The default skill set states several of the answers outright, so a pass with skills installed is not evidence that the page taught anything.
-
-The with-skills run is still worth having. A user who already has the skill installed can paste this same prompt, and that is a real scenario to measure. Read the two cells as different questions rather than as one score, and use the no-skills cell when the question is whether the guide works.
-
-This eval therefore pins no `skills` override. Sibling `build-docs-` evals whose prompt has the agent install its own tooling keep `skills: []`, because preinstalled skills make "can the agent install the skill" meaningless.
-
 ## The prompt never asks for tests
 
 Whether the agent arrives at pgTAP is itself a measurement. If agents do not write tests here, that says something about how reachable testing is from the guide.

--- a/evals/build-docs-002-rls-guide/README.md
+++ b/evals/build-docs-002-rls-guide/README.md
@@ -28,6 +28,14 @@ The probes use three users. The list owner, an outsider, and a member who neithe
 
 Nothing in the migration says who may read or write what.
 
+## The eval runs with and without skills
+
+The no-skills run is the measurement of the guide. The default skill set states several of the answers outright, so a pass with skills installed is not evidence that the page taught anything.
+
+The with-skills run is still worth having. A user who already has the skill installed can paste this same prompt, and that is a real scenario to measure. Read the two cells as different questions rather than as one score, and use the no-skills cell when the question is whether the guide works.
+
+This eval therefore pins no `skills` override. Sibling `build-docs-` evals whose prompt has the agent install its own tooling keep `skills: []`, because preinstalled skills make "can the agent install the skill" meaningless.
+
 ## The prompt never asks for tests
 
 Whether the agent arrives at pgTAP is itself a measurement. If agents do not write tests here, that says something about how reachable testing is from the guide.


### PR DESCRIPTION
## Problem

`build-docs-002-rls-guide` pinned `skills: []` in its frontmatter. That override wins over the experiment's own skill list, so two things happened:

- **Baseline cell**: `claude-code-sonnet-5` ran the eval with no skills, under a column that says skills are installed.
- **No-skills cell**: `claude-code-sonnet-5-no-skills` skipped the eval entirely, via its `skipEval`, and the cell rendered empty.

Matt raised the empty cells in [this thread](https://supabase.slack.com/archives/C051L8U2EJF/p1787170188981209?thread_ts=1787167849.852059&cid=C051L8U2EJF). Greg agreed there is benefit in running this one both ways.

## Solution

- Drop `skills: []` from `PROMPT.md`. The eval now takes each experiment's own skill list.
- Document in `README.md` how to read the two cells. The no-skills run measures the guide. The with-skills run measures a user who already has the skill installed and pastes the same prompt.

Sibling `build-docs-` evals whose prompt has the agent install its own tooling keep the override. `build-docs-001-homepage-quickstart` is unchanged for that reason.

**Follow-up, not in this PR:** `skipEval` is defined on `claude-code-sonnet-5-no-skills` only. The other four `*-no-skills` experiments lack it, so evals that pin `skills: []` still run redundantly against them.

## Manual testing

1. Check out the branch and run the planner.

   ```bash
   pnpm eval:dry -- --eval build-docs-002-rls-guide
   ```

2. Confirm both regression experiments plan. Before this change the second line read `SKIP ... (skipEval)`.

   ```
   PLAN claude-code-sonnet-5-no-skills x build-docs-002-rls-guide
   PLAN claude-code-sonnet-5 x build-docs-002-rls-guide
   ```

3. Confirm `build-docs-001-homepage-quickstart` still skips under the no-skills experiment.

   ```bash
   pnpm eval:dry -- --eval build-docs-001-homepage-quickstart
   ```
