### PR TITLE
feat(evals): eval the Edge Function secrets guide in supabase.com/docs

### DIFF
--- a/apps/web/src/data/docs-eval-results.json
+++ b/apps/web/src/data/docs-eval-results.json
@@ -45,12 +45,12 @@
       {
         "name": "the provider key sits where the local function runtime loads it",
         "passed": false,
-        "notes": "credential set only in supabase/functions/.env.example, which supabase/functions/.env does not cover and no --env-file points at"
+        "notes": "the function reads OPENAI_API_KEY, and no env file sets it"
       },
       {
         "name": "the file holding the provider key is covered by the project's ignore rules",
         "passed": false,
-        "notes": "the credential is only in a template file, so nothing real was placed"
+        "notes": "not run because no credential was placed in an env file"
       },
       {
         "name": "the local stack serves the suggest endpoint",
@@ -101,135 +101,19 @@
     "usage": [
       {
         "model": "gpt-5.6-luna",
-        "inputTokens": 597623,
-        "cacheReadInputTokens": 530683,
-        "cacheWriteInputTokens": 66892,
-        "outputTokens": 5349
+        "inputTokens": 729132,
+        "cacheReadInputTokens": 678365,
+        "cacheWriteInputTokens": 50692,
+        "outputTokens": 5438
       }
     ],
-    "stepCount": 16,
-    "toolCallCount": 17,
-    "durationMs": 153982,
+    "stepCount": 25,
+    "toolCallCount": 14,
+    "durationMs": 169981,
     "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
     "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
     "run": 1,
     "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-1/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.6-luna-no-skills",
-    "experimentSuite": "docs",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.6-luna",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-docs-007-edge-function-secrets",
-    "stage": "build",
-    "product": [
-      "edge-functions"
-    ],
-    "topic": [
-      "security",
-      "sdk"
-    ],
-    "suite": "docs",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "the client bundle builds",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from the built client bundle",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from the client project's env files",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from every client source file",
-        "passed": true
-      },
-      {
-        "name": "every function reads the provider key from the environment",
-        "passed": true,
-        "notes": "reads OPENAI_API_KEY"
-      },
-      {
-        "name": "the provider key sits where the local function runtime loads it",
-        "passed": false,
-        "notes": "credential set only in supabase/functions/.env.example, which supabase/functions/.env does not cover and no --env-file points at"
-      },
-      {
-        "name": "the file holding the provider key is covered by the project's ignore rules",
-        "passed": false,
-        "notes": "the credential is only in a template file, so nothing real was placed"
-      },
-      {
-        "name": "the local stack serves the suggest endpoint",
-        "passed": true,
-        "notes": "status 503"
-      },
-      {
-        "name": "the suggest endpoint has the provider key at request time",
-        "passed": false,
-        "notes": "answered missing_api_key, so the runtime handed the function no credential: {\"error\":\"missing_api_key\"}"
-      },
-      {
-        "name": "the suggest response does not echo the provider key",
-        "passed": true
-      },
-      {
-        "name": "the agent read the Managing secrets guide the prompt referenced",
-        "passed": false,
-        "notes": "reached the guide via web_search, web_search but retrieved no page content"
-      }
-    ],
-    "skills": {
-      "available": [],
-      "loaded": []
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/functions/secrets.md",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets.md"
-            }
-          ]
-        },
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/functions/secrets",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets"
-            }
-          ]
-        }
-      ]
-    },
-    "usage": [
-      {
-        "model": "gpt-5.6-luna",
-        "inputTokens": 592098,
-        "cacheReadInputTokens": 548138,
-        "cacheWriteInputTokens": 43888,
-        "outputTokens": 5933
-      }
-    ],
-    "stepCount": 24,
-    "toolCallCount": 18,
-    "durationMs": 166710,
-    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
-    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
-    "run": 2,
-    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-2/result.json"
   },
   {
     "experiment": "codex-gpt-5.6-luna-no-skills",
@@ -301,7 +185,104 @@
       {
         "name": "the agent read the Managing secrets guide the prompt referenced",
         "passed": false,
-        "notes": "reached the guide via web_search, web_search but retrieved no page content"
+        "notes": "no docs call reached the guide"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": []
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-luna",
+        "inputTokens": 880705,
+        "cacheReadInputTokens": 812185,
+        "cacheWriteInputTokens": 68457,
+        "outputTokens": 7215
+      }
+    ],
+    "stepCount": 21,
+    "toolCallCount": 21,
+    "durationMs": 185656,
+    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
+    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
+    "run": 2,
+    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-2/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6-luna-no-skills",
+    "experimentSuite": "docs",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-luna",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-docs-007-edge-function-secrets",
+    "stage": "build",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "docs",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "the client bundle builds",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the built client bundle",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the client project's env files",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from every client source file",
+        "passed": true
+      },
+      {
+        "name": "every function reads the provider key from the environment",
+        "passed": true,
+        "notes": "reads OPENAI_API_KEY"
+      },
+      {
+        "name": "the provider key sits where the local function runtime loads it",
+        "passed": true,
+        "notes": "loaded from supabase/functions/.env"
+      },
+      {
+        "name": "the file holding the provider key is covered by the project's ignore rules",
+        "passed": true,
+        "notes": "ignored: supabase/functions/.env"
+      },
+      {
+        "name": "the local stack serves the suggest endpoint",
+        "passed": true,
+        "notes": "status 502"
+      },
+      {
+        "name": "the suggest endpoint has the provider key at request time",
+        "passed": true,
+        "notes": "status 502: {\"error\":\"provider_error\"}"
+      },
+      {
+        "name": "the suggest response does not echo the provider key",
+        "passed": true
+      },
+      {
+        "name": "the agent read the Managing secrets guide the prompt referenced",
+        "passed": false,
+        "notes": "reached the guide via web_search but retrieved no page content"
       }
     ],
     "skills": {
@@ -310,15 +291,6 @@
     },
     "docs": {
       "calls": [
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/functions/secrets.md",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets.md"
-            }
-          ]
-        },
         {
           "source": "web_search",
           "query": "https://supabase.com/docs/guides/functions/secrets",
@@ -333,15 +305,15 @@
     "usage": [
       {
         "model": "gpt-5.6-luna",
-        "inputTokens": 1134310,
-        "cacheReadInputTokens": 1062870,
-        "cacheWriteInputTokens": 71353,
-        "outputTokens": 6529
+        "inputTokens": 1810549,
+        "cacheReadInputTokens": 1703324,
+        "cacheWriteInputTokens": 107135,
+        "outputTokens": 5858
       }
     ],
-    "stepCount": 29,
-    "toolCallCount": 18,
-    "durationMs": 156103,
+    "stepCount": 30,
+    "toolCallCount": 17,
+    "durationMs": 205252,
     "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
     "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
     "run": 3,

--- a/apps/web/src/data/docs-eval-results.json
+++ b/apps/web/src/data/docs-eval-results.json
@@ -1,0 +1,339 @@
+[
+  {
+    "experiment": "codex-gpt-5.6-luna-no-skills",
+    "experimentSuite": "docs",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-luna",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-docs-007-edge-function-secrets",
+    "stage": "build",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "docs",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "the client bundle builds",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the built client bundle",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the client project's env files",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from every client source file",
+        "passed": true
+      },
+      {
+        "name": "every function reads the provider key from the environment",
+        "passed": true
+      },
+      {
+        "name": "the provider key sits where the local function runtime loads it",
+        "passed": false,
+        "notes": "the seeded provider key is not in any file in the workspace"
+      },
+      {
+        "name": "the file holding the provider key is covered by the project's ignore rules",
+        "passed": false,
+        "notes": "not run because the seeded provider key is not in any file"
+      },
+      {
+        "name": "the local stack serves the suggest endpoint",
+        "passed": true,
+        "notes": "status 200"
+      },
+      {
+        "name": "the suggest endpoint has the provider key at request time",
+        "passed": true,
+        "notes": "status 200: {\"suggestion\":\"The Eval-Mtxiwc70 appears to be a specific model of stainless steel kettle. Unfortunately, detailed information about this specific model might be limited. However, I can provide a gene"
+      },
+      {
+        "name": "the suggest response does not echo the provider key",
+        "passed": true
+      },
+      {
+        "name": "the agent read the Managing secrets guide the prompt referenced",
+        "passed": false,
+        "notes": "reached the guide via shell_fetch but retrieved no page content"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "shell_fetch",
+          "query": "/bin/bash -lc \"curl -L --fail --silent --show-error https://supabase.com/docs/guides/functions/secrets.md | sed -n '1,260p'\nprintf '\\\\n--- package.json ---\\\\n'\nsed -n '1,220p' package.json\nprintf '\\\\n--- src/App.tsx ---\\\\n'\nsed -n '1,280p' src/App.tsx\nprintf '\\\\n--- supabase/config.toml ---\\\\n'\nsed -n '1,220p' supabase/config.toml\nprintf '\\\\n--- vite.config.ts ---\\\\n'\nsed -n '1,180p' vite.config.ts\"",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets.md"
+            }
+          ],
+          "resultChars": 11144
+        }
+      ]
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-luna",
+        "inputTokens": 1268241,
+        "cacheReadInputTokens": 1206315,
+        "cacheWriteInputTokens": 61818,
+        "outputTokens": 7600
+      }
+    ],
+    "stepCount": 36,
+    "toolCallCount": 22,
+    "durationMs": 216292,
+    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
+    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
+    "run": 1,
+    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-1/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6-luna-no-skills",
+    "experimentSuite": "docs",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-luna",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-docs-007-edge-function-secrets",
+    "stage": "build",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "docs",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "the client bundle builds",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the built client bundle",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the client project's env files",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from every client source file",
+        "passed": true
+      },
+      {
+        "name": "every function reads the provider key from the environment",
+        "passed": true
+      },
+      {
+        "name": "the provider key sits where the local function runtime loads it",
+        "passed": false,
+        "notes": "the seeded provider key is not in any file in the workspace"
+      },
+      {
+        "name": "the file holding the provider key is covered by the project's ignore rules",
+        "passed": false,
+        "notes": "not run because the seeded provider key is not in any file"
+      },
+      {
+        "name": "the local stack serves the suggest endpoint",
+        "passed": true,
+        "notes": "status 200"
+      },
+      {
+        "name": "the suggest endpoint has the provider key at request time",
+        "passed": true,
+        "notes": "status 200: {\"suggestion\":\"The Eval-Mtxiv55f appears to refer to a specific model of a stainless steel kettle. However, there are no widely recognized products by that exact name in my training data, which goes u"
+      },
+      {
+        "name": "the suggest response does not echo the provider key",
+        "passed": true
+      },
+      {
+        "name": "the agent read the Managing secrets guide the prompt referenced",
+        "passed": false,
+        "notes": "reached the guide via web_search, web_search but retrieved no page content"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets"
+            }
+          ]
+        }
+      ]
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-luna",
+        "inputTokens": 1056248,
+        "cacheReadInputTokens": 1021175,
+        "cacheWriteInputTokens": 34953,
+        "outputTokens": 7514
+      }
+    ],
+    "stepCount": 40,
+    "toolCallCount": 20,
+    "durationMs": 169735,
+    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
+    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
+    "run": 2,
+    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-2/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6-luna-no-skills",
+    "experimentSuite": "docs",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-luna",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-docs-007-edge-function-secrets",
+    "stage": "build",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "docs",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "the client bundle builds",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the built client bundle",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the client project's env files",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from every client source file",
+        "passed": true
+      },
+      {
+        "name": "every function reads the provider key from the environment",
+        "passed": true
+      },
+      {
+        "name": "the provider key sits where the local function runtime loads it",
+        "passed": false,
+        "notes": "the seeded provider key is not in any file in the workspace"
+      },
+      {
+        "name": "the file holding the provider key is covered by the project's ignore rules",
+        "passed": false,
+        "notes": "not run because the seeded provider key is not in any file"
+      },
+      {
+        "name": "the local stack serves the suggest endpoint",
+        "passed": true,
+        "notes": "status 503"
+      },
+      {
+        "name": "the suggest endpoint has the provider key at request time",
+        "passed": false,
+        "notes": "answered missing_api_key, so the runtime handed the function no credential: {\"error\":\"missing_api_key\"}"
+      },
+      {
+        "name": "the suggest response does not echo the provider key",
+        "passed": true
+      },
+      {
+        "name": "the agent read the Managing secrets guide the prompt referenced",
+        "passed": false,
+        "notes": "reached the guide via web_search, web_search but retrieved no page content"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets"
+            }
+          ]
+        }
+      ]
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-luna",
+        "inputTokens": 595023,
+        "cacheReadInputTokens": 538254,
+        "cacheWriteInputTokens": 56706,
+        "outputTokens": 6798
+      }
+    ],
+    "stepCount": 21,
+    "toolCallCount": 14,
+    "durationMs": 158451,
+    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
+    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
+    "run": 3,
+    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-3/result.json"
+  }
+]

