### PR TITLE
feat: record token usage and duration for eval runs

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -37,6 +37,7 @@ import {
   supabaseMcpServerMounts,
 } from '@supabase-evals/core';
 import type {
+  AgentUsage,
   ExperimentConfig,
   EvalInterface,
   EvalManifest,
@@ -373,6 +374,8 @@ async function runOne(
     transcript: TranscriptPart[];
     agentReport: string;
     stoppedReason: string;
+    usage?: AgentUsage;
+    durationMs: number;
   }
 > {
   const prompt = parseEvalMarkdown(
@@ -486,6 +489,8 @@ async function runOne(
       transcript: run.transcript,
       agentReport: run.agentReport,
       stoppedReason: run.stoppedReason,
+      usage: run.usage,
+      durationMs: run.durationMs,
     };
   }
 
@@ -544,6 +549,8 @@ async function runOne(
     transcript: run.transcript,
     agentReport: run.agentReport,
     stoppedReason: run.stoppedReason,
+    usage: run.usage,
+    durationMs: run.durationMs,
   };
 }
 

--- a/apps/framework/harness/types.ts
+++ b/apps/framework/harness/types.ts
@@ -6,6 +6,7 @@ import type {
 } from '@supabase-evals/core/eval-metadata';
 
 export type {
+  AgentUsage,
   ScoreResult,
   CheckResult,
   ToolCallRecord,

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -138,6 +138,8 @@ async function readResultFile(
     checks: parsedResult.checks,
     skills: parsedResult.skills,
     docs: parsedResult.docs,
+    usage: parsedResult.usage,
+    durationMs: parsedResult.durationMs,
     prompt: promptData?.prompt,
     promptSourcePath: promptData?.promptSourcePath,
     attempts: parsedResult.attempts,

--- a/apps/web/src/components/results/eval-details.tsx
+++ b/apps/web/src/components/results/eval-details.tsx
@@ -8,8 +8,16 @@ import {
   XIcon,
 } from "lucide-react"
 
-import { passFailClassName } from "@/components/results/table-shared"
-import type { CheckResult, DocsCall, ParsedResult } from "@/lib/eval-results"
+import {
+  formatDuration,
+  formatTokens,
+  passFailClassName,
+} from "@/components/results/table-shared"
+import {
+  type CheckResult,
+  type DocsCall,
+  type ParsedResult,
+} from "@/lib/eval-results"
 import { formatProductLabel, formatTagLabel } from "@/lib/format"
 import { cn } from "@/lib/utils"
 
@@ -218,6 +226,15 @@ export function EvalDetails({ result }: { result: ParsedResult }) {
             </div>
           }
         />
+      ) : null}
+      {result.durationMs !== undefined ? (
+        <EvalMetadataRow
+          label="Duration"
+          value={formatDuration(result.durationMs)}
+        />
+      ) : null}
+      {result.usage ? (
+        <EvalMetadataRow label="Tokens" value={formatTokens(result.usage)} />
       ) : null}
       <EvalMetadataRow
         label="Source"

--- a/apps/web/src/components/results/table-shared.test.ts
+++ b/apps/web/src/components/results/table-shared.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  formatDuration,
+  formatTokens,
   hasMoreContentToRight,
   sampleSetLabel,
   scoreLabel,
@@ -21,6 +23,34 @@ describe("scoreLabel", () => {
 describe("sampleSetLabel", () => {
   it("shows both the fraction and the rate", () => {
     expect(sampleSetLabel(2, 3)).toBe("2/3 \u00b7 67%")
+  })
+})
+
+describe("metric formatters", () => {
+  it("formats durations", () => {
+    expect(formatDuration(38_000)).toBe("38s")
+    expect(formatDuration(245_000)).toBe("4m 05s")
+  })
+
+  it("formats tokens as a total with the in/out split, summed across models", () => {
+    expect(
+      formatTokens([
+        {
+          model: "claude-sonnet-5",
+          uncachedInputTokens: 3_703,
+          cacheReadInputTokens: 418_062,
+          cacheWriteInputTokens: 20_952,
+          outputTokens: 1_693,
+        },
+        {
+          model: "claude-haiku-4-5-20251001",
+          uncachedInputTokens: 519,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          outputTokens: 14,
+        },
+      ])
+    ).toBe("444.9K (443.2K in / 1.7K out)")
   })
 })
 

--- a/apps/web/src/components/results/table-shared.test.ts
+++ b/apps/web/src/components/results/table-shared.test.ts
@@ -37,14 +37,14 @@ describe("metric formatters", () => {
       formatTokens([
         {
           model: "claude-sonnet-5",
-          uncachedInputTokens: 3_703,
+          inputTokens: 442_717,
           cacheReadInputTokens: 418_062,
           cacheWriteInputTokens: 20_952,
           outputTokens: 1_693,
         },
         {
           model: "claude-haiku-4-5-20251001",
-          uncachedInputTokens: 519,
+          inputTokens: 519,
           cacheReadInputTokens: 0,
           cacheWriteInputTokens: 0,
           outputTokens: 14,

--- a/apps/web/src/components/results/table-shared.ts
+++ b/apps/web/src/components/results/table-shared.ts
@@ -1,8 +1,4 @@
-import {
-  inputTokens,
-  outputTokens,
-  type AgentUsage,
-} from "@supabase-evals/core/eval-metadata"
+import type { AgentUsage } from "@supabase-evals/core/eval-metadata"
 
 import type { KeyboardEvent } from "react"
 
@@ -70,8 +66,8 @@ const compact = new Intl.NumberFormat("en", {
 
 /** Summed across models, e.g. "444.4K (442.7K in / 1.7K out)". */
 export function formatTokens(usage: AgentUsage) {
-  const input = inputTokens(usage)
-  const output = outputTokens(usage)
+  const input = usage.reduce((n, u) => n + u.inputTokens, 0)
+  const output = usage.reduce((n, u) => n + u.outputTokens, 0)
   return `${compact.format(input + output)} (${compact.format(input)} in / ${compact.format(output)} out)`
 }
 

--- a/apps/web/src/components/results/table-shared.ts
+++ b/apps/web/src/components/results/table-shared.ts
@@ -1,3 +1,9 @@
+import {
+  inputTokens,
+  outputTokens,
+  type AgentUsage,
+} from "@supabase-evals/core/eval-metadata"
+
 import type { KeyboardEvent } from "react"
 
 /** Small pieces the results table and the detail sheet both render with. */
@@ -46,6 +52,27 @@ export function scoreLabel(
 /** Formats a sample set's score, e.g. `2/3 · 67%`. */
 export function sampleSetLabel(passed: number, total: number) {
   return `${passed}/${total} \u00b7 ${Math.round((passed / total) * 100)}%`
+}
+
+/** Formats a run duration: "38s" under a minute, "4m 05s" above. */
+export function formatDuration(ms: number) {
+  const totalSec = Math.round(ms / 1000)
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  if (!min) return `${sec}s`
+  return `${min}m ${String(sec).padStart(2, "0")}s`
+}
+
+const compact = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+})
+
+/** Summed across models, e.g. "444.4K (442.7K in / 1.7K out)". */
+export function formatTokens(usage: AgentUsage) {
+  const input = inputTokens(usage)
+  const output = outputTokens(usage)
+  return `${compact.format(input + output)} (${compact.format(input)} in / ${compact.format(output)} out)`
 }
 
 /** Checks whether a horizontal scroller has content beyond its right edge. */

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -782,67 +782,151 @@
       ]
     },
     "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 1,
+    "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "claude-code-opus-5",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-opus-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "claude-code-opus-5",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-opus-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
       "calls": [
         {
           "source": "search_docs",
-          "query": "{ searchDocs(query: \"declarative database schemas migration diff workflow\", limit: 4) { nodes { title href content } } }",
+          "query": "{ searchDocs(query: \"declarative database schemas generate migration db diff local\", limit: 4) { nodes { title href content } } }",
           "hasContent": true,
           "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
             {
               "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
               "title": "Local development workflow"
             },
             {
-              "url": "https://supabase.com/docs/guides/platform/sso/multiple-providers",
-              "title": "Multiple SSO Providers"
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
             },
             {
-              "url": "https://supabase.com/docs/reference/cli/supabase-db-pull",
-              "title": "Pull schema from the remote database"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments",
+              "title": "Managing Environments"
             }
           ],
-          "resultChars": 59751
-        },
-        {
-          "source": "shell_fetch",
-          "query": "curl -sL \"https://supabase.com/docs/guides/local-development/declarative-database-schemas.md\" | head -120",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas.md"
-            }
-          ],
-          "resultChars": 4194
-        },
-        {
-          "source": "shell_fetch",
-          "query": "curl -sL \"https://supabase.com/changelog.md\" | grep -iE \"breaking|db diff|declarative\" | head -20",
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ],
-          "resultChars": 3619
+          "resultChars": 66910
         }
       ]
     },
-    "usage": [
-      {
-        "model": "claude-opus-5",
-        "inputTokens": 401722,
-        "cacheReadInputTokens": 359823,
-        "cacheWriteInputTokens": 38147,
-        "outputTokens": 4664
-      }
-    ],
-    "durationMs": 98388,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 1,
-    "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-1/result.json"
+    "run": 3,
+    "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "claude-code-opus-5",
@@ -12136,20 +12220,122 @@
     "docs": {
       "calls": []
     },
-    "usage": [
-      {
-        "model": "claude-sonnet-5",
-        "inputTokens": 433570,
-        "cacheReadInputTokens": 408252,
-        "cacheWriteInputTokens": 21622,
-        "outputTokens": 2120
-      }
-    ],
-    "durationMs": 91057,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 3,
+    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "claude-code-sonnet-5",
@@ -23264,19 +23450,91 @@
     "docs": {
       "calls": [
         {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "site:supabase.com changelog breaking-change supabase",
+          "pages": []
+        }
+      ]
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 1,
+    "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.4-mini",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.4-mini",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
           "source": "shell_fetch",
-          "query": "/bin/bash -lc \"curl -fsSL https://supabase.com/changelog.md | sed -n '1,120p'\"",
+          "query": "/bin/bash -lc \"curl -fsSL https://supabase.com/changelog.md | sed -n '1,160p'\"",
           "hasContent": true,
           "pages": [
             {
               "url": "https://supabase.com/changelog.md"
             }
           ],
-          "resultChars": 6693
+          "resultChars": 9005
         },
         {
           "source": "search_docs",
-          "query": "query { searchDocs(query: \"declarative database schemas add column existing table migration\", limit: 5) { nodes { __typename ... on Guide { title href content subsections { totalCount } } ... on CLICommandReference { title href content } } } }",
+          "query": "query { searchDocs(query: \"declarative database schemas supabase migration generate schema_paths alter table add column\", limit: 5) { nodes { ... on Guide { title href content } ... on CLICommandReference { title href content } ... on TroubleshootingGuide { title href content } } totalCount } }",
           "hasContent": true,
           "pages": [
             {
@@ -23288,36 +23546,112 @@
               "title": "Local development workflow"
             },
             {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            },
+            {
               "url": "https://supabase.com/docs/guides/deployment/database-migrations",
               "title": "Database Migrations"
             },
             {
-              "url": "https://supabase.com/docs/guides/database/replication/ducklake",
-              "title": "DuckLake destination"
+              "url": "https://supabase.com/docs/guides/database/postgres/column-level-security",
+              "title": "Column Level Security"
+            }
+          ],
+          "resultChars": 74593
+        }
+      ]
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.4-mini",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.4-mini",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query {\n  searchDocs(query: \"declarative database schemas supabase db pull local schema_paths\", limit: 5) {\n    nodes {\n      title\n      href\n      content\n    }\n  }\n}",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
             },
             {
               "url": "https://supabase.com/docs/guides/local-development/database-migrations",
               "title": "Database migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-pull",
+              "title": "Pull schema from the remote database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches",
+              "title": "Working with branches"
             }
           ],
-          "resultChars": 84897
+          "resultChars": 64546
         }
       ]
     },
