### PR TITLE
chore(platform-lite): bump Supabase MCP to 0.12.0

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1253,7 +1253,7 @@ async function getAvailablePort(): Promise<number> {
 }
 
 export const ACCESS_TOKEN = 'eval-token';
-export const MCP_SERVER_VERSION = '0.11.0';
+export const MCP_SERVER_VERSION = '0.12.0';
 // Well-formed but inert PAT used when a Supabase MCP server is docs-only: the
 // server requires a token to boot but never authenticates without a platform.
 const THROWAWAY_ACCESS_TOKEN = `sbp_${'0'.repeat(40)}`;

--- a/packages/platform-lite/package.json
+++ b/packages/platform-lite/package.json
@@ -28,7 +28,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@supabase/mcp-server-supabase": "^0.11.0",
+    "@supabase/mcp-server-supabase": "^0.12.0",
     "@types/node": "catalog:",
     "openapi-typescript": "^7.8.0",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,8 +344,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@supabase/mcp-server-supabase':
-        specifier: ^0.11.0
-        version: 0.11.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)
+        specifier: ^0.12.0
+        version: 0.12.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.20
@@ -2124,15 +2124,15 @@ packages:
       vite:
         optional: true
 
-  '@supabase/mcp-server-supabase@0.11.0':
-    resolution: {integrity: sha512-++eAgAmq3SAnj3nf2Ic0i2Si9oFmTn9ppEJOioABf7+DZ/w3blPuxLlSTSBZV5+Sf1SdueMpTvYvkKJh0zx+/Q==}
+  '@supabase/mcp-server-supabase@0.12.0':
+    resolution: {integrity: sha512-Rjh3k7pQel+vePiffG8m8DkqCT2y3pD9Z4dKejzjACfvrzGeFsaoRhgXoDeZio6kjgOvi8Wy7mgdezEwPklJhg==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/server': ^2.0.0
       zod: ^3.25.0 || ^4.0.0
 
-  '@supabase/mcp-utils@0.7.0':
-    resolution: {integrity: sha512-PDTPOn/0AEPWwAXc8I98wruYucGwNLCAfiCu0eZS1mE+E/e0xZhdSY3nfE2n+sh8p5aaep5Kqd9Wt0rThAKgdQ==}
+  '@supabase/mcp-utils@0.8.0':
+    resolution: {integrity: sha512-T3PpwysWEFBuvD7TMekFSv7xLqO6DjoUUh2ZHojyRdJD7UNaydffJx8ZGoUW2Ju9NOf5ffomfuzreioJUTFFcQ==}
     peerDependencies:
       '@modelcontextprotocol/server': ^2.0.0
       zod: ^3.25.0 || ^4.0.0
@@ -6335,18 +6335,18 @@ snapshots:
       - pg-native
       - supports-color
 
-  '@supabase/mcp-server-supabase@0.11.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)':
+  '@supabase/mcp-server-supabase@0.12.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)':
     dependencies:
       '@mjackson/multipart-parser': 0.10.1
       '@modelcontextprotocol/server': 2.0.0
-      '@supabase/mcp-utils': 0.7.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)
+      '@supabase/mcp-utils': 0.8.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)
       common-tags: 1.8.2
       gqlmin: 0.3.2
       graphql: 16.14.2
       openapi-fetch: 0.13.8
       zod: 4.4.3
 
-  '@supabase/mcp-utils@0.7.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)':
+  '@supabase/mcp-utils@0.8.0(@modelcontextprotocol/server@2.0.0)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/server': 2.0.0
       zod: 4.4.3


### PR DESCRIPTION
## Summary

- Bump the platform-lite Supabase MCP dependency to 0.12.0.
- Refresh the pnpm lockfile, including transitive mcp-utils 0.8.0.
- Keep the platform-lite integration unchanged after reviewing the 0.12.0 cost-confirmation behavior.

## Changelog review

platform-lite uses the MCP platform API with an access token and API URL. It does not enable cost confirmation or depend on the legacy cost tools, so 0.12.0 needs no integration change.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @supabase-evals/platform-lite typecheck`
- `pnpm exec biome check packages/platform-lite`
- `pnpm --filter @supabase-evals/platform-lite exec vitest run test/mcp-platform.test.ts test/clickhouse-logs.test.ts`