### PR TITLE
chore: bump codex CLI to 0.151.0

### DIFF
--- a/packages/core/src/agents/codex/runner.ts
+++ b/packages/core/src/agents/codex/runner.ts
@@ -31,7 +31,7 @@ export const codexRunner: AgentRunner<CodexModel> = {
   cliPackage: '@openai/codex',
   // Pinned: Codex's --json event schema evolves; bump deliberately and re-check
   // the parser. See ./parser.ts.
-  defaultCliVersion: '0.138.0',
+  defaultCliVersion: '0.151.0',
   defaultModel: 'gpt-5.4',
 
   async install(sandbox, version, apiKey) {


### PR DESCRIPTION
Bumps codex pin from 0.138.0 to 0.151.0.

This is a prereq for tracking token performance metrics in results, since https://github.com/openai/codex/pull/33454 shipped in 0.145.0+ includes `cache_write_input_tokens` on the `codex exec --json` stream.

## How to review

Nothing much to review since we don't use this field yet, just sanity check a couple evals still run.

I ran three `codex-gpt-5.6` runs locally across `build-cli-002-declarative-schema` and `resolve-dataapi-001-empty-results`. All passed, and the raw stream now ends with:

```json
{"type":"turn.completed","usage":{"input_tokens":317792,"cached_input_tokens":280060,"cache_write_input_tokens":37687,"output_tokens":2093,"reasoning_output_tokens":494}}
```


**References**

- Usage struct before the bump, no cache-write field: https://github.com/openai/codex/blob/rust-v0.138.0/codex-rs/exec/src/exec_events.rs#L63-L65
- Usage struct at 0.151.0: https://github.com/openai/codex/blob/rust-v0.151.0/codex-rs/exec/src/exec_events.rs#L68

Ref AI-1160