-    "usage": [
-      {
-        "model": "gpt-5.4-mini",
-        "inputTokens": 808410,
-        "cacheReadInputTokens": 723584,
-        "cacheWriteInputTokens": 0,
-        "outputTokens": 5338
-      }
-    ],
-    "durationMs": 84766,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 1,
-    "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-1/result.json"
+    "run": 3,
+    "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "codex-gpt-5.4-mini",
@@ -38974,31 +39308,211 @@
     "docs": {
       "calls": [
         {
-          "source": "shell_fetch",
-          "query": "/bin/bash -lc \"find .claude/skills/supabase-postgres-best-practices/references -maxdepth 1 -type f -printf '%f\\\\n' | sort | sed -n '1,200p'; curl -fsSL https://supabase.com/changelog.md | sed -n '1,160p'; supabase --version; supabase migration --help; find . -maxdepth 4 -type f | sort | sed -n '1,240p'\"",
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"local development declarative schemas generate migration db diff schema_paths\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
           "pages": [
             {
-              "url": "https://supabase.com/changelog.md"
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/managing-environments",
+              "title": "Managing Environments"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-diff",
+              "title": "Diffs the local database for schema changes"
             }
           ],
-          "resultChars": 14496
+          "resultChars": 72112
         }
       ]
     },
-    "usage": [
-      {
-        "model": "gpt-5.6-sol",
-        "inputTokens": 361969,
-        "cacheReadInputTokens": 319536,
-        "cacheWriteInputTokens": 42391,
-        "outputTokens": 1641
-      }
-    ],
-    "durationMs": 52738,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "codex-gpt-5.6/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-sol",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"local development declarative database schemas schema_paths db diff migrations\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-diff",
+              "title": "Diffs the local database for schema changes"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            }
+          ],
+          "resultChars": 71255
+        }
+      ]
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "codex-gpt-5.6/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-sol",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": false
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"Supabase CLI local database migrations declarative schemas db reset\", limit: 5) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-reset",
+              "title": "Resets the local database to current migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-redwoodjs",
+              "title": "Build a User Management App with RedwoodJS"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/testing/overview",
+              "title": "Testing Overview"
+            }
+          ],
+          "resultChars": 79345
+        }
+      ]
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 3,
+    "sourcePath": "codex-gpt-5.6/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "codex-gpt-5.6",
@@ -55497,20 +56011,121 @@
     "docs": {
       "calls": []
     },
