### PR TITLE
fix(core): default the judge to gpt-5.6-sol at medium reasoning effort

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -606,10 +606,10 @@ const judgeOutputSchema = z.object({
   notes: z.string(),
 });
 
-const DEFAULT_JUDGE_MODEL = openai('gpt-5.5');
+const DEFAULT_JUDGE_MODEL = openai('gpt-5.6-sol');
 const DEFAULT_JUDGE_PROVIDER_OPTIONS: AiSdkProviderOptions = {
   openai: {
-    reasoningEffort: 'low',
+    reasoningEffort: 'medium',
     textVerbosity: 'low',
   },
 };


### PR DESCRIPTION
Closes AI-1112

## Problem

`judge()` defaults to `gpt-5.5` at `reasoningEffort: 'low'`. Those defaults were set when 5.5 was the newest model. Judging is the part of a scorer that needs the most reasoning, and `low` is below OpenAI's recommended starting point of `medium`.

Per [Matt's note](https://supabase.slack.com/archives/C051L8U2EJF/p1787267143937309?thread_ts=1787167849.852059&cid=C051L8U2EJF), the fix belongs in the default rather than in per-eval overrides.

## Solution

- `DEFAULT_JUDGE_MODEL`: `gpt-5.5` to `gpt-5.6-sol`.
- Default `reasoningEffort`: `low` to `medium`.
- `textVerbosity` unchanged at `low`.

Supersedes [#220](https://github.com/supabase/evals/pull/220), which set `high` effort as a per-eval override on `build-docs-002-rls-guide`. That PR should close in favor of this one.


## Manual testing

1. Confirm the change typechecks and formats.

   ```bash
   pnpm typecheck && pnpm biome check packages
   ```

2. Dispatch a full refresh from the Actions tab and compare judge-backed checks against the previous nightly. The suites worth watching are the ones whose only judge check is pass/fail on a report, such as `investigate-security-001-public-table`.