### PR TITLE
fix(evals): raise the RLS coverage judge's reasoning effort

### DIFF
--- a/evals/build-docs-002-rls-guide/tests.ts
+++ b/evals/build-docs-002-rls-guide/tests.ts
@@ -64,8 +64,16 @@ export async function checkTestCoverage(
     files.map(async (file) => `-- ${file}\n${await ctx.readFile(file)}`)
   );
 
+  // The default judge runs at reasoningEffort 'low', which grades this rubric
+  // inconsistently across runs: the same suite draws a different complaint each
+  // time, and two of the three name coverage the suite has. The rubric is seven
+  // compound conditions over every test file at once, so raise the effort
+  // rather than lengthening it further.
   const verdict = await judge({
     input: sources.join('\n\n'),
+    providerOptions: {
+      openai: { reasoningEffort: 'high', textVerbosity: 'low' },
+    },
     rubric: stripIndent`
       You are reviewing pgTAP test files written to prove that Row Level
       Security policies on a Postgres database behave correctly.

--- a/evals/build-docs-002-rls-guide/tests.ts
+++ b/evals/build-docs-002-rls-guide/tests.ts
@@ -64,11 +64,9 @@ export async function checkTestCoverage(
     files.map(async (file) => `-- ${file}\n${await ctx.readFile(file)}`)
   );
 
-  // The default judge runs at reasoningEffort 'low', which grades this rubric
-  // inconsistently across runs: the same suite draws a different complaint each
-  // time, and two of the three name coverage the suite has. The rubric is seven
-  // compound conditions over every test file at once, so raise the effort
-  // rather than lengthening it further.
+  // Judge (reasoningEffort 'low') is non-deterministic here. Same suite, different
+  // complaint each run. Rubric has seven compound conditions over every test file;
+  // raising effort rather than simplifying/retrying.
   const verdict = await judge({
     input: sources.join('\n\n'),
     providerOptions: {


### PR DESCRIPTION
## Problem

`build-docs-002-rls-guide` scored 39 to 43 out of 43 across the nine preview runs recorded on [supabase/supabase#49276](https://github.com/supabase/supabase/pull/49276#issuecomment-5348737183). One check was the residual failure in most of them:

`tests assert allow and deny per operation on the seeded tables, for anon and authenticated`

**It is flaky, not wrong.** Its complaint changes run to run:

- `lives_ok` on allowed writes
- Missing update or delete coverage
- Denied writes not proving the row survived

The suite it grades is stable at six files and 70 to 80 assertions, and run 7's notes read as a clean bill. Two of the three complaints name coverage the suite has.

**Cause:** `judge()` defaults to `reasoningEffort: 'low'`. This rubric asks that setting to verify seven compound conditions across every test file at once.

## Solution

- Pass `reasoningEffort: 'high'` at the one call site in `tests.ts`.

Rubric unchanged. Model unchanged. No check added or removed. The `evals-scorers` skill names this case: pass `model` and `providerOptions` when the rubric is hard, rather than making the rubric longer.

**Limit:** this reduces variance. It does not guarantee green. Higher effort could also surface a gap the low setting was missing, which would be a true red worth knowing about.

## Manual testing

1. Confirm the change typechecks and formats.

   ```bash
   pnpm typecheck && pnpm biome check evals
   ```

2. Label this PR `run-evals-changed` to refresh results.

3. Compare the coverage check across both attempts of the run. A stable verdict across attempts is the signal, not the score alone.

`pnpm eval:solution` cannot verify this locally. The eval has no `solutions/` directory, so there are no test files for the judge to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)