### PR TITLE
feat: record step and tool call counts for eval runs

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -375,6 +375,8 @@ async function runOne(
     agentReport: string;
     stoppedReason: string;
     usage?: AgentUsage;
+    turnCount?: number;
+    toolCallCount: number;
     durationMs: number;
   }
 > {
@@ -490,6 +492,8 @@ async function runOne(
       agentReport: run.agentReport,
       stoppedReason: run.stoppedReason,
       usage: run.usage,
+      turnCount: run.turnCount,
+      toolCallCount: run.toolCalls.length,
       durationMs: run.durationMs,
     };
   }
@@ -550,6 +554,8 @@ async function runOne(
     agentReport: run.agentReport,
     stoppedReason: run.stoppedReason,
     usage: run.usage,
+    turnCount: run.turnCount,
+    toolCallCount: run.toolCalls.length,
     durationMs: run.durationMs,
   };
 }

--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -375,7 +375,7 @@ async function runOne(
     agentReport: string;
     stoppedReason: string;
     usage?: AgentUsage;
-    turnCount?: number;
+    stepCount?: number;
     toolCallCount: number;
     durationMs: number;
   }
@@ -492,7 +492,7 @@ async function runOne(
       agentReport: run.agentReport,
       stoppedReason: run.stoppedReason,
       usage: run.usage,
-      turnCount: run.turnCount,
+      stepCount: run.stepCount,
       toolCallCount: run.toolCalls.length,
       durationMs: run.durationMs,
     };