--- a/apps/web/src/data/docs-eval-results.json
+++ b/apps/web/src/data/docs-eval-results.json
@@ -39,239 +39,18 @@
       },
       {
         "name": "every function reads the provider key from the environment",
-        "passed": true
+        "passed": true,
+        "notes": "reads OPENAI_API_KEY"
       },
       {
         "name": "the provider key sits where the local function runtime loads it",
         "passed": false,
-        "notes": "the seeded provider key is not in any file in the workspace"
+        "notes": "credential set only in supabase/functions/.env.example, which supabase/functions/.env does not cover and no --env-file points at"
       },
       {
         "name": "the file holding the provider key is covered by the project's ignore rules",
         "passed": false,
-        "notes": "not run because the seeded provider key is not in any file"
-      },
-      {
-        "name": "the local stack serves the suggest endpoint",
-        "passed": true,
-        "notes": "status 200"
-      },
-      {
-        "name": "the suggest endpoint has the provider key at request time",
-        "passed": true,
-        "notes": "status 200: {\"suggestion\":\"The Eval-Mtxiwc70 appears to be a specific model of stainless steel kettle. Unfortunately, detailed information about this specific model might be limited. However, I can provide a gene"
-      },
-      {
-        "name": "the suggest response does not echo the provider key",
-        "passed": true
-      },
-      {
-        "name": "the agent read the Managing secrets guide the prompt referenced",
-        "passed": false,
-        "notes": "reached the guide via shell_fetch but retrieved no page content"
-      }
-    ],
-    "skills": {
-      "available": [],
-      "loaded": []
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "shell_fetch",
-          "query": "/bin/bash -lc \"curl -L --fail --silent --show-error https://supabase.com/docs/guides/functions/secrets.md | sed -n '1,260p'\nprintf '\\\\n--- package.json ---\\\\n'\nsed -n '1,220p' package.json\nprintf '\\\\n--- src/App.tsx ---\\\\n'\nsed -n '1,280p' src/App.tsx\nprintf '\\\\n--- supabase/config.toml ---\\\\n'\nsed -n '1,220p' supabase/config.toml\nprintf '\\\\n--- vite.config.ts ---\\\\n'\nsed -n '1,180p' vite.config.ts\"",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets.md"
-            }
-          ],
-          "resultChars": 11144
-        }
-      ]
-    },
-    "usage": [
-      {
-        "model": "gpt-5.6-luna",
-        "inputTokens": 1268241,
-        "cacheReadInputTokens": 1206315,
-        "cacheWriteInputTokens": 61818,
-        "outputTokens": 7600
-      }
-    ],
-    "stepCount": 36,
-    "toolCallCount": 22,
-    "durationMs": 216292,
-    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
-    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
-    "run": 1,
-    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-1/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.6-luna-no-skills",
-    "experimentSuite": "docs",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.6-luna",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-docs-007-edge-function-secrets",
-    "stage": "build",
-    "product": [
-      "edge-functions"
-    ],
-    "topic": [
-      "security",
-      "sdk"
-    ],
-    "suite": "docs",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "the client bundle builds",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from the built client bundle",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from the client project's env files",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from every client source file",
-        "passed": true
-      },
-      {
-        "name": "every function reads the provider key from the environment",
-        "passed": true
-      },
-      {
-        "name": "the provider key sits where the local function runtime loads it",
-        "passed": false,
-        "notes": "the seeded provider key is not in any file in the workspace"
-      },
-      {
-        "name": "the file holding the provider key is covered by the project's ignore rules",
-        "passed": false,
-        "notes": "not run because the seeded provider key is not in any file"
-      },
-      {
-        "name": "the local stack serves the suggest endpoint",
-        "passed": true,
-        "notes": "status 200"
-      },
-      {
-        "name": "the suggest endpoint has the provider key at request time",
-        "passed": true,
-        "notes": "status 200: {\"suggestion\":\"The Eval-Mtxiv55f appears to refer to a specific model of a stainless steel kettle. However, there are no widely recognized products by that exact name in my training data, which goes u"
-      },
-      {
-        "name": "the suggest response does not echo the provider key",
-        "passed": true
-      },
-      {
-        "name": "the agent read the Managing secrets guide the prompt referenced",
-        "passed": false,
-        "notes": "reached the guide via web_search, web_search but retrieved no page content"
-      }
-    ],
-    "skills": {
-      "available": [],
-      "loaded": []
-    },
-    "docs": {
-      "calls": [
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/functions/secrets.md",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets.md"
-            }
-          ]
-        },
-        {
-          "source": "web_search",
-          "query": "https://supabase.com/docs/guides/functions/secrets",
-          "pages": [
-            {
-              "url": "https://supabase.com/docs/guides/functions/secrets"
-            }
-          ]
-        }
-      ]
-    },
-    "usage": [
-      {
-        "model": "gpt-5.6-luna",
-        "inputTokens": 1056248,
-        "cacheReadInputTokens": 1021175,
-        "cacheWriteInputTokens": 34953,
-        "outputTokens": 7514
-      }
-    ],
-    "stepCount": 40,
-    "toolCallCount": 20,
-    "durationMs": 169735,
-    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
-    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
-    "run": 2,
-    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-2/result.json"
-  },
-  {
-    "experiment": "codex-gpt-5.6-luna-no-skills",
-    "experimentSuite": "docs",
-    "experimentDisplay": {
-      "agent": "codex",
-      "modelProvider": "openai",
-      "modelId": "gpt-5.6-luna",
-      "reasoningEffort": "medium"
-    },
-    "eval": "build-docs-007-edge-function-secrets",
-    "stage": "build",
-    "product": [
-      "edge-functions"
-    ],
-    "topic": [
-      "security",
-      "sdk"
-    ],
-    "suite": "docs",
-    "interface": "cli",
-    "passed": false,
-    "checks": [
-      {
-        "name": "the client bundle builds",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from the built client bundle",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from the client project's env files",
-        "passed": true
-      },
-      {
-        "name": "the provider key is absent from every client source file",
-        "passed": true
-      },
-      {
-        "name": "every function reads the provider key from the environment",
-        "passed": true
-      },
-      {
-        "name": "the provider key sits where the local function runtime loads it",
-        "passed": false,
-        "notes": "the seeded provider key is not in any file in the workspace"
-      },
-      {
-        "name": "the file holding the provider key is covered by the project's ignore rules",
-        "passed": false,
-        "notes": "not run because the seeded provider key is not in any file"
+        "notes": "the credential is only in a template file, so nothing real was placed"
       },
       {
         "name": "the local stack serves the suggest endpoint",
@@ -322,15 +101,247 @@
     "usage": [
       {
         "model": "gpt-5.6-luna",
-        "inputTokens": 595023,
-        "cacheReadInputTokens": 538254,
-        "cacheWriteInputTokens": 56706,
-        "outputTokens": 6798
+        "inputTokens": 597623,
+        "cacheReadInputTokens": 530683,
+        "cacheWriteInputTokens": 66892,
+        "outputTokens": 5349
       }
     ],
-    "stepCount": 21,
-    "toolCallCount": 14,
-    "durationMs": 158451,
+    "stepCount": 16,
+    "toolCallCount": 17,
+    "durationMs": 153982,
+    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
+    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
+    "run": 1,
+    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-1/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6-luna-no-skills",
+    "experimentSuite": "docs",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-luna",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-docs-007-edge-function-secrets",
+    "stage": "build",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "docs",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "the client bundle builds",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the built client bundle",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the client project's env files",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from every client source file",
+        "passed": true
+      },
+      {
+        "name": "every function reads the provider key from the environment",
+        "passed": true,
+        "notes": "reads OPENAI_API_KEY"
+      },
+      {
+        "name": "the provider key sits where the local function runtime loads it",
+        "passed": false,
+        "notes": "credential set only in supabase/functions/.env.example, which supabase/functions/.env does not cover and no --env-file points at"
+      },
+      {
+        "name": "the file holding the provider key is covered by the project's ignore rules",
+        "passed": false,
+        "notes": "the credential is only in a template file, so nothing real was placed"
+      },
+      {
+        "name": "the local stack serves the suggest endpoint",
+        "passed": true,
+        "notes": "status 503"
+      },
+      {
+        "name": "the suggest endpoint has the provider key at request time",
+        "passed": false,
+        "notes": "answered missing_api_key, so the runtime handed the function no credential: {\"error\":\"missing_api_key\"}"
+      },
+      {
+        "name": "the suggest response does not echo the provider key",
+        "passed": true
+      },
+      {
+        "name": "the agent read the Managing secrets guide the prompt referenced",
+        "passed": false,
+        "notes": "reached the guide via web_search, web_search but retrieved no page content"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets"
+            }
+          ]
+        }
+      ]
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-luna",
+        "inputTokens": 592098,
+        "cacheReadInputTokens": 548138,
+        "cacheWriteInputTokens": 43888,
+        "outputTokens": 5933
+      }
+    ],
+    "stepCount": 24,
+    "toolCallCount": 18,
+    "durationMs": 166710,
+    "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
+    "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
+    "run": 2,
+    "sourcePath": "codex-gpt-5.6-luna-no-skills/build-docs-007-edge-function-secrets/run-2/result.json"
+  },
+  {
+    "experiment": "codex-gpt-5.6-luna-no-skills",
+    "experimentSuite": "docs",
+    "experimentDisplay": {
+      "agent": "codex",
+      "modelProvider": "openai",
+      "modelId": "gpt-5.6-luna",
+      "reasoningEffort": "medium"
+    },
+    "eval": "build-docs-007-edge-function-secrets",
+    "stage": "build",
+    "product": [
+      "edge-functions"
+    ],
+    "topic": [
+      "security",
+      "sdk"
+    ],
+    "suite": "docs",
+    "interface": "cli",
+    "passed": false,
+    "checks": [
+      {
+        "name": "the client bundle builds",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the built client bundle",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from the client project's env files",
+        "passed": true
+      },
+      {
+        "name": "the provider key is absent from every client source file",
+        "passed": true
+      },
+      {
+        "name": "every function reads the provider key from the environment",
+        "passed": true,
+        "notes": "reads OPENAI_API_KEY"
+      },
+      {
+        "name": "the provider key sits where the local function runtime loads it",
+        "passed": false,
+        "notes": "the function reads OPENAI_API_KEY, and no env file sets it"
+      },
+      {
+        "name": "the file holding the provider key is covered by the project's ignore rules",
+        "passed": false,
+        "notes": "not run because no credential was placed in an env file"
+      },
+      {
+        "name": "the local stack serves the suggest endpoint",
+        "passed": true,
+        "notes": "status 503"
+      },
+      {
+        "name": "the suggest endpoint has the provider key at request time",
+        "passed": false,
+        "notes": "answered missing_api_key, so the runtime handed the function no credential: {\"error\":\"missing_api_key\"}"
+      },
+      {
+        "name": "the suggest response does not echo the provider key",
+        "passed": true
+      },
+      {
+        "name": "the agent read the Managing secrets guide the prompt referenced",
+        "passed": false,
+        "notes": "reached the guide via web_search, web_search but retrieved no page content"
+      }
+    ],
+    "skills": {
+      "available": [],
+      "loaded": []
+    },
+    "docs": {
+      "calls": [
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets.md",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets.md"
+            }
+          ]
+        },
+        {
+          "source": "web_search",
+          "query": "https://supabase.com/docs/guides/functions/secrets",
+          "pages": [
+            {
+              "url": "https://supabase.com/docs/guides/functions/secrets"
+            }
+          ]
+        }
+      ]
+    },
+    "usage": [
+      {
+        "model": "gpt-5.6-luna",
+        "inputTokens": 1134310,
+        "cacheReadInputTokens": 1062870,
+        "cacheWriteInputTokens": 71353,
+        "outputTokens": 6529
+      }
+    ],
+    "stepCount": 29,
+    "toolCallCount": 18,
+    "durationMs": 156103,
     "prompt": "My app calls the OpenAI API to write copy suggestions. The key is sitting in a\nReact component right now, which I'm told is a problem. Sort that out.\n\nThen get the local stack running so the app works end to end when I run it.\n\nRead the guide below before you start and rely on it for how to set this up,\nrather than on what you already know.\n\nREFERENCE\nhttps://supabase.com/docs/guides/functions/secrets.md",
     "promptSourcePath": "evals/docs/build-docs-007-edge-function-secrets/PROMPT.md",
     "run": 3,