-    "usage": [
-      {
-        "model": "moonshotai/kimi-k3",
-        "inputTokens": 207198,
-        "cacheReadInputTokens": 179064,
-        "cacheWriteInputTokens": 0,
-        "outputTokens": 2666
-      }
-    ],
-    "durationMs": 108426,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "opencode-kimi-k3",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "opencode",
+      "modelProvider": "moonshotai",
+      "modelId": "moonshotai/kimi-k3"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "opencode-kimi-k3",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "opencode",
+      "modelProvider": "moonshotai",
+      "modelId": "moonshotai/kimi-k3"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": false
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": false,
+        "notes": "description not found in any schema file"
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": false,
+        "notes": "found 1 migration file(s)"
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": false
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": []
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 3,
+    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "opencode-kimi-k3",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -787,7 +787,7 @@
     "usage": [
       {
         "model": "claude-opus-5",
-        "uncachedInputTokens": 3891,
+        "inputTokens": 543603,
         "cacheReadInputTokens": 495565,
         "cacheWriteInputTokens": 44147,
         "outputTokens": 6709
@@ -12094,7 +12094,7 @@
     "usage": [
       {
         "model": "claude-sonnet-5",
-        "uncachedInputTokens": 3698,
+        "inputTokens": 459669,
         "cacheReadInputTokens": 434520,
         "cacheWriteInputTokens": 21451,
         "outputTokens": 2152
@@ -23222,7 +23222,7 @@
     "usage": [
       {
         "model": "gpt-5.4-mini",
-        "uncachedInputTokens": 48277,
+        "inputTokens": 451733,
         "cacheReadInputTokens": 403456,
         "cacheWriteInputTokens": 0,
         "outputTokens": 5753
@@ -38906,7 +38906,7 @@
     "usage": [
       {
         "model": "gpt-5.6-sol",
-        "uncachedInputTokens": 57,
+        "inputTokens": 536569,
         "cacheReadInputTokens": 490433,
         "cacheWriteInputTokens": 46079,
         "outputTokens": 2658
@@ -55418,7 +55418,7 @@
     "usage": [
       {
         "model": "moonshotai/kimi-k3",
-        "uncachedInputTokens": 33019,
+        "inputTokens": 245543,
         "cacheReadInputTokens": 212524,
         "cacheWriteInputTokens": 0,
         "outputTokens": 2554

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -784,149 +784,20 @@
     "docs": {
       "calls": []
     },
+    "usage": [
+      {
+        "model": "claude-opus-5",
+        "uncachedInputTokens": 3891,
+        "cacheReadInputTokens": 495565,
+        "cacheWriteInputTokens": 44147,
+        "outputTokens": 6709
+      }
+    ],
+    "durationMs": 143603,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "claude-code-opus-5",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-opus-5",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "claude-code-opus-5",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-opus-5",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "search_docs",
-          "query": "{ searchDocs(query: \"declarative database schemas generate migration db diff local\", limit: 4) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
-              "title": "Local development workflow"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
-              "title": "Database Migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/managing-environments",
-              "title": "Managing Environments"
-            }
-          ],
-          "resultChars": 66910
-        }
-      ]
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "claude-code-opus-5/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "claude-code-opus-5",
@@ -12220,122 +12091,20 @@
     "docs": {
       "calls": []
     },
+    "usage": [
+      {
+        "model": "claude-sonnet-5",
+        "uncachedInputTokens": 3698,
+        "cacheReadInputTokens": 434520,
+        "cacheWriteInputTokens": 21451,
+        "outputTokens": 2152
+      }
+    ],
+    "durationMs": 83345,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-5",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-5",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-5",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-5",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "claude-code-sonnet-5",
@@ -23448,210 +23217,22 @@
       ]
     },
     "docs": {
-      "calls": [
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/changelog.md",
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ]
-        },
-        {
-          "source": "web_search",
-          "query": "site:supabase.com changelog breaking-change supabase",
-          "pages": []
-        }
-      ]
+      "calls": []
     },
+    "usage": [
+      {
+        "model": "gpt-5.4-mini",
+        "uncachedInputTokens": 48277,
+        "cacheReadInputTokens": 403456,
+        "cacheWriteInputTokens": 0,
+        "outputTokens": 5753
+      }
+    ],
+    "durationMs": 98169,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.4-mini",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.4-mini",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "shell_fetch",
-          "query": "/bin/bash -lc \"curl -fsSL https://supabase.com/changelog.md | sed -n '1,160p'\"",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ],
-          "resultChars": 9005
-        },
-        {
-          "source": "search_docs",
-          "query": "query { searchDocs(query: \"declarative database schemas supabase migration generate schema_paths alter table add column\", limit: 5) { nodes { ... on Guide { title href content } ... on CLICommandReference { title href content } ... on TroubleshootingGuide { title href content } } totalCount } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
-              "title": "Local development workflow"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
-              "title": "Database migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
-              "title": "Database Migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/database/postgres/column-level-security",
-              "title": "Column Level Security"
-            }
-          ],
-          "resultChars": 74593
-        }
-      ]
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.4-mini",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.4-mini",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "search_docs",
-          "query": "query {\n  searchDocs(query: \"declarative database schemas supabase db pull local schema_paths\", limit: 5) {\n    nodes {\n      title\n      href\n      content\n    }\n  }\n}",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
-              "title": "Database migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
-              "title": "Local development workflow"
-            },
-            {
-              "url": "https://supabase.com/docs/reference/cli/supabase-db-pull",
-              "title": "Pull schema from the remote database"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/branching/working-with-branches",
-              "title": "Working with branches"
-            }
-          ],
-          "resultChars": 64546
-        }
-      ]
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "codex-gpt-5.4-mini/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "codex-gpt-5.4-mini",
@@ -39308,211 +38889,34 @@
     "docs": {
       "calls": [
         {
-          "source": "search_docs",
-          "query": "query { searchDocs(query: \"local development declarative schemas generate migration db diff schema_paths\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
+          "source": "shell_fetch",
+          "query": "/bin/bash -lc \"supabase --version\nsupabase db --help\nsupabase db diff --help\nsupabase migration --help\nsupabase status || true\ncurl -fsSL https://supabase.com/changelog.md | rg -n -i 'breaking-change|declarative|schema|migration' | head -80\ncurl -fsSL https://supabase.com/docs/guides/local-development/declarative-database-schemas.md | sed -n '1,220p'\nsed -n '1,100p' supabase/schemas/products.sql\"",
           "pages": [
             {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
+              "url": "https://supabase.com/changelog.md"
             },
             {
-              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
-              "title": "Local development workflow"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
-              "title": "Database Migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/managing-environments",
-              "title": "Managing Environments"
-            },
-            {
-              "url": "https://supabase.com/docs/reference/cli/supabase-db-diff",
-              "title": "Diffs the local database for schema changes"
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas.md"
             }
           ],
-          "resultChars": 72112
+          "resultChars": 22559
         }
       ]
     },
+    "usage": [
+      {
+        "model": "gpt-5.6-sol",
+        "uncachedInputTokens": 57,
+        "cacheReadInputTokens": 490433,
+        "cacheWriteInputTokens": 46079,
+        "outputTokens": 2658
+      }
+    ],
+    "durationMs": 94869,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "codex-gpt-5.6/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.6",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.6-sol",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "search_docs",
-          "query": "query { searchDocs(query: \"local development declarative database schemas schema_paths db diff migrations\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
-              "title": "Database Migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
-              "title": "Local development workflow"
-            },
-            {
-              "url": "https://supabase.com/docs/reference/cli/supabase-db-diff",
-              "title": "Diffs the local database for schema changes"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
-              "title": "Database migrations"
-            }
-          ],
-          "resultChars": 71255
-        }
-      ]
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "codex-gpt-5.6/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.6",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.6-sol",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": false
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "search_docs",
-          "query": "query { searchDocs(query: \"Supabase CLI local database migrations declarative schemas db reset\", limit: 5) { nodes { title href content } } }",
-          "hasContent": true,
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
-              "title": "Local development workflow"
-            },
-            {
-              "url": "https://supabase.com/docs/reference/cli/supabase-db-reset",
-              "title": "Resets the local database to current migrations"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
-              "title": "Declarative database schemas"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/getting-started/tutorials/with-redwoodjs",
-              "title": "Build a User Management App with RedwoodJS"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/testing/overview",
-              "title": "Testing Overview"
-            }
-          ],
-          "resultChars": 79345
-        }
-      ]
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "codex-gpt-5.6/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "codex-gpt-5.6",
@@ -56011,121 +55415,20 @@
     "docs": {
       "calls": []
     },