@@ -554,7 +554,7 @@ async function runOne(
     agentReport: run.agentReport,
     stoppedReason: run.stoppedReason,
     usage: run.usage,
-    turnCount: run.turnCount,
+    stepCount: run.stepCount,
     toolCallCount: run.toolCalls.length,
     durationMs: run.durationMs,
   };

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -139,7 +139,7 @@ async function readResultFile(
     skills: parsedResult.skills,
     docs: parsedResult.docs,
     usage: parsedResult.usage,
-    turnCount: parsedResult.turnCount,
+    stepCount: parsedResult.stepCount,
     toolCallCount: parsedResult.toolCallCount,
     durationMs: parsedResult.durationMs,
     prompt: promptData?.prompt,

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -139,6 +139,8 @@ async function readResultFile(
     skills: parsedResult.skills,
     docs: parsedResult.docs,
     usage: parsedResult.usage,
+    turnCount: parsedResult.turnCount,
+    toolCallCount: parsedResult.toolCallCount,
     durationMs: parsedResult.durationMs,
     prompt: promptData?.prompt,
     promptSourcePath: promptData?.promptSourcePath,

--- a/apps/web/src/components/results/eval-details.tsx
+++ b/apps/web/src/components/results/eval-details.tsx
@@ -236,6 +236,12 @@ export function EvalDetails({ result }: { result: ParsedResult }) {
       {result.usage ? (
         <EvalMetadataRow label="Tokens" value={formatTokens(result.usage)} />
       ) : null}
+      {result.turnCount !== undefined ? (
+        <EvalMetadataRow label="Turns" value={result.turnCount} />
+      ) : null}
+      {result.toolCallCount !== undefined ? (
+        <EvalMetadataRow label="Tool calls" value={result.toolCallCount} />
+      ) : null}
       <EvalMetadataRow
         label="Source"
         value={<span className="break-all">{result.sourcePath}</span>}

--- a/apps/web/src/components/results/eval-details.tsx
+++ b/apps/web/src/components/results/eval-details.tsx
@@ -236,8 +236,8 @@ export function EvalDetails({ result }: { result: ParsedResult }) {
       {result.usage ? (
         <EvalMetadataRow label="Tokens" value={formatTokens(result.usage)} />
       ) : null}
-      {result.turnCount !== undefined ? (
-        <EvalMetadataRow label="Turns" value={result.turnCount} />
+      {result.stepCount !== undefined ? (
+        <EvalMetadataRow label="Steps" value={result.stepCount} />
       ) : null}
       {result.toolCallCount !== undefined ? (
         <EvalMetadataRow label="Tool calls" value={result.toolCallCount} />

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -13255,123 +13255,22 @@
     "docs": {
       "calls": []
     },
+    "usage": [
+      {
+        "model": "claude-sonnet-5",
+        "inputTokens": 387637,
+        "cacheReadInputTokens": 342153,
+        "cacheWriteInputTokens": 41790,
+        "outputTokens": 1886
+      }
+    ],
+    "turnCount": 12,
+    "toolCallCount": 11,
+    "durationMs": 82142,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-5",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-5",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "claude-code-sonnet-5",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "claude-code",
-      "modelProvider": "anthropic",
-      "modelId": "claude-sonnet-5",
-      "reasoningEffort": "high"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "claude-code-sonnet-5",
@@ -45967,6 +45866,98 @@
     "sourcePath": "codex-gpt-5.6-no-skills/resolve-security-002-rls-cross-tenant-leak/run-3/result.json"
   },
   {
+    "experiment": "codex-gpt-5.6-sol",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-sol",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/changelog.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            }
+          ]
+        },
+        {
+          "source": "shell_fetch",
+          "query": "/bin/bash -lc \"sed -n '1,240p' .claude/skills/supabase-postgres-best-practices/references/schema-data-types.md\nsed -n '1,240p' supabase/config.toml\nfind supabase/schemas -maxdepth 2 -type f -print -exec sed -n '1,240p' {} \\\\;\nsed -n '1,240p' supabase/migrations/20260101000000_create_products.sql\nsupabase --version\nsupabase migration new --help | sed -n '1,180p'\ncurl -fsSL https://supabase.com/changelog.md | rg -i -C 2 'breaking|migration|declarative|schema' | head -n 120\ncurl -fsSL https://supabase.com/docs/guides/local-development/declarative-database-schemas.md | sed -n '1,220p'\"",
+          "pages": [
+            {
+              "url": "https://supabase.com/changelog.md"
+            },
+            {
+              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas.md"
+            }
+          ],
+          "resultChars": 17428
+        }
+      ]
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-sol",
+        "inputTokens": 283265,
+        "cacheReadInputTokens": 239473,
+        "cacheWriteInputTokens": 43756,
+        "outputTokens": 1871
+      }
+    ],
+    "turnCount": 12,
+    "toolCallCount": 8,
+    "durationMs": 78244,
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 1,
+    "sourcePath": "codex-gpt-5.6-sol/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
     "experiment": "opencode-kimi-k3",
     "experimentSuite": "benchmark",
     "experimentDisplay": {
@@ -46694,122 +46685,22 @@
     "docs": {
       "calls": []
     },
+    "usage": [
+      {
+        "model": "moonshotai/kimi-k3",
+        "inputTokens": 189203,
+        "cacheReadInputTokens": 162304,
+        "cacheWriteInputTokens": 0,
+        "outputTokens": 2440
+      }
+    ],
+    "turnCount": 12,
+    "toolCallCount": 19,
+    "durationMs": 85772,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
-    "experiment": "opencode-kimi-k3",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "opencode",
-      "modelProvider": "moonshotai",
-      "modelId": "moonshotai/kimi-k3"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 2,
-    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-2/result.json"
-  },
-  {
-    "experiment": "opencode-kimi-k3",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "opencode",
-      "modelProvider": "moonshotai",
-      "modelId": "moonshotai/kimi-k3"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": []
-    },
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 3,
-    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "opencode-kimi-k3",

--- a/apps/web/src/data/eval-results.json
+++ b/apps/web/src/data/eval-results.json
@@ -13255,22 +13255,123 @@
     "docs": {
       "calls": []
     },
-    "usage": [
-      {
-        "model": "claude-sonnet-5",
-        "inputTokens": 387637,
-        "cacheReadInputTokens": 342153,
-        "cacheWriteInputTokens": 41790,
-        "outputTokens": 1886
-      }
-    ],
-    "turnCount": 12,
-    "toolCallCount": 11,
-    "durationMs": 82142,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "claude-code-sonnet-5",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "claude-code",
+      "modelProvider": "anthropic",
+      "modelId": "claude-sonnet-5",
+      "reasoningEffort": "high"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 3,
+    "sourcePath": "claude-code-sonnet-5/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "claude-code-sonnet-5",
@@ -45866,98 +45967,6 @@
     "sourcePath": "codex-gpt-5.6-no-skills/resolve-security-002-rls-cross-tenant-leak/run-3/result.json"
   },
   {
-    "experiment": "codex-gpt-5.6-sol",
-    "experimentSuite": "benchmark",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.6-sol",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-cli-002-declarative-schema",
-    "stage": "build",
-    "product": [
-      "database"
-    ],
-    "topic": [
-      "declarative-schema",
-      "migrations"
-    ],
-    "suite": "benchmark",
-    "interface": "cli",
-    "passed": true,
-    "checks": [
-      {
-        "name": "supabase db diff used to generate the migration",
-        "passed": true
-      },
-      {
-        "name": "schema file updated to include description column",
-        "passed": true
-      },
-      {
-        "name": "a new migration was generated for the change",
-        "passed": true
-      },
-      {
-        "name": "description column exists in the live database",
-        "passed": true
-      }
-    ],
-    "skills": {
-      "available": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ],
-      "loaded": [
-        "supabase",
-        "supabase-postgres-best-practices"
-      ]
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/changelog.md",
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            }
-          ]
-        },
-        {
-          "source": "shell_fetch",
-          "query": "/bin/bash -lc \"sed -n '1,240p' .claude/skills/supabase-postgres-best-practices/references/schema-data-types.md\nsed -n '1,240p' supabase/config.toml\nfind supabase/schemas -maxdepth 2 -type f -print -exec sed -n '1,240p' {} \\\\;\nsed -n '1,240p' supabase/migrations/20260101000000_create_products.sql\nsupabase --version\nsupabase migration new --help | sed -n '1,180p'\ncurl -fsSL https://supabase.com/changelog.md | rg -i -C 2 'breaking|migration|declarative|schema' | head -n 120\ncurl -fsSL https://supabase.com/docs/guides/local-development/declarative-database-schemas.md | sed -n '1,220p'\"",
-          "pages": [
-            {
-              "url": "https://supabase.com/changelog.md"
-            },
-            {
-              "url": "https://supabase.com/docs/guides/local-development/declarative-database-schemas.md"
-            }
-          ],
-          "resultChars": 17428
-        }
-      ]
-    },
-    "usage": [
-      {
-        "model": "gpt-5.6-sol",
-        "inputTokens": 283265,
-        "cacheReadInputTokens": 239473,
-        "cacheWriteInputTokens": 43756,
-        "outputTokens": 1871
-      }
-    ],
-    "turnCount": 12,
-    "toolCallCount": 8,
-    "durationMs": 78244,
-    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
-    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
-    "run": 1,
-    "sourcePath": "codex-gpt-5.6-sol/build-cli-002-declarative-schema/run-1/result.json"
-  },
-  {
     "experiment": "opencode-kimi-k3",
     "experimentSuite": "benchmark",
     "experimentDisplay": {
@@ -46685,22 +46694,122 @@
     "docs": {
       "calls": []
     },
-    "usage": [
-      {
-        "model": "moonshotai/kimi-k3",
-        "inputTokens": 189203,
-        "cacheReadInputTokens": 162304,
-        "cacheWriteInputTokens": 0,
-        "outputTokens": 2440
-      }
-    ],
-    "turnCount": 12,
-    "toolCallCount": 19,
-    "durationMs": 85772,
     "prompt": "Add a description text column to the `products` table in my local Supabase stack",
     "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
     "run": 1,
     "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-1/result.json"
+  },
+  {
+    "experiment": "opencode-kimi-k3",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "opencode",
+      "modelProvider": "moonshotai",
+      "modelId": "moonshotai/kimi-k3"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 2,
+    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-2/result.json"
+  },
+  {
+    "experiment": "opencode-kimi-k3",
+    "experimentSuite": "benchmark",
+    "experimentDisplay": {
+      "agent": "opencode",
+      "modelProvider": "moonshotai",
+      "modelId": "moonshotai/kimi-k3"
+    },
+    "eval": "build-cli-002-declarative-schema",
+    "stage": "build",
+    "product": [
+      "database"
+    ],
+    "topic": [
+      "declarative-schema",
+      "migrations"
+    ],
+    "suite": "benchmark",
+    "interface": "cli",
+    "passed": true,
+    "checks": [
+      {
+        "name": "supabase db diff used to generate the migration",
+        "passed": true
+      },
+      {
+        "name": "schema file updated to include description column",
+        "passed": true
+      },
+      {
+        "name": "a new migration was generated for the change",
+        "passed": true
+      },
+      {
+        "name": "description column exists in the live database",
+        "passed": true
+      }
+    ],
+    "skills": {
+      "available": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ],
+      "loaded": [
+        "supabase",
+        "supabase-postgres-best-practices"
+      ]
+    },
+    "docs": {
+      "calls": []
+    },
+    "prompt": "Add a description text column to the `products` table in my local Supabase stack",
+    "promptSourcePath": "evals/build-cli-002-declarative-schema/PROMPT.md",
+    "run": 3,
+    "sourcePath": "opencode-kimi-k3/build-cli-002-declarative-schema/run-3/result.json"
   },
   {
     "experiment": "opencode-kimi-k3",

--- a/packages/core/src/agents/claude-code/runner.test.ts
+++ b/packages/core/src/agents/claude-code/runner.test.ts
@@ -113,3 +113,12 @@ describe('claudeCodeRunner.extractUsage', () => {
     ).toBeUndefined();
   });
 });