--- a/evals/docs/build-docs-007-edge-function-secrets/EVAL.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/EVAL.ts
@@ -1,0 +1,76 @@
+import {
+  buildDocsResult,
+  type CheckResult,
+  type LocalStackEvalContext,
+  type LocalStackScorer,
+} from '@supabase-evals/core';
+
+import { checkClient } from './client.js';
+import { checkProbes } from './probes.js';
+import { checkSecret } from './secret.js';
+
+const GUIDE_PATH = 'guides/functions/secrets';
+
+const scorer: LocalStackScorer = async (ctx) => {
+  try {
+    // Scoped to the run, so nothing a previous run left behind can satisfy a
+    // probe in this one.
+    const marker = `eval-${Date.now().toString(36)}`;
+
+    // Static first. The client build writes dist/, and the probe wakes a
+    // function that may write files of its own, so neither should be in scope
+    // when the workspace is read for the key.
+    const secret = await checkSecret(ctx);
+    const client = await checkClient(ctx);
+    const probes = await checkProbes(ctx, marker);
+
+    const checks: CheckResult[] = [
+      client.build,
+      client.notInBundle,
+      client.noExposedEnvVar,
+      client.notInSource,
+      secret.readsFromEnv,
+      secret.loadablePath,
+      secret.ignored,
+      probes.served,
+      probes.keyAtRuntime,
+      probes.noEcho,
+      checkGuideWasRead(ctx),
+    ];
+
+    return { passed: checks.every((check) => check.passed), checks };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      passed: false,
+      checks: [
+        {
+          name: 'scorer evaluated provider key placement',
+          passed: false,
+          notes: message,
+        },
+      ],
+    };
+  }
+};
+
+export default scorer;
+
+// A search_docs hit carries the guide's url in its result, not its request, so
+// reuse the harness's own resolution rather than scanning the raw tool call.
+function checkGuideWasRead(ctx: LocalStackEvalContext): CheckResult {
+  const calls = buildDocsResult(ctx.toolCalls).calls.filter((call) =>
+    call.pages?.some((page) => page.url.includes(GUIDE_PATH))
+  );
+  const withContent = calls.filter((call) => call.hasContent);
+  return {
+    name: 'the agent read the Managing secrets guide the prompt referenced',
+    passed: withContent.length > 0,
+    notes:
+      withContent.length > 0
+        ? withContent.map((call) => call.source).join(', ')
+        : calls.length > 0
+          ? `reached the guide via ${calls.map((call) => call.source).join(', ')} but retrieved no page content`
+          : 'no docs call reached the guide',
+  };
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/PROMPT.md
+++ b/evals/docs/build-docs-007-edge-function-secrets/PROMPT.md
@@ -1,0 +1,37 @@
+---
+stage: build
+interface: cli
+product:
+  - edge-functions
+topic:
+  - security
+  - sdk
+services:
+  - kong
+  - edge-runtime
+projectRunning: false
+motivation: >-
+  the Managing secrets guide is the page agents are pointed at to move a
+  provider credential out of client code, and it is the only place that says
+  where a local secret has to sit for the function runtime to load it. Neither
+  the Supabase agent skill nor Supacademy covers the topic, so the page is the
+  only carrier. Users keep landing on the wrong file: FDBKIN-11884 and CLI-818
+  both ask for the project-root .env and supabase/functions/.env to be told
+  apart, FDBKIN-7937 asks for a documented path for local env vars, and
+  FDBKIN-12716 and FDBKIN-6831 are the recurring "I set it and the function
+  cannot read it" shape. The page draws 17,405 views over 90 days at 35.3
+  percent negative, with 18,085 agent requests at 17.7 percent agent share.
+  The prompt deliberately omits the vocabulary the page teaches, so read
+  README.md before editing it. See DOCS-1305.
+---
+
+My app calls the OpenAI API to write copy suggestions. The key is sitting in a
+React component right now, which I'm told is a problem. Sort that out.
+
+Then get the local stack running so the app works end to end when I run it.
+
+Read the guide below before you start and rely on it for how to set this up,
+rather than on what you already know.
+
+REFERENCE
+https://supabase.com/docs/guides/functions/secrets.md

--- a/evals/docs/build-docs-007-edge-function-secrets/README.md
+++ b/evals/docs/build-docs-007-edge-function-secrets/README.md
@@ -54,6 +54,16 @@ The bundle scan reads the artifact Vite emitted rather than the source that prod
 whitelists the default path plus any path a `--env-file` argument points at, rather than blocklisting the places that
 do not work. Its behavioral counterpart is the request-time check.
 
+**It tracks the name the function reads, not the value the seed shipped.** The first baseline is why. Agents replace
+the placeholder with a credential of their own, so a check hunting the seeded literal reports "not in any file" on a
+solution that placed a working credential correctly. What has to be true is that whatever env name the function reads
+is set in a file the runtime loads. Platform names are excluded, because `SUPABASE_*`, `SB_*` and `DENO_*` are what
+`supabase start` injects on its own and none of them is the credential this eval is about.
+
+`the file holding the provider key is covered by the project's ignore rules` carves out `.env.example` and its
+siblings. Shipping a template with a placeholder is the documented habit, and failing a solution for it would be a
+false red.
+
 ## The guide has to actually be read
 
 The last check resolves the guide through the harness's own docs result, because a `search_docs` hit carries the url in
@@ -85,3 +95,9 @@ alone, the check is harsher than intended and this section is where to say so.
 
 An agent that answers `missing_api_key` for any error, including the upstream call failing, also fails that check. The
 seed's contract is specific about which condition it covers.
+
+**A working provider credential is reachable from inside the sandbox.** `packages/core/src/agents/codex/runner.ts`
+logs the agent in with a live `OPENAI_API_KEY`, so an agent can place a credential that really works without ever
+handling the seeded one, and the request-time check passes on a genuine upstream completion. That does not break the
+claim, because placement is what is scored and the checks no longer care which value was placed. It does mean a
+passing run can be making real provider calls, and it is why the placement checks are written against the name.

--- a/evals/docs/build-docs-007-edge-function-secrets/README.md
+++ b/evals/docs/build-docs-007-edge-function-secrets/README.md
@@ -1,0 +1,87 @@
+# build-docs-007-edge-function-secrets
+
+## What this eval measures
+
+The subject is [Managing secrets](https://supabase.com/docs/guides/functions/secrets), not the agent. The prompt is a
+product request plus the page's url, and the checks say whether an agent that read the page produced working code. A
+gap in the page counts as a failure here.
+
+One claim: a key that ships in browser code has to move somewhere only the function runtime can read, and it has to
+land where the local runtime actually loads it.
+
+## Do not reintroduce the vocabulary
+
+The prompt names the runtime and the task. It never names the mechanism, because whether the page transmits the
+mechanism is the measurement. Keep all of these out of `PROMPT.md`:
+
+secret, secrets, environment variable, env var, `.env`, `supabase/functions/.env`, `--env-file`, `Deno.env`,
+`supabase secrets set`, Edge Function, server-side, backend, gitignore, proxy, `VITE_`, publishable, service role,
+key management.
+
+The seed may carry product vocabulary the user would already have in front of them. The line is the prompt.
+
+## The seed carries the contract
+
+`local/src/App.tsx` holds the provider key as a literal and calls the provider straight from the browser. Its TODO
+comment fixes three things the checks depend on:
+
+- **The endpoint.** `POST /functions/v1/suggest`, taking `{ prompt }` and answering `{ suggestion }`. Without it the
+  scorer has no address to probe, and the prompt would have to name the runtime instead.
+- **The failure contract.** A 503 carrying `missing_api_key` when the credential is not reachable at request time.
+  This is what lets the probe tell "the runtime handed the function the key" from "the function ran and read nothing".
+  It buys a positive control the scorer can prove, at the cost of a discovery question, and that trade is deliberate.
+- **The framing.** Written as the on-call rotation's requirement, so it reads as a team convention rather than a hint.
+
+The key literal is not `sk-` or `sk-proj-` shaped. Push protection on this repo has already caught a fixture holding a
+provider-shaped credential. The scorer reads the literal out of the seed at module load, so rotating it cannot leave
+the checks hunting a value the app never carried.
+
+`projectRunning: false` is load-bearing. `supabase start` bakes `supabase/functions/.env` into the edge runtime
+container's environment at creation time, so a file written after the stack is up is invisible to it. Letting the agent
+own the lifecycle is what makes the runtime claim measurable without the scorer restarting anything.
+
+## Do not drop the positive controls
+
+`the provider key is absent from the built client bundle`, `the provider key is absent from every client source file`
+and `no client-exposed variable carries the provider key` all pass for an agent that deleted the key and built nothing
+else. What makes them mean something is `the suggest endpoint has the provider key at request time`, which only passes
+when a function is served and holds the credential.
+
+The bundle scan reads the artifact Vite emitted rather than the source that produced it. An alias, a computed
+`envPrefix`, or a wrapper around the call each defeat a source-level scan and none of them defeat this one.
+
+`the provider key sits where the local function runtime loads it` is a source-level claim, and named as one. It
+whitelists the default path plus any path a `--env-file` argument points at, rather than blocklisting the places that
+do not work. Its behavioral counterpart is the request-time check.
+
+## The guide has to actually be read
+
+The last check resolves the guide through the harness's own docs result, because a `search_docs` hit carries the url in
+its result rather than its request. It requires retrieved content, not just a url that was reached.
+
+Read `docs.calls` before reading the score. Docs evals run on one experiment and it is a no-skills one, so there is no
+second arm to rule out prior knowledge. An empty `docs.calls` means the run measured nothing about the page, whatever
+the checks say.
+
+## What this eval does not score
+
+- **The production push.** `supabase secrets set --env-file`, `supabase secrets list`, and the dashboard flow.
+  `evals/benchmark/deploy-functions-001-edge-function-secrets` owns the hosted side, including the secret landing on
+  the project and the value staying out of the repo.
+- **The default secrets list.** The page documents `SUPABASE_PUBLISHABLE_KEYS` and `SUPABASE_SECRET_KEYS` as JSON
+  dictionaries, which is hosted behavior. The local CLI injects `SUPABASE_URL`, `SUPABASE_ANON_KEY`,
+  `SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_DB_URL` instead. A check here would report a CLI upgrade as a docs change.
+- **Whether the upstream provider call succeeds.** The sandbox has no route to the provider, so a 5xx from the upstream
+  call is the expected shape of a correct solution. Only the `missing_api_key` contract is scored.
+- **Whether `verify_jwt` is on.** The prompt does not say, so the probe tries the publishable key and then no
+  credentials, and either shape passes.
+
+## A risk worth knowing
+
+An agent that starts the stack before writing its key file, and never checks the endpoint, ships something broken and
+fails `the suggest endpoint has the provider key at request time`. That is the finding rather than a scorer defect, and
+the page documents both recoveries. It is still the check to watch across a baseline. If every run fails on ordering
+alone, the check is harsher than intended and this section is where to say so.
+
+An agent that answers `missing_api_key` for any error, including the upstream call failing, also fails that check. The
+seed's contract is specific about which condition it covers.

--- a/evals/docs/build-docs-007-edge-function-secrets/README.md
+++ b/evals/docs/build-docs-007-edge-function-secrets/README.md
@@ -22,8 +22,8 @@ The seed may carry product vocabulary the user would already have in front of th
 
 ## The seed carries the contract
 
-`local/src/App.tsx` holds the provider key as a literal and calls the provider straight from the browser. Its TODO
-comment fixes three things the checks depend on:
+`local/src/App.tsx` holds the provider key as a literal and calls the provider straight from the browser. The note
+above the component fixes three things the checks depend on:
 
 - **The endpoint.** `POST /functions/v1/suggest`, taking `{ prompt }` and answering `{ suggestion }`. Without it the
   scorer has no address to probe, and the prompt would have to name the runtime instead.

--- a/evals/docs/build-docs-007-edge-function-secrets/client.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/client.ts
@@ -1,0 +1,119 @@
+import { join, relative } from 'node:path';
+import type { CheckResult, LocalStackEvalContext } from '@supabase-evals/core';
+
+import { readText, walk } from './files.js';
+import { PROVIDER_KEY } from './fixture.js';
+
+export type ClientChecks = {
+  build: CheckResult;
+  notInBundle: CheckResult;
+  noExposedEnvVar: CheckResult;
+  notInSource: CheckResult;
+};
+
+/**
+ * What a browser can reach. The bundle scan is the load-bearing one: it reads
+ * the artifact Vite actually emitted, so an alias, a computed `envPrefix`, or a
+ * wrapper around the call cannot hide the value the way a source-level scan can
+ * be fooled.
+ */
+export async function checkClient(
+  ctx: LocalStackEvalContext
+): Promise<ClientChecks> {
+  const result = await ctx.runViteBuild();
+  const build: CheckResult = {
+    name: 'the client bundle builds',
+    passed: result.ok,
+    notes: result.ok
+      ? undefined
+      : (result.stderr || result.stdout).trim().slice(0, 4000),
+  };
+
+  const sources = sourceChecks(ctx);
+
+  if (!result.ok) {
+    // Not a pass. A missing bundle is the absence of evidence, and reporting it
+    // green hands a clean sheet to a workspace that never built.
+    return {
+      build,
+      notInBundle: {
+        name: 'the provider key is absent from the built client bundle',
+        passed: false,
+        notes: 'not run because the client bundle did not build',
+      },
+      ...sources,
+    };
+  }
+
+  const distRoot = join(ctx.hostWorkspace, 'dist');
+  const offenders = walk(distRoot, distRoot)
+    .filter((file) => readText(file).includes(PROVIDER_KEY))
+    .map((file) => relative(distRoot, file));
+
+  return {
+    build,
+    notInBundle: {
+      name: 'the provider key is absent from the built client bundle',
+      passed: offenders.length === 0,
+      notes: offenders.length
+        ? `provider key shipped to the browser in dist/${offenders.join(', dist/')}`
+        : undefined,
+    },
+    ...sources,
+  };
+}
+
+function sourceChecks(
+  ctx: LocalStackEvalContext
+): Pick<ClientChecks, 'noExposedEnvVar' | 'notInSource'> {
+  const root = ctx.hostWorkspace;
+  const files = walk(root, root);
+
+  // Every client source file, not the first one that matches. A workspace can
+  // hold one screen that was cleaned up and one that was missed.
+  const inSource = files
+    .map((file) => relative(root, file))
+    .filter(
+      (rel) =>
+        !rel.startsWith('dist/') &&
+        !rel.startsWith('supabase/') &&
+        !/(^|\/)\.env/.test(rel) &&
+        readText(join(root, rel)).includes(PROVIDER_KEY)
+    );
+
+  // The client project's env, meaning any `.env` outside `supabase/`. Whether
+  // Vite inlines a given name depends on a prefix the config can compute, so
+  // the name is not parsed and the whole file is treated as the web project's
+  // territory. The credential does not belong in it either way.
+  const exposed: string[] = [];
+  for (const file of files) {
+    const rel = relative(root, file);
+    if (!/(^|\/)\.env/.test(rel) || rel.startsWith('supabase/')) continue;
+    for (const line of readText(file).split('\n')) {
+      const [name, ...rest] = line.split('=');
+      if (!name || rest.length === 0) continue;
+      if (rest.join('=').includes(PROVIDER_KEY)) {
+        exposed.push(`${rel}: ${name.trim().replace(/^export\s+/, '')}`);
+      }
+    }
+  }
+
+  return {
+    notInSource: {
+      name: 'the provider key is absent from every client source file',
+      passed: inSource.length === 0,
+      notes: inSource.length
+        ? `provider key still in ${inSource.join(', ')}`
+        : undefined,
+    },
+    noExposedEnvVar: {
+      // Passes when the project has no env file at all, which is one valid
+      // shape rather than something the scenario requires.
+      name: "the provider key is absent from the client project's env files",
+      passed: exposed.length === 0,
+      notes: exposed.length
+        ? `in the web project's env: ${exposed.join(', ')}`
+        : undefined,
+    },
+  };
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/files.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/files.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/** Directories that are never the agent's work. */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  '.supabase',
+  'supabase/.temp',
+]);
+
+export function walk(dir: string, root: string): string[] {
+  let out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const rel = relative(root, full);
+    if (SKIP_DIRS.has(entry) || SKIP_DIRS.has(rel)) continue;
+    let info;
+    try {
+      info = statSync(full);
+    } catch {
+      continue;
+    }
+    if (info.isDirectory()) {
+      out = out.concat(walk(full, root));
+    } else if (info.size < 5_000_000) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+export function readText(path: string): string {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/fixture.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/fixture.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-/** The endpoint the seed's TODO comment points the agent at. */
+/** The endpoint the seed names as the team's existing contract. */
 export const FUNCTION = 'suggest';
 
 /** The failure the seed's contract requires when the credential is missing. */

--- a/evals/docs/build-docs-007-edge-function-secrets/fixture.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/fixture.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** The endpoint the seed's TODO comment points the agent at. */
+export const FUNCTION = 'suggest';
+
+/** The failure the seed's contract requires when the credential is missing. */
+export const MISSING_KEY_MARKER = 'missing_api_key';
+
+/**
+ * Read the provider key out of the seed rather than repeating it here, so
+ * rotating the fixture cannot leave every check hunting a value the seeded app
+ * never carried.
+ */
+export const PROVIDER_KEY = readProviderKey();
+
+function readProviderKey(): string {
+  const seed = fileURLToPath(new URL('./local/src/App.tsx', import.meta.url));
+  const match = /const OPENAI_API_KEY = '([^']+)'/.exec(
+    readFileSync(seed, 'utf8')
+  );
+  if (!match) {
+    throw new Error(
+      'could not read the seeded provider key from local/src/App.tsx'
+    );
+  }
+  return match[1];
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/local/.gitignore
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/evals/docs/build-docs-007-edge-function-secrets/local/index.html
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy suggestions</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/evals/docs/build-docs-007-edge-function-secrets/local/package.json
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "^5.1.2",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "vite": "^6.4.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/local/src/App.tsx
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/src/App.tsx
@@ -6,12 +6,12 @@ import { useState } from 'react';
 // key below. That key is on the invoice, and anyone who opens devtools can read
 // it out of the page.
 //
-// TODO: the rest of the team is building against `POST /functions/v1/suggest`,
-// taking `{ "prompt": string }` and answering `{ "suggestion": string }`, so
-// move the call there and have this screen read it.
+// The rest of the team is building against `POST /functions/v1/suggest`, which
+// takes `{ "prompt": string }` and answers `{ "suggestion": string }`. This
+// screen is meant to read it.
 //
 // One rule from the on-call rotation: when the provider credential is not
-// reachable at request time, `suggest` has to answer 503 with
+// reachable at request time, `suggest` answers 503 with
 // `{ "error": "missing_api_key" }` rather than guessing or returning prose. The
 // dashboard pages on that response, and it is the only way to tell a
 // misconfigured deploy from a caller sending a bad request.

--- a/evals/docs/build-docs-007-edge-function-secrets/local/src/App.tsx
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/src/App.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+// One screen. You type a product name, it comes back with marketing copy.
+//
+// It works today, and it calls the provider straight from the browser with the
+// key below. That key is on the invoice, and anyone who opens devtools can read
+// it out of the page.
+//
+// TODO: the rest of the team is building against `POST /functions/v1/suggest`,
+// taking `{ "prompt": string }` and answering `{ "suggestion": string }`, so
+// move the call there and have this screen read it.
+//
+// One rule from the on-call rotation: when the provider credential is not
+// reachable at request time, `suggest` has to answer 503 with
+// `{ "error": "missing_api_key" }` rather than guessing or returning prose. The
+// dashboard pages on that response, and it is the only way to tell a
+// misconfigured deploy from a caller sending a bad request.
+
+const OPENAI_API_KEY = 'oai_eval_key_do_not_use_4f19c2a7';
+
+export default function App() {
+  const [product, setProduct] = useState('');
+  const [suggestion, setSuggestion] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus('thinking');
+    setSuggestion('');
+
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${OPENAI_API_KEY}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            { role: 'user', content: `Write one line of copy for ${product}.` },
+          ],
+        }),
+      });
+
+      if (!res.ok) {
+        setStatus(`provider returned ${res.status}`);
+        return;
+      }
+
+      const body = (await res.json()) as {
+        choices?: { message?: { content?: string } }[];
+      };
+      setSuggestion(body.choices?.[0]?.message?.content ?? '');
+      setStatus('');
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  return (
+    <main>
+      <h1>Copy suggestions</h1>
+      <form data-testid="suggest-form" onSubmit={handleSubmit}>
+        <input
+          data-testid="suggest-product"
+          name="product"
+          placeholder="Product name"
+          value={product}
+          onChange={(event) => setProduct(event.target.value)}
+        />
+        <button data-testid="suggest-submit" type="submit">
+          Suggest
+        </button>
+      </form>
+      <p data-testid="suggest-status">{status}</p>
+      <p data-testid="suggest-result">{suggestion}</p>
+    </main>
+  );
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/local/src/main.tsx
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/evals/docs/build-docs-007-edge-function-secrets/local/supabase/config.toml
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/supabase/config.toml
@@ -1,0 +1,165 @@
+project_id = "sandbox-edge-function-secrets"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[api.tls]
+enabled = false
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 17
+
+[db.pooler]
+enabled = false
+port = 54329
+pool_mode = "transaction"
+default_pool_size = 20
+max_client_conn = 100
+
+[db.migrations]
+enabled = true
+schema_paths = []
+
+[db.seed]
+enabled = false
+
+[realtime]
+enabled = true
+
+[studio]
+enabled = true
+port = 54323
+api_url = "http://127.0.0.1"
+openai_api_key = "env(OPENAI_API_KEY)"
+
+[inbucket]
+enabled = true
+port = 54324
+
+[storage]
+enabled = true
+file_size_limit = "50MiB"
+
+[storage.s3_protocol]
+enabled = true
+
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+[auth]
+enabled = true
+site_url = "http://127.0.0.1:3000"
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+refresh_token_reuse_interval = 10
+enable_signup = true
+enable_anonymous_sign_ins = false
+enable_manual_linking = false
+minimum_password_length = 6
+password_requirements = ""
+
+[auth.rate_limit]
+email_sent = 2
+sms_sent = 30
+anonymous_users = 30
+token_refresh = 150
+sign_in_sign_ups = 30
+token_verifications = 30
+web3 = 30
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = true
+enable_confirmations = false
+secure_password_change = false
+max_frequency = "1s"
+otp_length = 6
+otp_expiry = 3600
+
+[auth.sms]
+enable_signup = false
+enable_confirmations = false
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+[auth.mfa]
+max_enrolled_factors = 10
+
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+[auth.external.apple]
+enabled = false
+client_id = ""
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+redirect_uri = ""
+url = ""
+skip_nonce_check = false
+email_optional = false
+
+[auth.web3.solana]
+enabled = false
+
+[auth.third_party.firebase]
+enabled = false
+
+[auth.third_party.auth0]
+enabled = false
+
+[auth.third_party.aws_cognito]
+enabled = false
+
+[auth.third_party.clerk]
+enabled = false
+
+[auth.oauth_server]
+enabled = false
+authorization_url_path = "/oauth/consent"
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+policy = "per_worker"
+inspector_port = 8083
+deno_version = 2
+
+[analytics]
+enabled = true
+port = 54327
+backend = "postgres"
+
+[experimental]
+orioledb_version = ""
+s3_host = "env(S3_HOST)"
+s3_region = "env(S3_REGION)"
+s3_access_key = "env(S3_ACCESS_KEY)"
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/evals/docs/build-docs-007-edge-function-secrets/local/tsconfig.json
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/local/vite.config.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/local/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/evals/docs/build-docs-007-edge-function-secrets/probes.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/probes.ts
@@ -1,0 +1,199 @@
+import type { CheckResult, LocalStackEvalContext } from '@supabase-evals/core';
+
+import { FUNCTION, MISSING_KEY_MARKER, PROVIDER_KEY } from './fixture.js';
+
+/** A cold `per_worker` runtime boots a worker on the first request. */
+const ATTEMPTS = 5;
+const RETRY_MS = 2000;
+
+type Response = { status: number; body: string };
+
+export type ProbeChecks = {
+  served: CheckResult;
+  keyAtRuntime: CheckResult;
+  noEcho: CheckResult;
+};
+
+/**
+ * The end-to-end phase. `projectRunning: false`, so the agent starts the stack
+ * itself and its own env file is on disk before the edge runtime container is
+ * created. That ordering is the thing under test: the guide is the only place
+ * that says where the file has to sit for `supabase start` to pick it up.
+ */
+export async function checkProbes(
+  ctx: LocalStackEvalContext,
+  marker: string
+): Promise<ProbeChecks> {
+  const status = await readStatus(ctx);
+  const apiUrl = str(status.API_URL);
+  if (!apiUrl) {
+    return blocked(
+      'the local stack is not running, so nothing serves the function'
+    );
+  }
+
+  const url = `${apiUrl}/functions/v1/${FUNCTION}`;
+  const key = str(status.PUBLISHABLE_KEY) ?? str(status.ANON_KEY);
+  const response = await poll(url, key, marker);
+
+  if (!response) {
+    return blocked(`no response from ${url}`);
+  }
+  if (response.status === 404) {
+    return blocked(`${url} returned 404, so no function is deployed there`);
+  }
+
+  const served: CheckResult = {
+    name: 'the local stack serves the suggest endpoint',
+    passed: true,
+    notes: `status ${response.status}`,
+  };
+
+  // Pass on anything that is not the seed's missing-credential contract. The
+  // sandbox has no route to the provider, so the upstream call fails and a 5xx
+  // is the expected shape of a correct solution. What a correct solution must
+  // not say is that the credential never arrived.
+  const missing = response.body.includes(MISSING_KEY_MARKER);
+  const keyAtRuntime: CheckResult = {
+    name: 'the suggest endpoint has the provider key at request time',
+    passed: !missing,
+    notes: missing
+      ? `answered ${MISSING_KEY_MARKER}, so the runtime handed the function no credential: ${preview(response.body)}`
+      : `status ${response.status}: ${preview(response.body)}`,
+  };
+
+  const echoed = response.body.includes(PROVIDER_KEY);
+  const noEcho: CheckResult = {
+    name: 'the suggest response does not echo the provider key',
+    passed: !echoed,
+    notes: echoed
+      ? 'the response body carries the provider key back to the caller'
+      : undefined,
+  };
+
+  return { served, keyAtRuntime, noEcho };
+}
+
+/** A blocked probe fails. Reporting it green hands a clean sheet to a run that produced nothing. */
+function blocked(reason: string): ProbeChecks {
+  return {
+    served: {
+      name: 'the local stack serves the suggest endpoint',
+      passed: false,
+      notes: reason,
+    },
+    keyAtRuntime: {
+      name: 'the suggest endpoint has the provider key at request time',
+      passed: false,
+      notes: 'not run because the suggest endpoint was not served',
+    },
+    noEcho: {
+      name: 'the suggest response does not echo the provider key',
+      passed: false,
+      notes: 'not run because the suggest endpoint was not served',
+    },
+  };
+}
+
+async function poll(
+  url: string,
+  key: string | undefined,
+  marker: string
+): Promise<Response | undefined> {
+  let last: Response | undefined;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    if (attempt > 0) await sleep(RETRY_MS);
+    const response = await invoke(url, key, marker);
+    if (response) {
+      last = response;
+      if (!stillBooting(response)) return response;
+    }
+  }
+  return last;
+}
+
+/**
+ * A gateway error with nothing in the body is the runtime still coming up. The
+ * seed's own contract answers 503 with a body, so that is an answer and not
+ * something to wait out.
+ */
+function stillBooting(response: Response): boolean {
+  return (
+    (response.status === 502 || response.status === 503) &&
+    response.body.trim().length === 0
+  );
+}
+
+/**
+ * Tries the publishable key first, then no credentials. The agent decides
+ * whether to leave `verify_jwt` on, and the scorer's choice of header should
+ * not be what fails a working function.
+ */
+async function invoke(
+  url: string,
+  key: string | undefined,
+  marker: string
+): Promise<Response | undefined> {
+  const attempts: Record<string, string>[] = [];
+  if (key) {
+    attempts.push({ apikey: key, authorization: `Bearer ${key}` });
+  }
+  attempts.push({});
+
+  let last: Response | undefined;
+  for (const auth of attempts) {
+    const response = await send(url, auth, marker);
+    if (!response) continue;
+    last = response;
+    if (response.status !== 401) return response;
+  }
+  return last;
+}
+
+async function send(
+  url: string,
+  auth: Record<string, string>,
+  marker: string
+): Promise<Response | undefined> {
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: `a stainless steel kettle ${marker}` }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    return { status: res.status, body: await res.text() };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Reads `supabase status`, with stderr dropped so its `Stopped services` chatter cannot lead a failure note. */
+async function readStatus(
+  ctx: LocalStackEvalContext
+): Promise<Record<string, unknown>> {
+  const result = await ctx.exec('supabase status -o json 2>/dev/null');
+  const start = result.stdout.indexOf('{');
+  const end = result.stdout.lastIndexOf('}');
+  if (start === -1 || end <= start) return {};
+  try {
+    return JSON.parse(result.stdout.slice(start, end + 1)) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return {};
+  }
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function preview(body: string): string {
+  return body.replace(/\s+/g, ' ').slice(0, 200);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/evals/docs/build-docs-007-edge-function-secrets/secret.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/secret.ts
@@ -14,8 +14,21 @@ const AUTOLOADED = 'supabase/functions/.env';
 /** Where a `--env-file` argument could be written down and still be run. */
 const SCRIPT_FILES = /^(package\.json|Makefile|justfile|.*\.sh)$/;
 
-const ENV_READ =
-  /Deno\.env\.(get|toObject)\s*\(|process\.env\b|from\s*['"](?:npm:|jsr:)?@?std\/dotenv/;
+/**
+ * Names `supabase start` injects on its own. A function reading one of these is
+ * not reading the credential this eval is about, so they never count as the one
+ * that has to be placed.
+ */
+const PLATFORM_NAMES = /^(SUPABASE_|SB_|DENO_)/;
+
+/** Files whose whole point is to be committed, so they are not a leak. */
+const TEMPLATE_FILE = /\.(example|sample|template)$/;
+
+const ENV_FILE = /(^|\/)\.env/;
+const ENV_GET = /Deno\.env\.get\s*\(\s*['"`]([A-Za-z_][A-Za-z0-9_]*)['"`]/g;
+const ENV_BROAD = /Deno\.env\.toObject\s*\(|process\.env\b/;
+
+type EnvEntry = { file: string; name: string };
 
 export type SecretChecks = {
   readsFromEnv: CheckResult;
@@ -27,34 +40,89 @@ export async function checkSecret(
   ctx: LocalStackEvalContext
 ): Promise<SecretChecks> {
   const root = ctx.hostWorkspace;
-  const holders = walk(root, root)
-    .map((file) => relative(root, file))
-    .filter(
-      (rel) =>
-        !rel.startsWith('dist/') &&
-        readText(join(root, rel)).includes(PROVIDER_KEY)
-    );
+  const sources = functionSources(root);
+  const wanted = credentialNames(sources);
+  const defined = envAssignments(root);
+
+  // The files that stand up the credential the function asks for. Tracking the
+  // name rather than the seeded value is deliberate: an agent is free to
+  // replace the placeholder the seed shipped, and the first baseline showed
+  // they do. What has to be true is that whatever the function reads is set
+  // somewhere the runtime loads, and that the file is not committed.
+  const holders = defined.filter((entry) => wanted.names.has(entry.name));
+  const carriers =
+    holders.length > 0
+      ? holders
+      : wanted.broad
+        ? defined.filter((entry) => !PLATFORM_NAMES.test(entry.name))
+        : [];
 
   return {
-    readsFromEnv: checkReadsFromEnv(root),
-    loadablePath: checkLoadablePath(ctx, holders),
-    ignored: await checkIgnored(ctx, holders),
+    readsFromEnv: checkReadsFromEnv(root, sources),
+    loadablePath: checkLoadablePath(ctx, carriers, wanted),
+    ignored: await checkIgnored(ctx, carriers),
   };
 }
 
-/**
- * A source-level claim, and named as one. It rules out the literal being
- * pasted into the handler, and requires at least one function to read its
- * configuration from the environment at all. What the runtime hands the
- * function is check `the suggest endpoint has the provider key at request
- * time`, which is the behavioral counterpart.
- */
-function checkReadsFromEnv(root: string): CheckResult {
-  const name = 'every function reads the provider key from the environment';
+function functionSources(root: string): string[] {
   const dir = join(root, 'supabase', 'functions');
-  const sources = walk(dir, dir).filter(
-    (file) => /\.(ts|tsx|js|mjs)$/.test(file) && !/(^|\/)\.env/.test(file)
+  return walk(dir, dir).filter(
+    (file) => /\.(ts|tsx|js|mjs)$/.test(file) && !ENV_FILE.test(file)
   );
+}
+
+/**
+ * The non-platform env names the functions read. `broad` covers a function that
+ * takes the whole environment at once, where there is no name to extract and
+ * the check falls back to asking whether any credential is placed at all.
+ */
+function credentialNames(sources: string[]): {
+  names: Set<string>;
+  broad: boolean;
+} {
+  const names = new Set<string>();
+  let broad = false;
+  for (const file of sources) {
+    const src = readText(file);
+    if (ENV_BROAD.test(src)) broad = true;
+    for (const match of src.matchAll(ENV_GET)) {
+      if (!PLATFORM_NAMES.test(match[1])) names.add(match[1]);
+    }
+  }
+  return { names, broad };
+}
+
+/** Every `NAME=value` with a value, across every env file in the workspace. */
+function envAssignments(root: string): EnvEntry[] {
+  const entries: EnvEntry[] = [];
+  for (const file of walk(root, root)) {
+    const rel = relative(root, file);
+    if (!ENV_FILE.test(rel) || rel.startsWith('dist/')) continue;
+    for (const line of readText(file).split('\n')) {
+      const trimmed = line.trim().replace(/^export\s+/, '');
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const split = trimmed.indexOf('=');
+      if (split <= 0) continue;
+      const value = trimmed
+        .slice(split + 1)
+        .trim()
+        .replace(/^["']|["']$/g, '');
+      if (!value) continue;
+      entries.push({ file: rel, name: trimmed.slice(0, split).trim() });
+    }
+  }
+  return entries;
+}
+
+/**
+ * A source-level claim, and named as one. It rules out the seeded literal being
+ * pasted into the handler, and requires a function to read its configuration
+ * from the environment at all. What the runtime hands the function is check
+ * `the suggest endpoint has the provider key at request time`, which is the
+ * behavioral counterpart.
+ */
+function checkReadsFromEnv(root: string, sources: string[]): CheckResult {
+  const name = 'every function reads the provider key from the environment';
 
   if (sources.length === 0) {
     return {
@@ -69,8 +137,6 @@ function checkReadsFromEnv(root: string): CheckResult {
   const literal = sources
     .filter((file) => readText(file).includes(PROVIDER_KEY))
     .map((file) => relative(root, file));
-  const readsEnv = sources.some((file) => ENV_READ.test(readText(file)));
-
   if (literal.length > 0) {
     return {
       name,
@@ -78,11 +144,14 @@ function checkReadsFromEnv(root: string): CheckResult {
       notes: `provider key hardcoded in ${literal.join(', ')}`,
     };
   }
+
+  const { names, broad } = credentialNames(sources);
+  const reads = names.size > 0 || broad;
   return {
     name,
-    passed: readsEnv,
-    notes: readsEnv
-      ? undefined
+    passed: reads,
+    notes: reads
+      ? `reads ${names.size > 0 ? [...names].join(', ') : 'the whole environment'}`
       : 'no function reads its configuration from the environment',
   };
 }
@@ -95,38 +164,52 @@ function checkReadsFromEnv(root: string): CheckResult {
  */
 function checkLoadablePath(
   ctx: LocalStackEvalContext,
-  holders: string[]
+  carriers: EnvEntry[],
+  wanted: { names: Set<string>; broad: boolean }
 ): CheckResult {
   const name =
     'the provider key sits where the local function runtime loads it';
 
-  if (holders.length === 0) {
-    return {
-      name,
-      passed: false,
-      notes: 'the seeded provider key is not in any file in the workspace',
-    };
+  if (carriers.length === 0) {
+    const asked =
+      wanted.names.size > 0
+        ? `the function reads ${[...wanted.names].join(', ')}, and no env file sets ${wanted.names.size > 1 ? 'any of them' : 'it'}`
+        : 'no function reads a credential from the environment, so nothing was placed';
+    return { name, passed: false, notes: asked };
   }
 
   const referenced = envFileArguments(ctx);
-  const loadable = holders.filter(
-    (rel) => rel === AUTOLOADED || referenced.has(rel)
-  );
+  const loadable = [
+    ...new Set(
+      carriers
+        .filter(
+          (entry) => entry.file === AUTOLOADED || referenced.has(entry.file)
+        )
+        .map((entry) => entry.file)
+    ),
+  ];
 
   if (loadable.length === 0) {
+    const where = [...new Set(carriers.map((entry) => entry.file))];
     return {
       name,
       passed: false,
-      notes: `provider key only in ${holders.join(', ')}, which ${AUTOLOADED} does not cover and no --env-file points at`,
+      notes: `credential set only in ${where.join(', ')}, which ${AUTOLOADED} does not cover and no --env-file points at`,
     };
   }
 
-  const stray = holders.filter((rel) => !loadable.includes(rel));
+  const stray = [
+    ...new Set(
+      carriers
+        .map((entry) => entry.file)
+        .filter((file) => !loadable.includes(file))
+    ),
+  ];
   return {
     name,
     passed: true,
     notes: stray.length
-      ? `loaded from ${loadable.join(', ')}; also left in ${stray.join(', ')}`
+      ? `loaded from ${loadable.join(', ')}; also set in ${stray.join(', ')}`
       : `loaded from ${loadable.join(', ')}`,
   };
 }
@@ -154,23 +237,38 @@ function envFileArguments(ctx: LocalStackEvalContext): Set<string> {
  * `git check-ignore` rather than `git ls-files`. The harness strips `.git` when
  * it copies the seed in, so a tracked-file scan matches nothing and reads green
  * whatever the project ignores.
+ *
+ * Template files are carved out. Shipping `.env.example` with a placeholder is
+ * the documented habit, and failing a solution for doing it would be a false
+ * red.
  */
 async function checkIgnored(
   ctx: LocalStackEvalContext,
-  holders: string[]
+  carriers: EnvEntry[]
 ): Promise<CheckResult> {
   const name =
     "the file holding the provider key is covered by the project's ignore rules";
 
-  if (holders.length === 0) {
+  const files = [
+    ...new Set(
+      carriers
+        .map((entry) => entry.file)
+        .filter((file) => !TEMPLATE_FILE.test(file))
+    ),
+  ];
+
+  if (files.length === 0) {
     return {
       name,
       passed: false,
-      notes: 'not run because the seeded provider key is not in any file',
+      notes:
+        carriers.length > 0
+          ? 'the credential is only in a template file, so nothing real was placed'
+          : 'not run because no credential was placed in an env file',
     };
   }
 
-  const quoted = holders.map((rel) => `'${rel.replace(/'/g, "'\\''")}'`);
+  const quoted = files.map((file) => `'${file.replace(/'/g, "'\\''")}'`);
   const result = await ctx.exec(
     [
       'git rev-parse --git-dir >/dev/null 2>&1 || git init -q',
@@ -190,13 +288,13 @@ async function checkIgnored(
 
   const tracked = result.stdout
     .split('\n')
-    .map((l) => l.trim())
+    .map((line) => line.trim())
     .filter(Boolean);
   return {
     name,
     passed: tracked.length === 0,
     notes: tracked.length
       ? `would be committed: ${tracked.join(', ')}`
-      : `ignored: ${holders.join(', ')}`,
+      : `ignored: ${files.join(', ')}`,
   };
 }

--- a/evals/docs/build-docs-007-edge-function-secrets/secret.ts
+++ b/evals/docs/build-docs-007-edge-function-secrets/secret.ts
@@ -1,0 +1,202 @@
+import { join, relative } from 'node:path';
+import type { CheckResult, LocalStackEvalContext } from '@supabase-evals/core';
+
+import { readText, walk } from './files.js';
+import { PROVIDER_KEY } from './fixture.js';
+
+/**
+ * The path `supabase start` and `supabase functions serve` both read with no
+ * arguments. In CLI 2.67.1 `parseEnvFile("")` falls back to it, and the values
+ * become the edge runtime container's environment.
+ */
+const AUTOLOADED = 'supabase/functions/.env';
+
+/** Where a `--env-file` argument could be written down and still be run. */
+const SCRIPT_FILES = /^(package\.json|Makefile|justfile|.*\.sh)$/;
+
+const ENV_READ =
+  /Deno\.env\.(get|toObject)\s*\(|process\.env\b|from\s*['"](?:npm:|jsr:)?@?std\/dotenv/;
+
+export type SecretChecks = {
+  readsFromEnv: CheckResult;
+  loadablePath: CheckResult;
+  ignored: CheckResult;
+};
+
+export async function checkSecret(
+  ctx: LocalStackEvalContext
+): Promise<SecretChecks> {
+  const root = ctx.hostWorkspace;
+  const holders = walk(root, root)
+    .map((file) => relative(root, file))
+    .filter(
+      (rel) =>
+        !rel.startsWith('dist/') &&
+        readText(join(root, rel)).includes(PROVIDER_KEY)
+    );
+
+  return {
+    readsFromEnv: checkReadsFromEnv(root),
+    loadablePath: checkLoadablePath(ctx, holders),
+    ignored: await checkIgnored(ctx, holders),
+  };
+}
+
+/**
+ * A source-level claim, and named as one. It rules out the literal being
+ * pasted into the handler, and requires at least one function to read its
+ * configuration from the environment at all. What the runtime hands the
+ * function is check `the suggest endpoint has the provider key at request
+ * time`, which is the behavioral counterpart.
+ */
+function checkReadsFromEnv(root: string): CheckResult {
+  const name = 'every function reads the provider key from the environment';
+  const dir = join(root, 'supabase', 'functions');
+  const sources = walk(dir, dir).filter(
+    (file) => /\.(ts|tsx|js|mjs)$/.test(file) && !/(^|\/)\.env/.test(file)
+  );
+
+  if (sources.length === 0) {
+    return {
+      name,
+      passed: false,
+      notes: 'no function source under supabase/functions/',
+    };
+  }
+
+  // Every source file, not the first. One clean handler beside one that
+  // hardcodes the key is still a leak.
+  const literal = sources
+    .filter((file) => readText(file).includes(PROVIDER_KEY))
+    .map((file) => relative(root, file));
+  const readsEnv = sources.some((file) => ENV_READ.test(readText(file)));
+
+  if (literal.length > 0) {
+    return {
+      name,
+      passed: false,
+      notes: `provider key hardcoded in ${literal.join(', ')}`,
+    };
+  }
+  return {
+    name,
+    passed: readsEnv,
+    notes: readsEnv
+      ? undefined
+      : 'no function reads its configuration from the environment',
+  };
+}
+
+/**
+ * A whitelist of the places the local runtime will load, rather than a
+ * blocklist of the places it will not. The default path needs no argument. A
+ * custom path counts when something that gets run points `--env-file` at it,
+ * which is the other route the guide documents.
+ */
+function checkLoadablePath(
+  ctx: LocalStackEvalContext,
+  holders: string[]
+): CheckResult {
+  const name =
+    'the provider key sits where the local function runtime loads it';
+
+  if (holders.length === 0) {
+    return {
+      name,
+      passed: false,
+      notes: 'the seeded provider key is not in any file in the workspace',
+    };
+  }
+
+  const referenced = envFileArguments(ctx);
+  const loadable = holders.filter(
+    (rel) => rel === AUTOLOADED || referenced.has(rel)
+  );
+
+  if (loadable.length === 0) {
+    return {
+      name,
+      passed: false,
+      notes: `provider key only in ${holders.join(', ')}, which ${AUTOLOADED} does not cover and no --env-file points at`,
+    };
+  }
+
+  const stray = holders.filter((rel) => !loadable.includes(rel));
+  return {
+    name,
+    passed: true,
+    notes: stray.length
+      ? `loaded from ${loadable.join(', ')}; also left in ${stray.join(', ')}`
+      : `loaded from ${loadable.join(', ')}`,
+  };
+}
+
+/** Paths a `--env-file` argument names, from committed scripts and from the agent's own commands. */
+function envFileArguments(ctx: LocalStackEvalContext): Set<string> {
+  const root = ctx.hostWorkspace;
+  const haystack = [
+    ...walk(root, root)
+      .filter((file) => SCRIPT_FILES.test(relative(root, file)))
+      .map(readText),
+    ...ctx.toolCalls.map((call) => call.command ?? ''),
+  ].join('\n');
+
+  const paths = new Set<string>();
+  for (const match of haystack.matchAll(
+    /--env-file[=\s]+["']?([^\s"';|&]+)/g
+  )) {
+    paths.add(match[1].replace(/^\.\//, ''));
+  }
+  return paths;
+}
+
+/**
+ * `git check-ignore` rather than `git ls-files`. The harness strips `.git` when
+ * it copies the seed in, so a tracked-file scan matches nothing and reads green
+ * whatever the project ignores.
+ */
+async function checkIgnored(
+  ctx: LocalStackEvalContext,
+  holders: string[]
+): Promise<CheckResult> {
+  const name =
+    "the file holding the provider key is covered by the project's ignore rules";
+
+  if (holders.length === 0) {
+    return {
+      name,
+      passed: false,
+      notes: 'not run because the seeded provider key is not in any file',
+    };
+  }
+
+  const quoted = holders.map((rel) => `'${rel.replace(/'/g, "'\\''")}'`);
+  const result = await ctx.exec(
+    [
+      'git rev-parse --git-dir >/dev/null 2>&1 || git init -q',
+      `for f in ${quoted.join(' ')}; do`,
+      '  git check-ignore -q "$f" || echo "$f"',
+      'done',
+    ].join('\n')
+  );
+
+  if (!result.ok) {
+    return {
+      name,
+      passed: false,
+      notes: `could not read ignore rules: ${(result.stderr || result.stdout).trim().slice(0, 500)}`,
+    };
+  }
+
+  const tracked = result.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return {
+    name,
+    passed: tracked.length === 0,
+    notes: tracked.length
+      ? `would be committed: ${tracked.join(', ')}`
+      : `ignored: ${holders.join(', ')}`,
+  };
+}


### PR DESCRIPTION
Closes DOCS-1305

## Problem

The [Managing secrets](https://supabase.com/docs/guides/functions/secrets) guide is the only place that says where a local secret has to sit for the function runtime to load it. Neither the Supabase agent skill nor Supacademy covers the topic, so the page is the only carrier. Users keep landing on the wrong file: FDBKIN-11884 and CLI-818 both ask for the project-root `.env` and `supabase/functions/.env` to be told apart, and FDBKIN-12716 and FDBKIN-6831 are the recurring "I set it and the function cannot read it" shape.

Nothing in the repo tests an Edge Functions docs page as the subject under test. `deploy-functions-001-edge-function-secrets` owns the hosted side and does not touch local loading.

## Solution

- Adds `evals/docs/build-docs-007-edge-function-secrets`. The seed is a Vite app that calls a provider from the browser with the key as a literal, and a TODO comment fixes the endpoint and the `missing_api_key` failure contract the probe needs.
- The prompt asks for the key to be sorted out and for the local stack to be running. It never names the mechanism. The stripped-word list is in `README.md`.
- `projectRunning: false`, so the agent owns the stack lifecycle. `supabase start` bakes `supabase/functions/.env` into the edge runtime container's environment at creation time, so a file written after the stack is up is invisible to it. Letting the agent start the stack is what makes the runtime claim measurable without the scorer restarting anything.
- Eleven checks. Four read the client, three read where the key landed, three probe the served endpoint, and one asserts the page was retrieved with content.
- The ignore-rules check uses `git check-ignore` rather than `git ls-files`. The harness strips `.git` when it copies the seed in, so the tracked-file form matches nothing and reads green whatever the project ignores. The same check in `deploy-functions-001` is affected.

## Manual testing

1. `pnpm typecheck`. Passes.
2. `npx biome check evals/docs/build-docs-007-edge-function-secrets/`. Clean.
3. `pnpm eval:dry -- --suite docs --experiment-suite docs`. Plans `codex-gpt-5.6-luna-no-skills x build-docs-007-edge-function-secrets`.
4. Score six local fixtures against the file-based checks. Predictions were written before running and all six matched. The one that decides the design puts the key in the project-root `.env` and fails `the provider key sits where the local function runtime loads it`, with the other five failing on the bundle, the function source, and the ignore rules respectively.

## Baseline

Three runs on `codex-gpt-5.6-luna-no-skills`, all 7/11.

All three built a function reading `OPENAI_API_KEY` from the environment, started the stack, and answered `{"error":"missing_api_key"}`. Two wrote `supabase/functions/.env.example` and stopped rather than creating the file `supabase start` reads. The third wrote no env file. Placement, ignore rules, and the request-time probe agree on every run, which is the source-level claim and the behavioral one corroborating each other.

The fourth failure is instrumentation, not the page. `the agent read the Managing secrets guide the prompt referenced` reds on every run even though every run reached the page. Codex `web_search` never sets `hasContent`, because CLI 0.138 mangles `open_page` into the catch-all and the url-shape fallback in `packages/core/src/docs-results.ts:309` leaves it unset. Every docs eval carries this check and docs evals run only on Codex, so it needs a fix that is not scoped to this PR.

An earlier baseline on this branch red two checks that hunted the seeded literal. Agents replace it, so those checks reported nothing placed on solutions that placed a credential correctly. Fixed in `6f38449`, and a fixture reproducing it is part of the set.