+    "usage": [
+      {
+        "model": "moonshotai/kimi-k3",
+        "uncachedInputTokens": 33019,
+        "cacheReadInputTokens": 212524,
+        "cacheWriteInputTokens": 0,
+        "outputTokens": 2554
+      }
+    ],
+    "durationMs": 75691,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "opencode-kimi-k3",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "opencode",
-      "modelProvider": "moonshotai",
-      "modelId": "moonshotai/kimi-k3"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "opencode-kimi-k3",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "opencode",
-      "modelProvider": "moonshotai",
-      "modelId": "moonshotai/kimi-k3"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": false
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": false,
-        "notes": "description not found in any schema file"
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": false,
-        "notes": "found 1 migration file(s)"
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": false
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": []
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "opencode-kimi-k3",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -782,18 +782,63 @@
       ]
     },
     "docs": {
-      "calls": []
+      "calls": [
+        {
+          "source": "search_docs",
+          "query": "{ searchDocs(query: \"declarative database schemas migration diff workflow\", limit: 4) { nodes { title href content } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/platform/sso/multiple-providers",
+              "title": "Multiple SSO Providers"
+            },
+            {
+              "url": "https://supabase.com/docs/reference/cli/supabase-db-pull",
+              "title": "Pull schema from the remote database"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            }
+          ],
+          "resultChars": 59751
+        },
+        {
+          "source": "shell_fetch",
+          "query": "curl -sL \"https://supabase.com/docs/guides/local-development/declarative-database-schemas.md\" | head -120",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas.md"
+            }
+          ],
+          "resultChars": 4194
+        },
+        {
+          "source": "shell_fetch",
+          "query": "curl -sL \"https://supabase.com/changelog.md\" | grep -iE \"breaking|db diff|declarative\" | head -20",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ],
+          "resultChars": 3619
+        }
+      ]
     },
     "usage": [
       {
         "model": "claude-opus-5",
-        "inputTokens": 543603,
-        "cacheReadInputTokens": 495565,
-        "cacheWriteInputTokens": 44147,
-        "outputTokens": 6709
+        "inputTokens": 401722,
+        "cacheReadInputTokens": 359823,
+        "cacheWriteInputTokens": 38147,
+        "outputTokens": 4664
       }
     ],
-    "durationMs": 143603,
+    "durationMs": 98388,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
@@ -12094,13 +12139,13 @@
     "usage": [
       {
         "model": "claude-sonnet-5",
-        "inputTokens": 459669,
-        "cacheReadInputTokens": 434520,
-        "cacheWriteInputTokens": 21451,
-        "outputTokens": 2152
+        "inputTokens": 433570,
+        "cacheReadInputTokens": 408252,
+        "cacheWriteInputTokens": 21622,
+        "outputTokens": 2120
       }
     ],
-    "durationMs": 83345,
+    "durationMs": 91057,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
@@ -23217,18 +23262,58 @@
       ]
     },
     "docs": {
-      "calls": []
+      "calls": [
+        {
+          "source": "shell_fetch",
+          "query": "/bin/bash -lc \"curl -fsSL https://supabase.com/changelog.md | sed -n '1,120p'\"",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ],
+          "resultChars": 6693
+        },
+        {
+          "source": "search_docs",
+          "query": "query { searchDocs(query: \"declarative database schemas add column existing table migration\", limit: 5) { nodes { __typename ... on Guide { title href content subsections { totalCount } } ... on CLICommandReference { title href content } } } }",
+          "hasContent": true,
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas",
+              "title": "Declarative database schemas"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/cli-workflows",
+              "title": "Local development workflow"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/deployment/database-migrations",
+              "title": "Database Migrations"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/database/replication/ducklake",
+              "title": "DuckLake destination"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/database-migrations",
+              "title": "Database migrations"
+            }
+          ],
+          "resultChars": 84897
+        }
+      ]
     },
     "usage": [
       {
         "model": "gpt-5.4-mini",
-        "inputTokens": 451733,
-        "cacheReadInputTokens": 403456,
+        "inputTokens": 808410,
+        "cacheReadInputTokens": 723584,
         "cacheWriteInputTokens": 0,
-        "outputTokens": 5753
+        "outputTokens": 5338
       }
     ],
-    "durationMs": 98169,
+    "durationMs": 84766,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
@@ -38890,29 +38975,26 @@
       "calls": [
         {
           "source": "shell_fetch",
-          "query": "/bin/bash -lc \"supabase --version\nsupabase db --help\nsupabase db diff --help\nsupabase migration --help\nsupabase status || true\ncurl -fsSL https://supabase.com/changelog.md | rg -n -i 'breaking-change|declarative|schema|migration' | head -80\ncurl -fsSL https://supabase.com/docs/guides/local-development/declarative-database-schemas.md | sed -n '1,220p'\nsed -n '1,100p' supabase/schemas/products.sql\"",
+          "query": "/bin/bash -lc \"find .claude/skills/supabase-postgres-best-practices/references -maxdepth 1 -type f -printf '%f\\\\n' | sort | sed -n '1,200p'; curl -fsSL https://supabase.com/changelog.md | sed -n '1,160p'; supabase --version; supabase migration --help; find . -maxdepth 4 -type f | sort | sed -n '1,240p'\"",
           "pages": [
             {
               "url": "https://supabase.com/changelog.md"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas.md"
             }
           ],
-          "resultChars": 22559
+          "resultChars": 14496
         }
       ]
     },
     "usage": [
       {
         "model": "gpt-5.6-sol",
-        "inputTokens": 536569,
-        "cacheReadInputTokens": 490433,
-        "cacheWriteInputTokens": 46079,
-        "outputTokens": 2658
+        "inputTokens": 361969,
+        "cacheReadInputTokens": 319536,
+        "cacheWriteInputTokens": 42391,
+        "outputTokens": 1641
       }
     ],
-    "durationMs": 94869,
+    "durationMs": 52738,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
@@ -55418,13 +55500,13 @@
     "usage": [
       {
         "model": "moonshotai/kimi-k3",
-        "inputTokens": 245543,
-        "cacheReadInputTokens": 212524,
+        "inputTokens": 207198,
+        "cacheReadInputTokens": 179064,
         "cacheWriteInputTokens": 0,
-        "outputTokens": 2554
+        "outputTokens": 2666
       }
     ],
-    "durationMs": 75691,
+    "durationMs": 108426,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,

--- a/packages/core/src/agents/claude-code/runner.test.ts
+++ b/packages/core/src/agents/claude-code/runner.test.ts
@@ -55,3 +55,61 @@ describe('claudeCodeRunner.deriveStopReason', () => {
     expect(derive(undefined, ok)).toBe('stop');
   });
 });