+
+describe('claudeCodeRunner.extractTurnCount', () => {
+  const extract = claudeCodeRunner.extractTurnCount!;
+
+  it('reads num_turns off the result event', () => {
+    expect(extract(streamJson('success'))).toBe(3);
+    expect(extract(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/agents/claude-code/runner.test.ts
+++ b/packages/core/src/agents/claude-code/runner.test.ts
@@ -114,8 +114,8 @@ describe('claudeCodeRunner.extractUsage', () => {
   });
 });
 
-describe('claudeCodeRunner.extractTurnCount', () => {
-  const extract = claudeCodeRunner.extractTurnCount!;
+describe('claudeCodeRunner.extractStepCount', () => {
+  const extract = claudeCodeRunner.extractStepCount!;
 
   it('reads num_turns off the result event', () => {
     expect(extract(streamJson('success'))).toBe(3);

--- a/packages/core/src/agents/claude-code/runner.ts
+++ b/packages/core/src/agents/claude-code/runner.ts
@@ -106,6 +106,11 @@ export const claudeCodeRunner: AgentRunner<AnthropicModel> = {
     return processStopReason(command);
   },
 
+  extractTurnCount(raw) {
+    const n = lastResultEvent(raw)?.num_turns;
+    return typeof n === 'number' ? n : undefined;
+  },
+
   extractUsage(raw) {
     // `modelUsage` covers every model the run called, unlike the sibling
     // `usage` aggregate. Anthropic's input count excludes both cache buckets.

--- a/packages/core/src/agents/claude-code/runner.ts
+++ b/packages/core/src/agents/claude-code/runner.ts
@@ -106,7 +106,7 @@ export const claudeCodeRunner: AgentRunner<AnthropicModel> = {
     return processStopReason(command);
   },
 
-  extractTurnCount(raw) {
+  extractStepCount(raw) {
     const n = lastResultEvent(raw)?.num_turns;
     return typeof n === 'number' ? n : undefined;
   },

--- a/packages/core/src/agents/codex/runner.test.ts
+++ b/packages/core/src/agents/codex/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { codexRunner } from './runner.js';
+import { codexRunner, countModelResponses } from './runner.js';
 
 describe('codexRunner.extractUsage', () => {
   const extract = codexRunner.extractUsage!;
@@ -56,5 +56,23 @@ describe('codexRunner.extractUsage', () => {
     expect(
       extract(JSON.stringify({ type: 'turn.completed' }), 'gpt-5.6')
     ).toBeUndefined();
+  });
+});
+
+describe('countModelResponses', () => {
+  it('counts token_count events in a session rollout', () => {
+    const rollout = [
+      JSON.stringify({ type: 'session_meta', payload: {} }),
+      JSON.stringify({ type: 'event_msg', payload: { type: 'token_count' } }),
+      JSON.stringify({ type: 'response_item', payload: { type: 'reasoning' } }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: { type: 'custom_tool_call' },
+      }),
+      JSON.stringify({ type: 'event_msg', payload: { type: 'token_count' } }),
+      JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete' } }),
+    ].join('\n');
+    expect(countModelResponses(rollout)).toBe(2);
+    expect(countModelResponses('')).toBeUndefined();
   });
 });

--- a/packages/core/src/agents/codex/runner.ts
+++ b/packages/core/src/agents/codex/runner.ts
@@ -100,7 +100,16 @@ export const codexRunner: AgentRunner<CodexModel> = {
       `{ cat ${systemPromptPath}; printf '\\n\\n'; cat ${userPromptPath}; } | ${codex} ${flags}`,
       { timeoutMs: timeoutSec * 1000, env: { OPENAI_API_KEY: apiKey } }
     );
-    return { command, raw: command.stdout };
+    // The --json stream has no per-response boundary, but the session rollout
+    // Codex writes to disk logs one token_count event per model response.
+    const rollout = await sandbox.exec(
+      `cat "$(ls -t "$HOME"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1)"`
+    );
+    return {
+      command,
+      raw: command.stdout,
+      turnCount: countModelResponses(rollout.stdout),
+    };
   },
 
   deriveStopReason(raw, command) {
@@ -143,6 +152,18 @@ export const codexRunner: AgentRunner<CodexModel> = {
     return sawUsage ? [usage] : undefined;
   },
 };
+
+/** Model responses in a Codex session rollout, one `token_count` event each. */
+export function countModelResponses(rollout: string): number | undefined {
+  const { records } = parseJsonlRecords(rollout);
+  const n = records.filter(
+    (r) =>
+      r.type === 'event_msg' &&
+      isRecord(r.payload) &&
+      r.payload.type === 'token_count'
+  ).length;
+  return n || undefined;
+}
 
 /** The last turn-level outcome in a `codex exec --json` stream, if any. */
 function terminalOutcome(

--- a/packages/core/src/agents/codex/runner.ts
+++ b/packages/core/src/agents/codex/runner.ts
@@ -108,7 +108,7 @@ export const codexRunner: AgentRunner<CodexModel> = {
     return {
       command,
       raw: command.stdout,
-      turnCount: countModelResponses(rollout.stdout),
+      stepCount: countModelResponses(rollout.stdout),
     };
   },
 

--- a/packages/core/src/agents/engine.ts
+++ b/packages/core/src/agents/engine.ts
@@ -94,7 +94,7 @@ export function createCliAgent<M extends string = string>(
       await writeSandboxFile(sandbox, USER_PROMPT_PATH, args.userPrompt);
 
       const start = Date.now();
-      const { command, raw } = await runner.exec({
+      const { command, raw, turnCount } = await runner.exec({
         sandbox,
         model: options.model,
         apiKey,
@@ -137,6 +137,7 @@ export function createCliAgent<M extends string = string>(
         stoppedReason:
           runner.deriveStopReason?.(raw, command) ?? processStopReason(command),
         usage: runner.extractUsage?.(raw, options.model),
+        turnCount: turnCount ?? runner.extractTurnCount?.(raw),
         durationMs: Date.now() - start,
       };
     },

--- a/packages/core/src/agents/engine.ts
+++ b/packages/core/src/agents/engine.ts
@@ -94,7 +94,7 @@ export function createCliAgent<M extends string = string>(
       await writeSandboxFile(sandbox, USER_PROMPT_PATH, args.userPrompt);
 
       const start = Date.now();
-      const { command, raw, turnCount } = await runner.exec({
+      const { command, raw, stepCount } = await runner.exec({
         sandbox,
         model: options.model,
         apiKey,
@@ -133,11 +133,10 @@ export function createCliAgent<M extends string = string>(
         agentReport: adapted.agentReport,
         toolCalls: adapted.toolCalls,
         transcript: adapted.transcript,
-        steps: adapted.steps,
         stoppedReason:
           runner.deriveStopReason?.(raw, command) ?? processStopReason(command),
         usage: runner.extractUsage?.(raw, options.model),
-        turnCount: turnCount ?? runner.extractTurnCount?.(raw),
+        stepCount: stepCount ?? runner.extractStepCount?.(raw),
         durationMs: Date.now() - start,
       };
     },

--- a/packages/core/src/agents/opencode/runner.test.ts
+++ b/packages/core/src/agents/opencode/runner.test.ts
@@ -203,3 +203,13 @@ describe('opencode runner exec routing', () => {
     expect(runCommand).toContain('OPENCODE_CONFIG=');
   });
 });
+
+describe('opencode runner extractTurnCount', () => {
+  const extract = createOpencodeRunner('anthropic/claude-sonnet-5')
+    .extractTurnCount!;
+
+  it('counts step_finish records', () => {
+    expect(extract(SESSION)).toBe(2);
+    expect(extract(undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/agents/opencode/runner.test.ts
+++ b/packages/core/src/agents/opencode/runner.test.ts
@@ -204,9 +204,9 @@ describe('opencode runner exec routing', () => {
   });
 });
 
-describe('opencode runner extractTurnCount', () => {
+describe('opencode runner extractStepCount', () => {
   const extract = createOpencodeRunner('anthropic/claude-sonnet-5')
-    .extractTurnCount!;
+    .extractStepCount!;
 
   it('counts step_finish records', () => {
     expect(extract(SESSION)).toBe(2);

--- a/packages/core/src/agents/opencode/runner.ts
+++ b/packages/core/src/agents/opencode/runner.ts
@@ -186,6 +186,13 @@ export function createOpencodeRunner(
       return processStopReason(command);
     },
 
+    extractTurnCount(raw) {
+      if (!raw) return undefined;
+      const { records } = parseJsonlRecords(raw);
+      const turns = records.filter((r) => r.type === 'step_finish').length;
+      return turns || undefined;
+    },
+
     extractUsage(raw, model) {
       // opencode keeps cache out of `input` and reasoning out of `output`.
       // https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/acp/usage.ts

--- a/packages/core/src/agents/opencode/runner.ts
+++ b/packages/core/src/agents/opencode/runner.ts
@@ -186,7 +186,7 @@ export function createOpencodeRunner(
       return processStopReason(command);
     },
 
-    extractTurnCount(raw) {
+    extractStepCount(raw) {
       if (!raw) return undefined;
       const { records } = parseJsonlRecords(raw);
       const turns = records.filter((r) => r.type === 'step_finish').length;

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -74,6 +74,12 @@ export interface RunnerExecResult {
   command: CommandResult;
   /** Raw transcript (JSONL) — stdout for streaming CLIs, or read from disk. */
   raw?: string;
+  /**
+   * Model responses in the run, when the runner reads them from somewhere
+   * other than `raw` (Codex uses its session rollout). Worked example on
+   * `turnCount` in eval-metadata.ts.
+   */
+  turnCount?: number;
 }
 
 /** A CLI coding agent's execution strategy. `M` is its SDK model-id type. */
@@ -113,6 +119,11 @@ export interface AgentRunner<M extends string = string> {
    * configured model id, for harnesses that report one aggregate.
    */
   extractUsage?(raw: string | undefined, model: M): AgentUsage | undefined;
+  /**
+   * Model responses in the run, from `raw`. Worked example on `turnCount` in
+   * eval-metadata.ts.
+   */
+  extractTurnCount?(raw: string | undefined): number | undefined;
 }
 
 /**

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -76,10 +76,10 @@ export interface RunnerExecResult {
   raw?: string;
   /**
    * Model responses in the run, for runners that read them from somewhere
-   * other than `raw` (Codex uses its session rollout). See `turnCount` in
+   * other than `raw` (Codex uses its session rollout). See `stepCount` in
    * eval-metadata.ts for what counts as one.
    */
-  turnCount?: number;
+  stepCount?: number;
 }
 
 /** A CLI coding agent's execution strategy. `M` is its SDK model-id type. */
@@ -119,8 +119,8 @@ export interface AgentRunner<M extends string = string> {
    * configured model id, for harnesses that report one aggregate.
    */
   extractUsage?(raw: string | undefined, model: M): AgentUsage | undefined;
-  /** Model responses in the run. See `turnCount` in eval-metadata.ts for what counts as one. */
-  extractTurnCount?(raw: string | undefined): number | undefined;
+  /** Model responses in the run. See `stepCount` in eval-metadata.ts for what counts as one. */
+  extractStepCount?(raw: string | undefined): number | undefined;
 }
 
 /**

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -75,9 +75,9 @@ export interface RunnerExecResult {
   /** Raw transcript (JSONL) — stdout for streaming CLIs, or read from disk. */
   raw?: string;
   /**
-   * Model responses in the run, when the runner reads them from somewhere
-   * other than `raw` (Codex uses its session rollout). Worked example on
-   * `turnCount` in eval-metadata.ts.
+   * Model responses in the run, for runners that read them from somewhere
+   * other than `raw` (Codex uses its session rollout). See `turnCount` in
+   * eval-metadata.ts for what counts as one.
    */
   turnCount?: number;
 }
@@ -119,10 +119,7 @@ export interface AgentRunner<M extends string = string> {
    * configured model id, for harnesses that report one aggregate.
    */
   extractUsage?(raw: string | undefined, model: M): AgentUsage | undefined;
-  /**
-   * Model responses in the run, from `raw`. Worked example on `turnCount` in
-   * eval-metadata.ts.
-   */
+  /** Model responses in the run. See `turnCount` in eval-metadata.ts for what counts as one. */
   extractTurnCount?(raw: string | undefined): number | undefined;
 }
 

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -380,6 +380,11 @@ const evalResultShape = {
   skills: skillResultSchema.optional(),
   docs: docsResultSchema.optional(),
   usage: agentUsageSchema.optional(),
+  // One turn per model response, for example:
+  //   text → [Read, Read] → Edit → reasoning → text
+  //   turnCount 5, toolCallCount 3
+  turnCount: z.number().optional(),
+  toolCallCount: z.number().optional(),
   // Wall-clock time of the agent run only. Sandbox boot and scoring are excluded.
   durationMs: z.number().optional(),
 };

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -382,8 +382,8 @@ const evalResultShape = {
   usage: agentUsageSchema.optional(),
   // One turn per model response, for example:
   //   text → [Read, Read] → Edit → reasoning → text
-  //   turnCount 5, toolCallCount 3
-  turnCount: z.number().optional(),
+  //   stepCount 5, toolCallCount 3
+  stepCount: z.number().optional(),
   toolCallCount: z.number().optional(),
   // Wall-clock time of the agent run only. Sandbox boot and scoring are excluded.
   durationMs: z.number().optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -409,10 +409,9 @@ export type AgentRunResult = {
   agentReport: string;
   toolCalls: ToolCallRecord[];
   transcript: TranscriptPart[];
-  steps: number;
   stoppedReason: string;
   usage?: AgentUsage;
-  turnCount?: number;
+  stepCount?: number;
   durationMs: number;
 };
 
@@ -820,13 +819,12 @@ export function aiSdkAgent(options: {
           agentReport,
           toolCalls,
           transcript,
-          steps: result.steps.length,
           stoppedReason:
             result.steps.length >= MAX_STEPS
               ? 'max_steps'
               : result.finishReason,
           usage,
-          turnCount: result.steps.length,
+          stepCount: result.steps.length,
           durationMs: Date.now() - start,
         };
       } finally {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -412,6 +412,7 @@ export type AgentRunResult = {
   steps: number;
   stoppedReason: string;
   usage?: AgentUsage;
+  turnCount?: number;
   durationMs: number;
 };
 
@@ -825,6 +826,7 @@ export function aiSdkAgent(options: {
               ? 'max_steps'
               : result.finishReason,
           usage,
+          turnCount: result.steps.length,
           durationMs: Date.now() - start,
         };
       } finally {


### PR DESCRIPTION
Records `stepCount` and `toolCallCount` on each result next to `usage` and `durationMs`, so we can compare how many model round trips a harness needs to finish a task. One step is one model response, however many tool calls it carries. See discussion [thread](https://supabase.slack.com/archives/C051L8U2EJF/p1788982481976779?thread_ts=1788896625.684619&cid=C051L8U2EJF) for why these are tracked.

```jsonc
// result.json
{
  // ...,
  "stepCount": 13,
  "toolCallCount": 8,
  "durationMs": 60974
}
```

Where `stepCount` comes from:

- Claude Code: `num_turns` on the final `result` event
- OpenCode: number of `step_finish` records in the stream
- Codex: number of `token_count` events in the session rollout under `$CODEX_HOME/sessions`, since `exec --json` has no per-response boundary ([one per model response](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs))

`toolCallCount` is the length of the `toolCalls` list we already parse.

"Step" over "turn" because Codex uses turn for the [whole agent response to a prompt](https://github.com/openai/codex/blob/7c88f037d935b4e78311027c32da4f046fd84058/codex-rs/exec/src/exec_events.rs#L15-L21), while step is [the unit within it](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#multi-step-calls-using-stopwhen) in AI SDK and OpenCode.

Sanity checked one eval per harness via the refresh workflow, [snapshot here](https://github.com/supabase/evals/commit/f5fca37) (reverted to keep results out of this PR).

Closes AI-1199





