### PR TITLE
fix(core): read a Codex `other` web_search action as a page read

### DIFF
--- a/packages/core/src/docs-results.test.ts
+++ b/packages/core/src/docs-results.test.ts
@@ -380,6 +380,52 @@ describe('buildDocsResult', () => {
     ]);
   });
 
+  it('reads an `other` action with a url-shaped query as a page read, which is how CLI 0.138 reports openPage', () => {
+    // The exact body a docs eval recorded on codex-gpt-5.6-luna: the action
+    // type is flattened to `other` and the url survives only in the query.
+    const url = 'https://supabase.com/docs/guides/functions/secrets.md';
+    const result = buildDocsResult([
+      toolCall(
+        'web_search',
+        { query: url, action: { type: 'other' } },
+        { name: 'web_search' }
+      ),
+    ]);
+
+    expect(result.calls).toEqual([
+      {
+        source: 'web_search',
+        query: url,
+        hasContent: true,
+        pages: [{ url }],
+      },
+    ]);
+  });
+
+  it('drops an `other` action pointing somewhere other than supabase.com', () => {
+    const result = buildDocsResult([
+      toolCall(
+        'web_search',
+        { query: 'https://example.com/docs', action: { type: 'other' } },
+        { name: 'web_search' }
+      ),
+    ]);
+
+    expect(result.calls).toEqual([]);
+  });
+
+  it("leaves an `other` action's content unknown when the query is a search term rather than a url", () => {
+    const result = buildDocsResult([
+      toolCall(
+        'web_search',
+        { query: 'supabase edge function secrets', action: { type: 'other' } },
+        { name: 'web_search' }
+      ),
+    ]);
+
+    expect(result.calls[0].hasContent).toBeUndefined();
+  });
+
   it("leaves a search action's content unknown, and doesn't mistake its url-shaped query for a page read", () => {
     const result = buildDocsResult([
       toolCall(

--- a/packages/core/src/docs-results.ts
+++ b/packages/core/src/docs-results.ts
@@ -305,6 +305,28 @@ export function buildDocsResult(toolCalls: ToolCallRecord[]): DocsResult {
         continue;
       }
 
+      // `other` is the catch-all the round trip described above collapses
+      // `openPage` and `findInPage` into. `search` survives that trip intact
+      // and is handled above, so reaching here with an explicit `other` is
+      // positive evidence this was a page read rather than a query. The url
+      // does not survive on the action, only in `query`, so that is what the
+      // page is attributed to.
+      //
+      // Codex reports no result for these calls, the same way `web_fetch`
+      // carries no body here. `hasContent` says the channel delivers page text
+      // to the model, not that the harness captured it.
+      if (action?.type === 'other' && URL_PATTERN.test(query)) {
+        if (!isSupabaseApexUrl(query)) continue;
+        calls.push({
+          source: 'web_search',
+          query,
+          hasContent: true,
+          pages: [{ url: query }],
+          resultChars: resultCharCount(result),
+        });
+        continue;
+      }
+
       // No action reported (Claude Code, or an action type we don't know):
       // fall back to the query's shape, which is all there is to go on.
       if (URL_PATTERN.test(query)) {


### PR DESCRIPTION
## Problem

The docs evals check that the agent retrieved the referenced page with content. That check reds on runs that plainly read the page, and docs evals run only on `codex-gpt-5.6-luna-no-skills`, so it is close to unpassable on the one experiment that matters.

Codex round-trips `openPage` and `findInPage` through a snake_case enum that has no such variants, so both page-reading actions arrive as `other`. The action carries no url, only the query does, and the url-shape fallback leaves `hasContent` unset. Three runs of `build-docs-007-edge-function-secrets` recorded this:

```json
{ "query": "https://supabase.com/docs/guides/functions/secrets.md",
  "action": { "type": "other" } }
```

## Solution

- Treat an explicit `other` action with a url-shaped Supabase query as a page read. `search` survives the round trip intact and is matched earlier, so reaching that branch with `other` is positive evidence of a page read rather than an absence of evidence.
- Attribute the page to the query, since the url does not survive on the action.
- Scoped to an explicit `other`. An action type we do not know still falls through to the url-shape fallback and stays unknown.
- Cite [openai/codex#45773](https://github.com/openai/codex/issues/45773) in the comment. It asks for the two fixes that retire this branch: parse the action variant by variant, and thread `results` through exec's `WebSearchItem`. [AI-1218](https://linear.app/supabase/issue/AI-1218) covers the cleanup here.

Codex reports no result for these calls, the same way `web_fetch` carries no body here. `hasContent` says the channel delivers page text to the model, not that the harness captured it. An open that 404s is indistinguishable from one that served the page, which is the second half of the upstream report.

## Manual testing

1. `cd packages/core && npx vitest run`. 134 pass, including three new cases: the recorded body, an `other` pointing off supabase.com, and an `other` whose query is a search term rather than a url.
2. Replay the tool calls recorded on the three runs through `buildDocsResult`. Each resolves two calls reaching the guide, both with content, so the check flips from fail to pass on all three. The bodies come from the run's `raw-results` artifact, which keeps `toolCalls` even though published results drop them.
3. `pnpm typecheck`. Passes.
4. Confirm the round trip upstream at `rust-v0.151.0`, the pinned CLI, and on main at `aaa2cabf`. `map_item_with_id` re-parses the camelCase action into the snake_case enum in both.