+
+describe('claudeCodeRunner.extractUsage', () => {
+  const extract = claudeCodeRunner.extractUsage!;
+
+  it('emits one entry per model in modelUsage', () => {
+    const raw = [
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        usage: { input_tokens: 10, output_tokens: 40 },
+        modelUsage: {
+          'claude-sonnet-5': {
+            inputTokens: 10,
+            cacheCreationInputTokens: 200,
+            cacheReadInputTokens: 3000,
+            outputTokens: 40,
+            costUSD: 0.05,
+          },
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 520,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            outputTokens: 13,
+            costUSD: 0.0006,
+          },
+        },
+      }),
+    ].join('\n');
+    expect(extract(raw, 'claude-sonnet-5')).toEqual([
+      {
+        model: 'claude-sonnet-5',
+        uncachedInputTokens: 10,
+        cacheReadInputTokens: 3000,
+        cacheWriteInputTokens: 200,
+        outputTokens: 40,
+      },
+      {
+        model: 'claude-haiku-4-5-20251001',
+        uncachedInputTokens: 520,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+        outputTokens: 13,
+      },
+    ]);
+  });
+
+  it('returns undefined without modelUsage', () => {
+    expect(extract(undefined, 'claude-sonnet-5')).toBeUndefined();
+    expect(extract('not json\n', 'claude-sonnet-5')).toBeUndefined();
+    expect(
+      extract(
+        JSON.stringify({ type: 'result', subtype: 'success' }),
+        'claude-sonnet-5'
+      )
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/agents/claude-code/runner.test.ts
+++ b/packages/core/src/agents/claude-code/runner.test.ts
@@ -59,7 +59,7 @@ describe('claudeCodeRunner.deriveStopReason', () => {
 describe('claudeCodeRunner.extractUsage', () => {
   const extract = claudeCodeRunner.extractUsage!;
 
-  it('emits one entry per model in modelUsage', () => {
+  it('adds cache into input, one entry per model', () => {
     const raw = [
       JSON.stringify({ type: 'system', subtype: 'init' }),
       JSON.stringify({
@@ -87,14 +87,14 @@ describe('claudeCodeRunner.extractUsage', () => {
     expect(extract(raw, 'claude-sonnet-5')).toEqual([
       {
         model: 'claude-sonnet-5',
-        uncachedInputTokens: 10,
+        inputTokens: 3210,
         cacheReadInputTokens: 3000,
         cacheWriteInputTokens: 200,
         outputTokens: 40,
       },
       {
         model: 'claude-haiku-4-5-20251001',
-        uncachedInputTokens: 520,
+        inputTokens: 520,
         cacheReadInputTokens: 0,
         cacheWriteInputTokens: 0,
         outputTokens: 13,

--- a/packages/core/src/agents/claude-code/runner.ts
+++ b/packages/core/src/agents/claude-code/runner.ts
@@ -6,7 +6,7 @@
 
 import type { Model as AnthropicModel } from '@anthropic-ai/sdk/resources/messages';
 import type { McpServerConfig } from '../../index.js';
-import { parseJsonlRecords } from '../../json.js';
+import { isRecord, parseJsonlRecords } from '../../json.js';
 import type { AgentRunner } from '../types.js';
 import {
   npmGlobalBin,
@@ -82,7 +82,15 @@ export const claudeCodeRunner: AgentRunner<AnthropicModel> = {
       `cat ${userPromptPath} | ${claude} ${flags}`,
       {
         timeoutMs: timeoutSec * 1000,
-        env: { ANTHROPIC_API_KEY: apiKey },
+        env: {
+          ANTHROPIC_API_KEY: apiKey,
+          // No auto-updates, telemetry, release notes, or feature-flag fetches
+          // during a run. https://code.claude.com/docs/en/env-vars
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+          // Skips the haiku call that titles the session, which would otherwise
+          // show up as a second model in usage.
+          CLAUDE_CODE_DISABLE_TERMINAL_TITLE: '1',
+        },
       }
     );
     return { command, raw: command.stdout };
@@ -96,6 +104,27 @@ export const claudeCodeRunner: AgentRunner<AnthropicModel> = {
     if (subtype === 'success') return 'stop';
     if (subtype) return subtype; // e.g. error_max_turns — surface verbatim
     return processStopReason(command);
+  },
+
+  extractUsage(raw) {
+    // `modelUsage` covers every model the run called, including Claude Code's
+    // own side calls, which the sibling `usage` aggregate leaves out.
+    // Anthropic's input count already excludes both cache buckets.
+    const byModel = lastResultEvent(raw)?.modelUsage;
+    if (!isRecord(byModel)) return undefined;
+    return Object.entries(byModel).flatMap(([model, u]) =>
+      isRecord(u)
+        ? [
+            {
+              model,
+              uncachedInputTokens: Number(u.inputTokens) || 0,
+              cacheReadInputTokens: Number(u.cacheReadInputTokens) || 0,
+              cacheWriteInputTokens: Number(u.cacheCreationInputTokens) || 0,
+              outputTokens: Number(u.outputTokens) || 0,
+            },
+          ]
+        : []
+    );
   },
 };
 

--- a/packages/core/src/agents/claude-code/runner.ts
+++ b/packages/core/src/agents/claude-code/runner.ts
@@ -107,24 +107,24 @@ export const claudeCodeRunner: AgentRunner<AnthropicModel> = {
   },
 
   extractUsage(raw) {
-    // `modelUsage` covers every model the run called, including Claude Code's
-    // own side calls, which the sibling `usage` aggregate leaves out.
-    // Anthropic's input count already excludes both cache buckets.
+    // `modelUsage` covers every model the run called, unlike the sibling
+    // `usage` aggregate. Anthropic's input count excludes both cache buckets.
     const byModel = lastResultEvent(raw)?.modelUsage;
     if (!isRecord(byModel)) return undefined;
-    return Object.entries(byModel).flatMap(([model, u]) =>
-      isRecord(u)
-        ? [
-            {
-              model,
-              uncachedInputTokens: Number(u.inputTokens) || 0,
-              cacheReadInputTokens: Number(u.cacheReadInputTokens) || 0,
-              cacheWriteInputTokens: Number(u.cacheCreationInputTokens) || 0,
-              outputTokens: Number(u.outputTokens) || 0,
-            },
-          ]
-        : []
-    );
+    return Object.entries(byModel).flatMap(([model, u]) => {
+      if (!isRecord(u)) return [];
+      const cacheRead = Number(u.cacheReadInputTokens) || 0;
+      const cacheWrite = Number(u.cacheCreationInputTokens) || 0;
+      return [
+        {
+          model,
+          inputTokens: (Number(u.inputTokens) || 0) + cacheRead + cacheWrite,
+          cacheReadInputTokens: cacheRead,
+          cacheWriteInputTokens: cacheWrite,
+          outputTokens: Number(u.outputTokens) || 0,
+        },
+      ];
+    });
   },
 };
 

--- a/packages/core/src/agents/codex/runner.test.ts
+++ b/packages/core/src/agents/codex/runner.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { codexRunner } from './runner.js';
+
+describe('codexRunner.extractUsage', () => {
+  const extract = codexRunner.extractUsage!;
+
+  it('subtracts cache buckets from input_tokens', () => {
+    const raw = [
+      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 30,
+          cache_write_input_tokens: 20,
+          output_tokens: 25,
+        },
+      }),
+    ].join('\n');
+    expect(extract(raw, 'gpt-5.6')).toEqual([
+      {
+        model: 'gpt-5.6',
+        uncachedInputTokens: 50,
+        cacheReadInputTokens: 30,
+        cacheWriteInputTokens: 20,
+        outputTokens: 25,
+      },
+    ]);
+  });
+
+  it('sums usage across multiple turns', () => {
+    const raw = [
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 25 },
+      }),
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 50, cached_input_tokens: 10, output_tokens: 5 },
+      }),
+    ].join('\n');
+    expect(extract(raw, 'gpt-5.6')).toEqual([
+      {
+        model: 'gpt-5.6',
+        uncachedInputTokens: 140,
+        cacheReadInputTokens: 10,
+        cacheWriteInputTokens: 0,
+        outputTokens: 30,
+      },
+    ]);
+  });
+
+  it('returns undefined without usage', () => {
+    expect(extract(undefined, 'gpt-5.6')).toBeUndefined();
+    expect(extract('not json\n', 'gpt-5.6')).toBeUndefined();
+    expect(
+      extract(JSON.stringify({ type: 'turn.completed' }), 'gpt-5.6')
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/agents/codex/runner.test.ts
+++ b/packages/core/src/agents/codex/runner.test.ts
@@ -4,7 +4,7 @@ import { codexRunner } from './runner.js';
 describe('codexRunner.extractUsage', () => {
   const extract = codexRunner.extractUsage!;
 
-  it('subtracts cache buckets from input_tokens', () => {
+  it('maps turn.completed usage straight across', () => {
     const raw = [
       JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
       JSON.stringify({
@@ -20,7 +20,7 @@ describe('codexRunner.extractUsage', () => {
     expect(extract(raw, 'gpt-5.6')).toEqual([
       {
         model: 'gpt-5.6',
-        uncachedInputTokens: 50,
+        inputTokens: 100,
         cacheReadInputTokens: 30,
         cacheWriteInputTokens: 20,
         outputTokens: 25,
@@ -42,7 +42,7 @@ describe('codexRunner.extractUsage', () => {
     expect(extract(raw, 'gpt-5.6')).toEqual([
       {
         model: 'gpt-5.6',
-        uncachedInputTokens: 140,
+        inputTokens: 150,
         cacheReadInputTokens: 10,
         cacheWriteInputTokens: 0,
         outputTokens: 30,

--- a/packages/core/src/agents/codex/runner.ts
+++ b/packages/core/src/agents/codex/runner.ts
@@ -120,15 +120,15 @@ export const codexRunner: AgentRunner<CodexModel> = {
   },
 
   extractUsage(raw, model) {
-    // OpenAI nests both cache buckets inside `input_tokens`. Cache writes are
-    // only reported on GPT-5.6 and newer, so 0 is a real zero on older models.
+    // Cache writes are only reported on GPT-5.6 and newer, so 0 is a real
+    // zero on older models.
     // https://developers.openai.com/api/docs/guides/prompt-caching
     if (!raw) return undefined;
     const { records } = parseJsonlRecords(raw);
     let sawUsage = false;
     const usage = {
       model,
-      uncachedInputTokens: 0,
+      inputTokens: 0,
       cacheReadInputTokens: 0,
       cacheWriteInputTokens: 0,
       outputTokens: 0,
@@ -136,17 +136,14 @@ export const codexRunner: AgentRunner<CodexModel> = {
     for (const record of records) {
       if (record.type !== 'turn.completed' || !isRecord(record.usage)) continue;
       sawUsage = true;
-      usage.uncachedInputTokens += Number(record.usage.input_tokens) || 0;
+      usage.inputTokens += Number(record.usage.input_tokens) || 0;
       usage.cacheReadInputTokens +=
         Number(record.usage.cached_input_tokens) || 0;
       usage.cacheWriteInputTokens +=
         Number(record.usage.cache_write_input_tokens) || 0;
       usage.outputTokens += Number(record.usage.output_tokens) || 0;
     }
-    if (!sawUsage) return undefined;
-    usage.uncachedInputTokens -=
-      usage.cacheReadInputTokens + usage.cacheWriteInputTokens;
-    return [usage];
+    return sawUsage ? [usage] : undefined;
   },
 };
 

--- a/packages/core/src/agents/codex/runner.ts
+++ b/packages/core/src/agents/codex/runner.ts
@@ -120,9 +120,6 @@ export const codexRunner: AgentRunner<CodexModel> = {
   },
 
   extractUsage(raw, model) {
-    // Cache writes are only reported on GPT-5.6 and newer, so 0 is a real
-    // zero on older models.
-    // https://developers.openai.com/api/docs/guides/prompt-caching
     if (!raw) return undefined;
     const { records } = parseJsonlRecords(raw);
     let sawUsage = false;

--- a/packages/core/src/agents/codex/runner.ts
+++ b/packages/core/src/agents/codex/runner.ts
@@ -9,7 +9,7 @@
 
 import type { ChatModel } from 'openai/resources/shared';
 import type { McpServerConfig } from '../../index.js';
-import { parseJsonlRecords } from '../../json.js';
+import { isRecord, parseJsonlRecords } from '../../json.js';
 import type { AgentRunner } from '../types.js';
 import {
   npmGlobalBin,
@@ -81,6 +81,9 @@ export const codexRunner: AgentRunner<CodexModel> = {
       '--skip-git-repo-check',
       // The sandbox is the isolation boundary — let Codex run commands freely.
       '--dangerously-bypass-approvals-and-sandbox',
+      // No anonymous usage pings during a run.
+      // https://learn.chatgpt.com/docs/config-file/config-advanced
+      `-c ${shellQuote('analytics.enabled=false')}`,
       `-m ${shellQuote(model)}`,
       // Reasoning effort via config override; omitted leaves Codex's default.
       // The value is parsed as TOML, so pass it as a quoted TOML string.
@@ -114,6 +117,36 @@ export const codexRunner: AgentRunner<CodexModel> = {
       default:
         return processStopReason(command);
     }
+  },
+
+  extractUsage(raw, model) {
+    // OpenAI nests both cache buckets inside `input_tokens`. Cache writes are
+    // only reported on GPT-5.6 and newer, so 0 is a real zero on older models.
+    // https://developers.openai.com/api/docs/guides/prompt-caching
+    if (!raw) return undefined;
+    const { records } = parseJsonlRecords(raw);
+    let sawUsage = false;
+    const usage = {
+      model,
+      uncachedInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      outputTokens: 0,
+    };
+    for (const record of records) {
+      if (record.type !== 'turn.completed' || !isRecord(record.usage)) continue;
+      sawUsage = true;
+      usage.uncachedInputTokens += Number(record.usage.input_tokens) || 0;
+      usage.cacheReadInputTokens +=
+        Number(record.usage.cached_input_tokens) || 0;
+      usage.cacheWriteInputTokens +=
+        Number(record.usage.cache_write_input_tokens) || 0;
+      usage.outputTokens += Number(record.usage.output_tokens) || 0;
+    }
+    if (!sawUsage) return undefined;
+    usage.uncachedInputTokens -=
+      usage.cacheReadInputTokens + usage.cacheWriteInputTokens;
+    return [usage];
   },
 };
 

--- a/packages/core/src/agents/engine.ts
+++ b/packages/core/src/agents/engine.ts
@@ -93,6 +93,7 @@ export function createCliAgent<M extends string = string>(
       await writeSandboxFile(sandbox, SYSTEM_PROMPT_PATH, args.systemPrompt);
       await writeSandboxFile(sandbox, USER_PROMPT_PATH, args.userPrompt);
 
+      const start = Date.now();
       const { command, raw } = await runner.exec({
         sandbox,
         model: options.model,
@@ -135,6 +136,8 @@ export function createCliAgent<M extends string = string>(
         steps: adapted.steps,
         stoppedReason:
           runner.deriveStopReason?.(raw, command) ?? processStopReason(command),
+        usage: runner.extractUsage?.(raw, options.model),
+        durationMs: Date.now() - start,
       };
     },
   };

--- a/packages/core/src/agents/opencode/runner.test.ts
+++ b/packages/core/src/agents/opencode/runner.test.ts
@@ -83,6 +83,66 @@ describe('opencode runner', () => {
   });
 });
 
+describe('opencode runner extractUsage', () => {
+  const extract = createOpencodeRunner('anthropic/claude-sonnet-5')
+    .extractUsage!;
+
+  it('sums steps and adds reasoning to output', () => {
+    const raw = [
+      JSON.stringify({
+        type: 'step_finish',
+        part: {
+          type: 'step-finish',
+          reason: 'tool-calls',
+          tokens: {
+            input: 100,
+            output: 20,
+            reasoning: 5,
+            cache: { read: 40, write: 10 },
+          },
+        },
+      }),
+      JSON.stringify({ type: 'text', part: { type: 'text', text: 'Done.' } }),
+      JSON.stringify({
+        type: 'step_finish',
+        part: {
+          type: 'step-finish',
+          reason: 'stop',
+          tokens: {
+            input: 200,
+            output: 30,
+            reasoning: 0,
+            cache: { read: 90, write: 0 },
+          },
+        },
+      }),
+    ].join('\n');
+    expect(extract(raw, 'anthropic/claude-sonnet-5')).toEqual([
+      {
+        model: 'anthropic/claude-sonnet-5',
+        uncachedInputTokens: 300,
+        cacheReadInputTokens: 130,
+        cacheWriteInputTokens: 10,
+        outputTokens: 55,
+      },
+    ]);
+  });
+
+  it('returns undefined without usage', () => {
+    expect(extract(undefined, 'anthropic/claude-sonnet-5')).toBeUndefined();
+    expect(extract('not json\n', 'anthropic/claude-sonnet-5')).toBeUndefined();
+    expect(
+      extract(
+        JSON.stringify({
+          type: 'step_finish',
+          part: { type: 'step-finish', reason: 'stop' },
+        }),
+        'anthropic/claude-sonnet-5'
+      )
+    ).toBeUndefined();
+  });
+});
+
 /** Capture the `--model` flag, run env, and written config from one exec. */
 async function captureExec(
   model: string,
@@ -129,7 +189,10 @@ describe('opencode runner exec routing', () => {
     );
     // Model is addressed under the vercel provider; the gateway slug stays intact.
     expect(runCommand).toContain("--model 'vercel/moonshotai/kimi-k3'");
-    expect(runEnv).toEqual({ AI_GATEWAY_API_KEY: 'gw-key' });
+    expect(runEnv).toEqual({
+      AI_GATEWAY_API_KEY: 'gw-key',
+      OPENCODE_DISABLE_AUTOUPDATE: '1',
+    });
     expect(config?.mcp).toHaveProperty('supabase');
   });
 

--- a/packages/core/src/agents/opencode/runner.test.ts
+++ b/packages/core/src/agents/opencode/runner.test.ts
@@ -87,7 +87,7 @@ describe('opencode runner extractUsage', () => {
   const extract = createOpencodeRunner('anthropic/claude-sonnet-5')
     .extractUsage!;
 
-  it('sums steps and adds reasoning to output', () => {
+  it('adds cache into input and reasoning into output', () => {
     const raw = [
       JSON.stringify({
         type: 'step_finish',
@@ -120,7 +120,7 @@ describe('opencode runner extractUsage', () => {
     expect(extract(raw, 'anthropic/claude-sonnet-5')).toEqual([
       {
         model: 'anthropic/claude-sonnet-5',
-        uncachedInputTokens: 300,
+        inputTokens: 440,
         cacheReadInputTokens: 130,
         cacheWriteInputTokens: 10,
         outputTokens: 55,

--- a/packages/core/src/agents/opencode/runner.ts
+++ b/packages/core/src/agents/opencode/runner.ts
@@ -194,7 +194,7 @@ export function createOpencodeRunner(
       let sawUsage = false;
       const usage = {
         model,
-        uncachedInputTokens: 0,
+        inputTokens: 0,
         cacheReadInputTokens: 0,
         cacheWriteInputTokens: 0,
         outputTokens: 0,
@@ -205,9 +205,12 @@ export function createOpencodeRunner(
         if (!isRecord(tokens)) continue;
         sawUsage = true;
         const cache = isRecord(tokens.cache) ? tokens.cache : undefined;
-        usage.uncachedInputTokens += Number(tokens.input) || 0;
-        usage.cacheReadInputTokens += Number(cache?.read) || 0;
-        usage.cacheWriteInputTokens += Number(cache?.write) || 0;
+        const cacheRead = Number(cache?.read) || 0;
+        const cacheWrite = Number(cache?.write) || 0;
+        usage.inputTokens +=
+          (Number(tokens.input) || 0) + cacheRead + cacheWrite;
+        usage.cacheReadInputTokens += cacheRead;
+        usage.cacheWriteInputTokens += cacheWrite;
         usage.outputTokens +=
           (Number(tokens.output) || 0) + (Number(tokens.reasoning) || 0);
       }

--- a/packages/core/src/agents/opencode/runner.ts
+++ b/packages/core/src/agents/opencode/runner.ts
@@ -156,7 +156,11 @@ export function createOpencodeRunner(
         {
           timeoutMs: timeoutSec * 1000,
           // The native vercel provider reads the gateway key from this env var.
-          env: { [this.apiKeyEnvVar]: apiKey },
+          env: {
+            [this.apiKeyEnvVar]: apiKey,
+            // No update check during a run.
+            OPENCODE_DISABLE_AUTOUPDATE: '1',
+          },
         }
       );
       return { command, raw: command.stdout };
@@ -180,6 +184,34 @@ export function createOpencodeRunner(
         break;
       }
       return processStopReason(command);
+    },
+
+    extractUsage(raw, model) {
+      // opencode keeps cache out of `input` and reasoning out of `output`.
+      // https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/acp/usage.ts
+      if (!raw) return undefined;
+      const { records } = parseJsonlRecords(raw);
+      let sawUsage = false;
+      const usage = {
+        model,
+        uncachedInputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+        outputTokens: 0,
+      };
+      for (const record of records) {
+        if (record.type !== 'step_finish' || !isRecord(record.part)) continue;
+        const tokens = record.part.tokens;
+        if (!isRecord(tokens)) continue;
+        sawUsage = true;
+        const cache = isRecord(tokens.cache) ? tokens.cache : undefined;
+        usage.uncachedInputTokens += Number(tokens.input) || 0;
+        usage.cacheReadInputTokens += Number(cache?.read) || 0;
+        usage.cacheWriteInputTokens += Number(cache?.write) || 0;
+        usage.outputTokens +=
+          (Number(tokens.output) || 0) + (Number(tokens.reasoning) || 0);
+      }
+      return sawUsage ? [usage] : undefined;
     },
   };
 }

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -14,6 +14,7 @@
 import type { CommandResult, McpServerConfig } from '../index.js';
 import type {
   AgentHarnessId,
+  AgentUsage,
   ModelProvider,
   ReasoningEffortLevel,
 } from '../eval-metadata.js';
@@ -107,6 +108,11 @@ export interface AgentRunner<M extends string = string> {
    * result. Falls back to a process-exit-based reason when omitted.
    */
   deriveStopReason?(raw: string | undefined, command: CommandResult): string;
+  /**
+   * Whole-run token usage from the transcript, per model. `model` is the
+   * configured model id, for harnesses that report one aggregate.
+   */
+  extractUsage?(raw: string | undefined, model: M): AgentUsage | undefined;
 }
 
 /**

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -252,17 +252,18 @@ export const evalFrontmatterSchema = z.preprocess((raw) => {
 }, evalMetadataSchema);
 
 /**
- * Token usage for one model, split into the buckets providers price
- * separately. Buckets are disjoint, so total tokens is their sum.
+ * Token usage for one model. Field names and semantics follow OpenTelemetry's
+ * GenAI conventions, where the cache buckets are subsets of `inputTokens`.
+ * https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md
  */
 export const modelUsageSchema = z.object({
   /** Model id as the harness reported it. */
   model: z.string(),
-  /** Input the model processed fresh. */
-  uncachedInputTokens: z.number(),
-  /** Input served from the prompt cache. */
+  /** All input tokens, cache reads and writes included. */
+  inputTokens: z.number(),
+  /** Input served from the prompt cache. Subset of `inputTokens`. */
   cacheReadInputTokens: z.number(),
-  /** Input written to the prompt cache for later calls to read. */
+  /** Input written to the prompt cache. Subset of `inputTokens`. */
   cacheWriteInputTokens: z.number(),
   /** All generated tokens, reasoning included. */
   outputTokens: z.number(),
@@ -270,28 +271,15 @@ export const modelUsageSchema = z.object({
 export type ModelUsage = z.infer<typeof modelUsageSchema>;
 
 /**
- * One entry per model the run called. A run can span models (Claude Code
- * makes side calls on a smaller model), and each model bills at its own
- * rates, so entries are kept separate rather than summed.
+ * One entry per model the run called. A run can span models, and each model
+ * bills at its own rates, so entries are kept separate rather than summed.
  */
 export const agentUsageSchema = z.array(modelUsageSchema);
 export type AgentUsage = z.infer<typeof agentUsageSchema>;
 
-/** Sum of the three input buckets across every model in the run. */
-export function inputTokens(usage: AgentUsage): number {
-  return usage.reduce(
-    (n, u) =>
-      n +
-      u.uncachedInputTokens +
-      u.cacheReadInputTokens +
-      u.cacheWriteInputTokens,
-    0
-  );
-}
-
-/** Output tokens across every model in the run. */
-export function outputTokens(usage: AgentUsage): number {
-  return usage.reduce((n, u) => n + u.outputTokens, 0);
+/** Input tokens the model processed fresh, outside the cache. */
+export function uncachedInputTokens(u: ModelUsage): number {
+  return u.inputTokens - u.cacheReadInputTokens - u.cacheWriteInputTokens;
 }
 
 export const checkResultSchema = z.object({

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -251,6 +251,49 @@ export const evalFrontmatterSchema = z.preprocess((raw) => {
   };
 }, evalMetadataSchema);
 
+/**
+ * Token usage for one model, split into the buckets providers price
+ * separately. Buckets are disjoint, so total tokens is their sum.
+ */
+export const modelUsageSchema = z.object({
+  /** Model id as the harness reported it. */
+  model: z.string(),
+  /** Input the model processed fresh. */
+  uncachedInputTokens: z.number(),
+  /** Input served from the prompt cache. */
+  cacheReadInputTokens: z.number(),
+  /** Input written to the prompt cache for later calls to read. */
+  cacheWriteInputTokens: z.number(),
+  /** All generated tokens, reasoning included. */
+  outputTokens: z.number(),
+});
+export type ModelUsage = z.infer<typeof modelUsageSchema>;
+
+/**
+ * One entry per model the run called. A run can span models (Claude Code
+ * makes side calls on a smaller model), and each model bills at its own
+ * rates, so entries are kept separate rather than summed.
+ */
+export const agentUsageSchema = z.array(modelUsageSchema);
+export type AgentUsage = z.infer<typeof agentUsageSchema>;
+
+/** Sum of the three input buckets across every model in the run. */
+export function inputTokens(usage: AgentUsage): number {
+  return usage.reduce(
+    (n, u) =>
+      n +
+      u.uncachedInputTokens +
+      u.cacheReadInputTokens +
+      u.cacheWriteInputTokens,
+    0
+  );
+}
+
+/** Output tokens across every model in the run. */
+export function outputTokens(usage: AgentUsage): number {
+  return usage.reduce((n, u) => n + u.outputTokens, 0);
+}
+
 export const checkResultSchema = z.object({
   name: z.string(),
   passed: z.boolean(),
@@ -348,6 +391,9 @@ const evalResultShape = {
   run: z.number().optional(),
   skills: skillResultSchema.optional(),
   docs: docsResultSchema.optional(),
+  usage: agentUsageSchema.optional(),
+  // Wall-clock time of the agent run only. Sandbox boot and scoring are excluded.
+  durationMs: z.number().optional(),
 };
 
 // Raw result files may carry extra fields we don't model; tolerate them.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,0 +1,84 @@
+import { MockLanguageModelV3 } from 'ai/test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { aiSdkAgent } from './index.js';
+
+describe('aiSdkAgent usage', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('maps totalUsage onto one entry for the configured model', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test'); // to satisfy `assertProviderReady()`
+    const model = new MockLanguageModelV3({
+      provider: 'anthropic.messages',
+      modelId: 'claude-sonnet-5',
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'Done.' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 3210,
+            noCache: 10,
+            cacheRead: 3000,
+            cacheWrite: 200,
+          },
+          outputTokens: { total: 40, text: 40, reasoning: undefined },
+        },
+        warnings: [],
+      }),
+    });
+
+    const run = await aiSdkAgent({ model }).run({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      timeoutSec: 30,
+    });
+
+    expect(run.usage).toEqual([
+      {
+        model: 'claude-sonnet-5',
+        inputTokens: 3210,
+        cacheReadInputTokens: 3000,
+        cacheWriteInputTokens: 200,
+        outputTokens: 40,
+      },
+    ]);
+    expect(run.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('treats missing token details as zero', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test');
+    const model = new MockLanguageModelV3({
+      provider: 'openai.responses',
+      modelId: 'gpt-5.4-mini',
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'Done.' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 500,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: { total: 20, text: undefined, reasoning: undefined },
+        },
+        warnings: [],
+      }),
+    });
+
+    const run = await aiSdkAgent({ model }).run({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      timeoutSec: 30,
+    });
+
+    expect(run.usage).toEqual([
+      {
+        model: 'gpt-5.4-mini',
+        inputTokens: 500,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+        outputTokens: 20,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ import {
 } from '@supabase-evals/platform-lite';
 import type {
   AgentHarnessId,
+  AgentUsage,
   CheckResult,
   EvalMetadata,
   EvalSuite,
@@ -131,6 +132,7 @@ export type {
 } from './transcript/types.js';
 export type {
   AgentHarnessId,
+  AgentUsage,
   CheckResult,
   EvalInterface,
   EvalMetadata,
@@ -409,6 +411,8 @@ export type AgentRunResult = {
   transcript: TranscriptPart[];
   steps: number;
   stoppedReason: string;
+  usage?: AgentUsage;
+  durationMs: number;
 };
 
 export type AgentHarness = {
@@ -710,6 +714,7 @@ export function aiSdkAgent(options: {
       ]);
 
       try {
+        const start = Date.now();
         const result = await generateText({
           model: options.model,
           system: args.systemPrompt,
@@ -798,6 +803,18 @@ export function aiSdkAgent(options: {
 
         const agentReport = result.text.trim();
 
+        // `inputTokens` would include cache reads, so use `noCacheTokens`.
+        const { inputTokenDetails, outputTokens } = result.totalUsage;
+        const usage: AgentUsage = [
+          {
+            model: modelId,
+            uncachedInputTokens: inputTokenDetails.noCacheTokens ?? 0,
+            cacheReadInputTokens: inputTokenDetails.cacheReadTokens ?? 0,
+            cacheWriteInputTokens: inputTokenDetails.cacheWriteTokens ?? 0,
+            outputTokens: outputTokens ?? 0,
+          },
+        ];
+
         return {
           agentReport,
           toolCalls,
@@ -807,6 +824,8 @@ export function aiSdkAgent(options: {
             result.steps.length >= MAX_STEPS
               ? 'max_steps'
               : result.finishReason,
+          usage,
+          durationMs: Date.now() - start,
         };
       } finally {
         await closeMcpHandles(mcpHandles);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -803,12 +803,12 @@ export function aiSdkAgent(options: {
 
         const agentReport = result.text.trim();
 
-        // `inputTokens` would include cache reads, so use `noCacheTokens`.
-        const { inputTokenDetails, outputTokens } = result.totalUsage;
+        const { inputTokens, inputTokenDetails, outputTokens } =
+          result.totalUsage;
         const usage: AgentUsage = [
           {
             model: modelId,
-            uncachedInputTokens: inputTokenDetails.noCacheTokens ?? 0,
+            inputTokens: inputTokens ?? 0,
             cacheReadInputTokens: inputTokenDetails.cacheReadTokens ?? 0,
             cacheWriteInputTokens: inputTokenDetails.cacheWriteTokens ?? 0,
             outputTokens: outputTokens ?? 0,


### PR DESCRIPTION
Records `usage` and `durationMs` on each result so we can see what a run costs in tokens and how long the agent took. Usage tracks input, cache read, cache write, and output tokens, inspired by [OTel GenAI conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/registry/attributes/gen-ai.md) where the cache buckets are subsets of input. All four harnesses report these fields, and from them we can price a run (the two cache buckets each have their own rate, and input minus both is the fresh input billed at the base rate), see [OpenAI](https://developers.openai.com/api/docs/pricing) or [Claude](https://platform.claude.com/docs/en/about-claude/pricing#model-pricing) pricing.

```jsonc
// result.json
{
  // ...,
  "usage": [
    {
      "model": "gpt-5.6-sol",
      "inputTokens": 267028,
      "cacheReadInputTokens": 230032,
      "cacheWriteInputTokens": 36957,
      "outputTokens": 1971
    }
  ],
  "durationMs": 61877
}
```

Usage is a list because runs can potentially use multiple models, e.g. by default Claude Code incurs a small amount of Haiku usage for title renames ([thread](https://supabase.slack.com/archives/C051L8U2EJF/p1788812576343199?thread_ts=1788197811.007299&cid=C051L8U2EJF)), but we could also see runs that spawn subagents.

> Aside: based on that finding, I took the opportunity to disable background traffic (Claude Code nonessential traffic + session title, codex analytics, opencode auto-update) to prevent unexpected token usage or other run interference. E.g. `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` and `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` per [docs](https://code.claude.com/docs/en/env-vars).

The UI details for a run now shows duration and a one-line token total ([Preview deep link](https://evals-pm6j3gx3t-supabase.vercel.app/?sheet=eval&item=build-cli-002-declarative-schema&run=codex-gpt-5.6%2Fbuild-cli-002-declarative-schema%2Frun-1%2Fresult.json))

<img width="893" height="438" alt="CleanShot 2026-09-07 at 17 49 24@2x" src="https://github.com/user-attachments/assets/907e4c2a-f617-4b7f-a8df-73e1e610cc9f" />


Sanity checked every bucket against raw CLI output for all three sandbox harnesses plus direct OpenAI API calls, and ran one eval per harness end to end. After merge, we can let performance metrics trickle in from nightly regression runs, and optionally trigger a full benchmark refresh when it's convenient. 

Closes AI-971
