### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,7 +51,7 @@ For an experiment, point at the `experiments/` file and call out the `suite:`, s
 
 <!-- Include the steps and evidence for how you verified this change. -->
 
-For new or changed evals (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
+For new or changed evals (see [CONTRIBUTING.md](/supabase/evals/blob/main/CONTRIBUTING.md)):
 
 - [ ] Ran the eval locally to sanity check it completes without framework errors.
 - [ ] Refreshed results in CI (`run-evals-changed` / `run-evals` labels, or the Refresh eval results workflow) and included them so a reviewer can see results directly.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+## What kind of change does this PR introduce?
+
+New eval, new experiment, scorer fix, framework change, docs update, ...
+
+## What is the current behavior?
+
+Please link any relevant issues here.
+
+## What is the new behavior?
+
+Feel free to include screenshots if it includes visual changes.
+
+## How to Review
+
+<!--
+A reviewer should understand what this PR does within 15-30 seconds, then know where to start reading.
+
+Non-trivial or multi-file PRs must fill in the reading path below. Trivial changes may delete this section when the review path is obvious.
+
+- For a new or changed eval, start from `PROMPT.md` (the task and `motivation:`), then `EVAL.ts` (the scorer), then any `remote/` or `local/` seed data.
+- For a new or changed experiment, start from the `experiments/` file and call out the `suite:`, skills, and MCP servers it configures.
+- Use bold numbered areas, each with one or two indented bullets: the exact files, then what to inspect.
+- Use exact repository-relative paths, and avoid line numbers while the branch is still changing.
+- Don't repeat the PR purpose or the verification steps here. Keep the section scannable.
+-->
+
+1. **Scenario**
+   - `evals/<your-eval>/PROMPT.md`
+   - The task the agent sees and the cited `motivation:`.
+
+2. **Scorer**
+   - `evals/<your-eval>/EVAL.ts`
+   - What end state it checks, and where it uses `judge()` versus deterministic checks.
+
+3. **Seed data**
+   - `evals/<your-eval>/remote/` or `local/`
+   - What project or filesystem state the scenario seeds.
+
+**Review questions**
+
+<!-- Four to six short questions covering the reviewer's judgment calls. -->
+
+- [ ] Does `motivation:` cite real evidence from the Supabase user journey?
+- [ ] Does the scorer check end state and prefer deterministic checks over prescribing process?
+- [ ] For a benchmark scenario, do results show agents legitimately failing rather than framework limitations?
+- [ ] Is the scenario representative rather than over-indexed on a niche use case?
+
+## Verification
+
+<!--
+Include the steps and evidence. Run the eval locally to sanity check it completes without framework errors.
+See CONTRIBUTING.md for the CI options (run-evals-changed / run-evals labels, or the Refresh eval results workflow).
+-->
+
+Include refreshed results (from CI or the Vercel preview) for PRs with new or changed evals, so a reviewer can see results directly.
+
+## Additional context
+
+Add any other context or screenshots.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,42 +17,44 @@ A reviewer should understand what this PR does within 15-30 seconds, then know w
 
 Non-trivial or multi-file PRs must fill in the reading path below. Trivial changes may delete this section when the review path is obvious.
 
-- For a new or changed eval, start from `PROMPT.md` (the task and `motivation:`), then `EVAL.ts` (the scorer), then any `remote/` or `local/` seed data.
-- For a new or changed experiment, start from the `experiments/` file and call out the `suite:`, skills, and MCP servers it configures.
 - Use bold numbered areas, each with one or two indented bullets: the exact files, then what to inspect.
 - Use exact repository-relative paths, and avoid line numbers while the branch is still changing.
-- Don't repeat the PR purpose or the verification steps here. Keep the section scannable.
+- Keep it scannable. Don't repeat the PR purpose or the verification steps here.
+
+For a new or changed eval, a good path is `PROMPT.md` (task + `motivation:`) -> `EVAL.ts` (scorer) -> `remote/` or `local/` seed data.
+For an experiment, point at the `experiments/` file and call out the `suite:`, skills, and MCP servers it configures.
 -->
 
-1. **Scenario**
-   - `evals/<your-eval>/PROMPT.md`
-   - The task the agent sees and the cited `motivation:`.
+1. **Review area**
+   - `path/to/file`
+   - What to follow or verify.
 
-2. **Scorer**
-   - `evals/<your-eval>/EVAL.ts`
-   - What end state it checks, and where it uses `judge()` versus deterministic checks.
-
-3. **Seed data**
-   - `evals/<your-eval>/remote/` or `local/`
-   - What project or filesystem state the scenario seeds.
+2. **Next review area**
+   - `path/to/next-file`
+   - What to follow or verify.
 
 **Review questions**
 
 <!-- Four to six short questions covering the reviewer's judgment calls. -->
 
+- [ ] Is the change scoped, and does the behavior match the description?
+- [ ] Are edge cases and failure paths handled safely?
+
+<!-- For new or changed evals, also confirm:
 - [ ] Does `motivation:` cite real evidence from the Supabase user journey?
 - [ ] Does the scorer check end state and prefer deterministic checks over prescribing process?
 - [ ] For a benchmark scenario, do results show agents legitimately failing rather than framework limitations?
 - [ ] Is the scenario representative rather than over-indexed on a niche use case?
+-->
 
 ## Verification
 
-<!--
-Include the steps and evidence. Run the eval locally to sanity check it completes without framework errors.
-See CONTRIBUTING.md for the CI options (run-evals-changed / run-evals labels, or the Refresh eval results workflow).
--->
+<!-- Include the steps and evidence for how you verified this change. -->
 
-Include refreshed results (from CI or the Vercel preview) for PRs with new or changed evals, so a reviewer can see results directly.
+For new or changed evals (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
+
+- [ ] Ran the eval locally to sanity check it completes without framework errors.
+- [ ] Refreshed results in CI (`run-evals-changed` / `run-evals` labels, or the Refresh eval results workflow) and included them so a reviewer can see results directly.
 
 ## Additional context
 


### PR DESCRIPTION
## What

Adds a local pull request template at `.github/PULL_REQUEST_TEMPLATE.md`, built on the inherited `supabase/.github` template.

All four existing prompts stay in place, with two additions:

- `## How to Review`: a generic numbered reading path plus review questions, so experiment, framework, and docs PRs aren't forced into an eval-only shape.
- `## Verification`: a visible checklist for eval changes covering the local sanity check and refreshed CI results, per `CONTRIBUTING.md`.

Eval-specific guidance (the `PROMPT.md` -> `EVAL.ts` -> seed-data path and the motivation/scorer/benchmark/coverage checks) sits in HTML comments as optional prompts, so it stays hidden in posted PRs and applies only when relevant.

## Why

The inherited org template covers general changes, but eval contributions have a repo-specific review flow. Reviewers should be able to confirm the motivation is cited, scorers deterministically check the end state, benchmark scenarios show legitimate agent failures, and coverage is representative rather than niche. Authors should also see the CI refresh requirement up front.

This mirrors [supabase/mcp#385](https://github.com/supabase/mcp/pull/385), adapted to the evals workflow.

## How to Review

1. Read `.github/PULL_REQUEST_TEMPLATE.md`.
2. Confirm it builds on the inherited org template and preserves all four prompts: change type, current behavior, new behavior, and additional context.
3. Confirm the visible How to Review body and review questions are generic (not eval-only), and the eval-specific path and checks are in HTML comments.
4. Confirm `## Verification` makes the local sanity check and refreshed CI results a visible requirement for eval changes.

## Verification

The net diff against `origin/main` is one new file, `.github/PULL_REQUEST_TEMPLATE.md` (+61 lines). This is a docs-only addition with no runtime behavior change.
